### PR TITLE
(#645) - Use 'typeof window' to check for window existence in HTML5 B…

### DIFF
--- a/packages/react-dnd-html5-backend/package.json
+++ b/packages/react-dnd-html5-backend/package.json
@@ -9,15 +9,15 @@
     "build:umd": "webpack",
     "build": "npm-run-all --parallel build:*",
     "lint": "eslint .",
-    "unit_test": "mocha --require babel-register --recursive",
-    "unit_test:watch": "npm run unit_test -- --watch",
-    "test": "npm-run-all clean --parallel lint build unit_test",
+    "unit_test": "jest",
+    "unit_test:coverage": "jest",
+    "unit_test:watch": "jest --watch",
+    "verify": "npm-run-all lint unit_test:coverage",
+    "test": "npm-run-all clean --parallel build verify",
     "develop": "npm run unit_test:watch",
     "prepublish": "npm test"
   },
   "devDependencies": {
-    "expect.js": "^0.3.1",
-    "mocha": "^3.2.0",
     "react-dnd": "^2.2.0"
   },
   "dependencies": {

--- a/packages/react-dnd-html5-backend/package.json
+++ b/packages/react-dnd-html5-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dnd-html5-backend",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "HTML5 backend for React DnD",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/react-dnd-html5-backend/src/HTML5Backend.js
+++ b/packages/react-dnd-html5-backend/src/HTML5Backend.js
@@ -36,11 +36,16 @@ export default class HTML5Backend {
   }
 
   get window() {
-    return (this.context && this.context.window) || window;
+    if (this.context && this.context.window) {
+      return this.context.window;
+    } else if (typeof window !== 'undefined') {
+      return window;
+    }
+    return undefined;
   }
 
   setup() {
-    if (typeof this.window === 'undefined') {
+    if (this.window === undefined) {
       return;
     }
 
@@ -52,7 +57,7 @@ export default class HTML5Backend {
   }
 
   teardown() {
-    if (typeof this.window === 'undefined') {
+    if (this.window === undefined) {
       return;
     }
 

--- a/packages/react-dnd-html5-backend/test/.eslintrc
+++ b/packages/react-dnd-html5-backend/test/.eslintrc
@@ -1,5 +1,5 @@
 {
     "env": {
-        "mocha": true
+        "jest": true
     }
 }

--- a/packages/react-dnd-html5-backend/test/HTML5Backend.spec.js
+++ b/packages/react-dnd-html5-backend/test/HTML5Backend.spec.js
@@ -1,0 +1,51 @@
+import HTML5Backend from '../src/HTML5Backend';
+
+describe('The HTML5 Backend', () => {
+  describe('window injection', () => {
+    it('uses an undefined window when no window is available', () => {
+      const mockManager = {
+        getActions: () => null,
+        getMonitor: () => null,
+        getRegistry: () => null,
+        getContext: () => ({}),
+      };
+      const mockWindow = global.window;
+      try {
+        delete global.window;
+        const backend = new HTML5Backend(mockManager);
+        expect(backend).toBeDefined();
+        expect(backend.window).toBeUndefined();
+      } finally {
+        global.window = mockWindow;
+      }
+    });
+
+    it('uses the ambient window global', () => {
+      const mockManager = {
+        getActions: () => null,
+        getMonitor: () => null,
+        getRegistry: () => null,
+        getContext: () => ({}),
+      };
+      const backend = new HTML5Backend(mockManager);
+      expect(backend).toBeDefined();
+      expect(backend.window).toBeDefined();
+    });
+
+    it('allows a window to be injected', () => {
+      const mockManager = {
+        getActions: () => null,
+        getMonitor: () => null,
+        getRegistry: () => null,
+        getContext: () => ({
+          window: {
+            x: 1,
+          },
+        }),
+      };
+      const backend = new HTML5Backend(mockManager);
+      expect(backend).toBeDefined();
+      expect(backend.window.x).toEqual(1);
+    });
+  });
+});


### PR DESCRIPTION
Update the window property getter so that it uses a typeof check. If `window` is used without typeof, and it is not defined, an error will be thrown.