### PR TITLE
Feature/432 wildcard drop target

### DIFF
--- a/docs/00 Quick Start/Overview.md
+++ b/docs/00 Quick Start/Overview.md
@@ -24,7 +24,7 @@ What is an item? An *item* is a plain JavaScript object *describing* what's bein
 
 What is a type, then? A *type* is a string (or a [symbol](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Symbol)) uniquely identifying *a whole class of items* in your application. In a Kanban board app, you might have a `'card'` type representing the draggable cards and a `'list'` type for the draggable lists of those cards. In Chess, you might only have a single `'piece'` type.
 
-Types are useful because, as your app grows, you might want to make more things draggable, but you don't necessarily want all the existing drop targets to suddenly start reacting to the new items. **The types let you specify which drag sources and drop targets are compatible.** You're probably going to have an enumeration of the type constants in your application, just like you may have an enumeration of the Flux action types.
+Types are useful because, as your app grows, you might want to make more things draggable, but you don't necessarily want all the existing drop targets to suddenly start reacting to the new items. **The types let you specify which drag sources and drop targets are compatible.** You're probably going to have an enumeration of the type constants in your application, just like you may have an enumeration of the Flux action types. If you want a target to match all sources, you can use the wildcard target type `true`.
 
 ### Monitors
 

--- a/docs/01 Top Level API/DropTarget.md
+++ b/docs/01 Top Level API/DropTarget.md
@@ -44,7 +44,7 @@ export default class MyComponent {
 
 ### Parameters
 
-* **`types`**: Required. A string, an ES6 symbol, an array of either, or a function that returns either of those, given component's `props`. This drop target will only react to the items produced by the [drag sources](docs-drag-source.html) of the specified type or types. Read the [overview](docs-overview.html) to learn more about the items and types.
+* **`types`**: Required. A string, an ES6 symbol, a boolean, an array of the above, or a function that returns any of those, given component's `props`. This drop target will only react to the items produced by the [drag sources](docs-drag-source.html) matching the specified type or types. `true` matches all source types, and `false` matches none. Read the [overview](docs-overview.html) to learn more about the items and types. 
 
 * **`spec`**: Required. A plain JavaScript object with a few allowed methods on it. It describes how the drop target reacts to the drag and drop events. See the drop target specification described in detail in the next section.
 

--- a/src/DragSource.js
+++ b/src/DragSource.js
@@ -1,3 +1,4 @@
+import { isValidSourceType } from 'dnd-core';
 import invariant from 'invariant';
 import isPlainObject from 'lodash/isPlainObject';
 import checkDecoratorArguments from './utils/checkDecoratorArguments';
@@ -6,17 +7,16 @@ import registerSource from './registerSource';
 import createSourceFactory from './createSourceFactory';
 import createSourceMonitor from './createSourceMonitor';
 import createSourceConnector from './createSourceConnector';
-import isValidType from './utils/isValidType';
 
 export default function DragSource(type, spec, collect, options = {}) {
   checkDecoratorArguments('DragSource', 'type, spec, collect[, options]', ...arguments);
   let getType = type;
   if (typeof type !== 'function') {
     invariant(
-      isValidType(type),
+      isValidSourceType(type),
       'Expected "type" provided as the first argument to DragSource to be ' +
-      'a string, or a function that returns a string given the current props. ' +
-      'Instead, received %s. ' +
+      'a string, a symbol, or a function that returns a string or symbol ' +
+      ' given the current props. Instead, received %s. ' +
       'Read more: http://gaearon.github.io/react-dnd/docs-drag-source.html',
       type
     );

--- a/src/DropTarget.js
+++ b/src/DropTarget.js
@@ -1,3 +1,4 @@
+import { isValidTargetType } from 'dnd-core';
 import invariant from 'invariant';
 import isPlainObject from 'lodash/isPlainObject';
 import checkDecoratorArguments from './utils/checkDecoratorArguments';
@@ -6,17 +7,16 @@ import registerTarget from './registerTarget';
 import createTargetFactory from './createTargetFactory';
 import createTargetMonitor from './createTargetMonitor';
 import createTargetConnector from './createTargetConnector';
-import isValidType from './utils/isValidType';
 
 export default function DropTarget(type, spec, collect, options = {}) {
   checkDecoratorArguments('DropTarget', 'type, spec, collect[, options]', ...arguments);
   let getType = type;
   if (typeof type !== 'function') {
     invariant(
-      isValidType(type, true),
+      isValidTargetType(type),
       'Expected "type" provided as the first argument to DropTarget to be ' +
-      'a string, an array of strings, or a function that returns either given ' +
-      'the current props. Instead, received %s. ' +
+      'a string, a symbol, a boolean, an array thereof, or a function that ' +
+      'returns one of the above given the current props. Instead, received %s. ' +
       'Read more: http://gaearon.github.io/react-dnd/docs-drop-target.html',
       type
     );

--- a/src/utils/isValidType.js
+++ b/src/utils/isValidType.js
@@ -1,7 +1,0 @@
-import isArray from 'lodash/isArray';
-
-export default function isValidType(type, allowArray) {
-  return typeof type === 'string' ||
-         typeof type === 'symbol' ||
-         allowArray && isArray(type) && type.every(t => isValidType(t, false));
-}


### PR DESCRIPTION
New feature for #432 

There's a hard dependency on gaearon/dnd-core#31 since I'm using the new `isValidSourceType` and `isValidTargetType`
