### PR TITLE
Suggest react-dnd-scrollzone as a way to scroll while dragging

### DIFF
--- a/examples/04 Sortable/Stress Test/index.js
+++ b/examples/04 Sortable/Stress Test/index.js
@@ -29,7 +29,15 @@ export default class SortableStressTest extends Component {
           Luckily, React DnD is designed to work great with any virtual React data list components because it doesn't keep any state in the DOM.
         </p>
         <p>
-          This example does not scroll automatically but you can add the scrolling with a parent drop target that compares <code>component.getBoundingClientRect()</code> with <code>monitor.getClientOffset()</code> inside its <code>hover</code> handler.
+          This example does not scroll automatically but you can add the scrolling with one of the following methods:
+          <ul>
+            <li>
+              Use the <a href="https://github.com/azuqua/react-dnd-scrollzone">react-dnd-scrollzone</a> library.
+            </li>
+            <li>
+              Use a parent drop target that compares <code>component.getBoundingClientRect()</code> with <code>monitor.getClientOffset()</code> inside its <code>hover</code> handler.
+            </li>
+          </ul>
           In fact, you are welcome to contribute this functionality to this example!
         </p>
         {shouldRender && <Container />}


### PR DESCRIPTION
I faced numerous issues when implementing scrolling as suggested in this example, and eventually resorted to using the [react-dnd-scrollzone](https://github.com/azuqua/react-dnd-scrollzone) library. It did everything I wanted with a very simple API.

I believe both scroll-on-drag approaches are valid, but the existence of such a convenient library for doing exactly what is described here deserves a mention.