### PR TITLE
Initializing class state in the Backend Constructor

### DIFF
--- a/packages/react-dnd-html5-backend/src/HTML5Backend.js
+++ b/packages/react-dnd-html5-backend/src/HTML5Backend.js
@@ -19,6 +19,15 @@ export default class HTML5Backend {
     this.sourceNodeOptions = {};
     this.enterLeaveCounter = new EnterLeaveCounter();
 
+    this.dragStartSourceIds = [];
+    this.dropTargetIds = [];
+    this.dragEnterTargetIds = [];
+    this.currentNativeSource = null;
+    this.currentNativeHandle = null;
+    this.currentDragSourceNode = null;
+    this.currentDragSourceNodeOffset = null;
+    this.currentDragSourceNodeOffsetChanged = false;
+
     this.getSourceClientOffset = this.getSourceClientOffset.bind(this);
     this.handleTopDragStart = this.handleTopDragStart.bind(this);
     this.handleTopDragStartCapture = this.handleTopDragStartCapture.bind(this);


### PR DESCRIPTION
The HTML5Backend initializes some arrays and local variables as methods are invoked on it. There are some unlikely edge cases where these pieces of state are being used prior to correct initialization. This commit explicitly sets a default initial state in the HTML5Backend constructor for those pieces of state.

See https://github.com/react-dnd/react-dnd-html5-backend/pull/33
See https://github.com/react-dnd/react-dnd-html5-backend/issues/32