### PR TITLE
Adding a React Component for establishing Context via React Trees

### DIFF
--- a/src/DragDropContext.js
+++ b/src/DragDropContext.js
@@ -8,8 +8,8 @@ const CHILD_CONTEXT_TYPES = {
   dragDropManager: PropTypes.object.isRequired
 };
 
-const createChildContext = (backend, window) => ({
-  dragDropManager: new DragDropManager(backend, window),
+const createChildContext = (backend, context) => ({
+  dragDropManager: new DragDropManager(backend, context),
 });
 
 const unpackBackendForEs5Users = (backendOrModule) => {
@@ -46,8 +46,7 @@ export class DragDropContextProvider extends Component {
   }
 
   getChildContext() {
-    const { window } = this.context;
-    return createChildContext(this.backend, window);
+    return createChildContext(this.backend, this.context.window);
   }
 
   render() {

--- a/src/DragDropContext.js
+++ b/src/DragDropContext.js
@@ -38,7 +38,7 @@ export class DragDropContextProvider extends Component {
   static displayName = 'DragDropContextProvider';
 
   static contextTypes = {
-    document: PropTypes.object,
+    window: PropTypes.object,
   };
 
   constructor(props, context) {
@@ -47,18 +47,12 @@ export class DragDropContextProvider extends Component {
   }
 
   getChildContext() {
-    const { document } = this.context;
-    const window = document.defaultView || document.parentView;
+    const { window } = this.context;
     return createChildContext(this.backend, window);
   }
 
   render() {
     return Children.only(this.props.children);
-  }
-
-  getDocument() {
-    const domNode = ReactDOM.findDOMNode(this);
-    return domNode.ownerDocument || domNode.contentDocument;
   }
 }
 

--- a/src/DragDropContext.js
+++ b/src/DragDropContext.js
@@ -1,5 +1,4 @@
 import React, { Component, PropTypes, Children } from 'react';
-import ReactDOM from 'react-dom';
 import { DragDropManager } from 'dnd-core';
 import invariant from 'invariant';
 import checkDecoratorArguments from './utils/checkDecoratorArguments';

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export { default as DragDropContext } from './DragDropContext';
+export { default as DragDropContext, DragDropContextProvider } from './DragDropContext';
 export { default as DragLayer } from './DragLayer';
 export { default as DragSource } from './DragSource';
 export { default as DropTarget } from './DropTarget';


### PR DESCRIPTION
This will allow us to nest the DragDrop engine under an iframe. Note that the iframe `window` must be injected via context.

see https://github.com/gaearon/react-dnd/issues/241
see https://github.com/gaearon/dnd-core/pull/37