### PR TITLE
Changed URL for browsing source to point to correct location

### DIFF
--- a/examples/06 Other/Native Files/index.js
+++ b/examples/06 Other/Native Files/index.js
@@ -6,7 +6,7 @@ export default class NativeFiles extends Component {
     return (
       <div>
         <p>
-          <b><a href="https://github.com/react-dnd/react-dnd/tree/master/examples/05%20Customize/Native%20Files">Browse the Source</a></b>
+          <b><a href="https://github.com/react-dnd/react-dnd/tree/master/examples/06%20Other/Native%20Files">Browse the Source</a></b>
         </p>
         <p>
           Example demonstrating drag and drop of native files.


### PR DESCRIPTION
Changing URL to point to correct location, when browsing source code for Native Files example.
fixes #723 