### PR TITLE
when rendering on the server window is undefined so no need to return it

### DIFF
--- a/packages/react-dnd/src/DragDropContextProvider.js
+++ b/packages/react-dnd/src/DragDropContextProvider.js
@@ -44,8 +44,11 @@ export default class DragDropContextProvider extends Component {
         return this.props.window;
       } else if (this.context && this.context.window) {
         return this.context.window;
+      } else if (typeof window !== undefined) {
+        return window;
+      } else {
+        return undefined;
       }
-      return window;
     };
 
     return createChildContext(this.backend, { window: getWindow() });

--- a/packages/react-dnd/src/DragDropContextProvider.js
+++ b/packages/react-dnd/src/DragDropContextProvider.js
@@ -44,11 +44,10 @@ export default class DragDropContextProvider extends Component {
         return this.props.window;
       } else if (this.context && this.context.window) {
         return this.context.window;
-      } else if (typeof window !== undefined) {
+      } else if (typeof window !== 'undefined') {
         return window;
-      } else {
-        return undefined;
       }
+      return undefined;
     };
 
     return createChildContext(this.backend, { window: getWindow() });


### PR DESCRIPTION
When rendering your react app on the server first DragDropContextProvider.js fails when trying to call getWindow() which fails on the server... Adding a simple check to avoid this