### PR TITLE
Updated reactiflux discord channel to #need-help

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See the changelog on the Releases page:
 
 https://github.com/react-dnd/react-dnd/releases
 
-Questions? Find us on the Reactiflux Discord Server (**#general**)
+Questions? Find us on the Reactiflux Discord Server (**#need-help**)
 
 https://www.reactiflux.com/
 


### PR DESCRIPTION
`#general` is for more general React discussion, `#need-help` is for actual questions regarding React and its ecosystem.