### PR TITLE
Add gzip size badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![bitHound Code](https://www.bithound.io/github/react-dnd/react-dnd/badges/code.svg)](https://www.bithound.io/github/react-dnd/react-dnd)
 [![bitHound Dependencies](https://www.bithound.io/github/react-dnd/react-dnd/badges/dependencies.svg)](https://www.bithound.io/github/react-dnd/react-dnd/master/dependencies/npm)
 [![bitHound Dev Dependencies](https://www.bithound.io/github/react-dnd/react-dnd/badges/devDependencies.svg)](https://www.bithound.io/github/react-dnd/react-dnd/master/dependencies/npm)
+![gzip size](http://img.badgesize.io/https://npmcdn.com/react-dnd/dist/ReactDnD.min.js?compression=gzip)
 
 
 React *DnD*


### PR DESCRIPTION
It would be really useful if this repo included a size badge for easy reference.

I just went through the process of finding the gzip size myself, but it was quite tedious:

1. Look for compile/minified file.
2. Discover that it's not included in the repo
3. Discover that the `dist` folder is part of the published npm package via https://github.com/react-dnd/react-dnd/issues/502 (docs are misleading)
4. Finally, `curl -sL https://npmcdn.com/react-dnd@2.2.4/dist/ReactDnD.min.js | gzip-size`

We can save others the bother by using this project which makes it easy to add a badge showing various sizes: https://github.com/ngryman/badge-size.

Thanks! 😄 