### PR TITLE
Fix typo on DragLayerMonitor doc

### DIFF
--- a/docs/03 Monitoring State/DragLayerMonitor.md
+++ b/docs/03 Monitoring State/DragLayerMonitor.md
@@ -17,7 +17,7 @@ DragLayerMonitor
 
 * **`getInitialSourceClientOffset()`**: Returns the `{ x, y }` client offset of the drag source component's root DOM node at the time when the current drag operation has started. Returns `null` if no item is being dragged.
 
-* **`getClientOffset`**: Returns the last recorded `{ x, y }` client offset of the pointer while a drag operation is in progress. Returns `null` if no item is being dragged.
+* **`getClientOffset()`**: Returns the last recorded `{ x, y }` client offset of the pointer while a drag operation is in progress. Returns `null` if no item is being dragged.
 
 * **`getDifferenceFromInitialOffset()`**: Returns the `{ x, y }` difference between the last recorded client offset of the pointer and the client offset when current the drag operation has started. Returns `null` if no item is being dragged.
 


### PR DESCRIPTION
add forgotten parentheses for `getClientOffset()`