### PR TITLE
CSS fixes for square

### DIFF
--- a/docs/00 Quick Start/Tutorial.md
+++ b/docs/00 Quick Start/Tutorial.md
@@ -214,8 +214,8 @@ var Square = React.createClass({
       <div style={{
         backgroundColor: fill,
         color: stroke,
-        width: '100%',
-        height: '100%'
+        minWidth: '12vw',
+        height: '12vw'
       }}>
         {this.props.children}
       </div>
@@ -239,8 +239,8 @@ export default class Square extends Component {
       <div style={{
         backgroundColor: fill,
         color: stroke,
-        width: '100%',
-        height: '100%'
+        minWidth: '12vw',
+        height: '12vw'
       }}>
         {this.props.children}
       </div>
@@ -270,8 +270,8 @@ export default class Square extends Component {
       <div style={{
         backgroundColor: fill,
         color: stroke,
-        width: '100%',
-        height: '100%'
+        minWidth: '12vw',
+        height: '12vw'
       }}>
         {this.props.children}
       </div>

--- a/docs/00 Quick Start/Tutorial.md
+++ b/docs/00 Quick Start/Tutorial.md
@@ -47,7 +47,7 @@ var React = require('react');
 
 var Knight = React.createClass({
   render: function () {
-    return <span>♘</span>;
+    return <span> style={{fontSize: '12vw'}}♘</span>;
   }
 });
 
@@ -59,7 +59,7 @@ import React, { Component } from 'react';
 
 export default class Knight extends Component {
   render() {
-    return <span>♘</span>;
+    return <span style={{fontSize: '12vw'}}>♘</span>;
   }
 }
 ```


### PR DESCRIPTION
minWidth: '12vw' and height: '12vw' fixes the square. Without them, the square is not visible on Chrome 52 and Firefox 48.
