### PR TITLE
Fix intermittent problems with dropping a native file in FF

### DIFF
--- a/packages/react-dnd-html5-backend/src/HTML5Backend.js
+++ b/packages/react-dnd-html5-backend/src/HTML5Backend.js
@@ -199,7 +199,7 @@ export default class HTML5Backend {
     this.currentNativeHandle = this.registry.addSource(type, this.currentNativeSource);
     this.actions.beginDrag([this.currentNativeHandle]);
 
-    // On Firefox, if mousemove fires, the drag is over but browser failed to tell us.
+    // On Firefox, if mouseover fires, the drag is over but browser failed to tell us.
     // See https://bugzilla.mozilla.org/show_bug.cgi?id=656164
     // This is not true for other browsers.
     if (isFirefox()) {

--- a/packages/react-dnd-html5-backend/src/HTML5Backend.js
+++ b/packages/react-dnd-html5-backend/src/HTML5Backend.js
@@ -208,7 +208,7 @@ export default class HTML5Backend {
   }
 
   asyncEndDragNativeItem() {
-    this.asyncEndDragTimeout = setTimeout(this.endDragNativeItem, 0);
+    this.asyncEndDragTimeout = setTimeout(this.endDragNativeItem, 100);
     if (isFirefox()) {
       this.window.removeEventListener('mouseover', this.asyncEndDragNativeItem, true);
       this.enterLeaveCounter.reset();

--- a/packages/react-dnd-html5-backend/src/HTML5Backend.js
+++ b/packages/react-dnd-html5-backend/src/HTML5Backend.js
@@ -75,7 +75,9 @@ export default class HTML5Backend {
     this.window.__isReactDndBackendSetUp = false; // eslint-disable-line no-underscore-dangle
     this.removeEventListeners(this.window);
     this.clearCurrentDragSourceNode();
-    clearTimeout(this.asyncEndDragTimeout);
+    if (this.asyncEndDragFrameId) {
+      this.window.cancelAnimationFrame(this.asyncEndDragFrameId);
+    }
   }
 
   addEventListeners(target) {
@@ -208,7 +210,7 @@ export default class HTML5Backend {
   }
 
   asyncEndDragNativeItem() {
-    this.asyncEndDragTimeout = setTimeout(this.endDragNativeItem, 100);
+    this.asyncEndDragFrameId = this.window.requestAnimationFrame(this.endDragNativeItem);
     if (isFirefox()) {
       this.window.removeEventListener('mouseover', this.asyncEndDragNativeItem, true);
       this.enterLeaveCounter.reset();


### PR DESCRIPTION
Fixes #539

When dropping a native file in FF, under some conditions the `mousemove` event was firing when the file was dropped before the `drop` event fired. If the drop operation would fail.

To fix, the event handler is delayed so that the end drag will always run after the drop handler. This commit also switches to using the `mouseover` event so that the drag state is reset sooner if the original FF dragleave bug is hit, and the commit resets the `EnterLeaveCounter` when ending the drag operation via the `mouseover` event handler because the FF `dragleave` bug results in `this.entered` not being empty.