### PR TITLE
html5 backend support dataTransfer.setData

### DIFF
--- a/packages/react-dnd-html5-backend/src/HTML5Backend.js
+++ b/packages/react-dnd-html5-backend/src/HTML5Backend.js
@@ -306,9 +306,22 @@ export default class HTML5Backend {
         dataTransfer.setDragImage(dragPreview, dragPreviewOffset.x, dragPreviewOffset.y);
       }
 
+      const { operateDataTransfer } = this.getCurrentSourceNodeOptions();
+      let setDataCalled = false;
+      if (typeof operateDataTransfer === 'function') {
+        const originSetData = dataTransfer.setData;
+        dataTransfer.setData = function (...args) {
+          originSetData.apply(this, args);
+          setDataCalled = true;
+        };
+        operateDataTransfer(dataTransfer);
+        dataTransfer.setData = originSetData;
+      }
       try {
-        // Firefox won't drag without setting data
-        dataTransfer.setData('application/json', {});
+        if (!setDataCalled) {
+          // Firefox won't drag without setting data
+          dataTransfer.setData('application/json', {});
+        }
       } catch (err) {
         // IE doesn't support MIME types in setData
       }


### PR DESCRIPTION
In my case I need to make todo item can be drag to native textfield of operating system and become some text like `- [ ] todo description`.

So I need call `dataTransfer.setData` in my component like :

```jsx
const operateDataTransfer = dataTransfer => {
  const completeMark = todo.get('completed') ? 'x' : ' '
  const markdown = `- [${completeMark}] ${todo.get('description')}`
  dataTransfer.setData('Text', markdown)
  dataTransfer.setData('text/plain', markdown)
  dataTransfer.setData('text/markdown', markdown)
  dataTransfer.setData('application/json', todo.toJS())
}

const dragSource = connectDragSource(
 <span className="handler">
   <i className="icon-handler" style={isSortable ? {} : {visibility: 'hidden'}}></i>
 </span>,
 { operateDataTransfer },
)
```

I'm not sure the code about `dataTransfer.setData` is a good solution, but I have no better idea :(