### PR TITLE
Migrated deprecated React.PropTypes in example + same for React.creat…

### DIFF
--- a/docs/00 Quick Start/FAQ.md
+++ b/docs/00 Quick Start/FAQ.md
@@ -16,9 +16,10 @@ You can see that in every example on the website that uses it, such as:
 
 -------------------
 ```js
+var createReactClass = require('create-react-class');
 var DragSource = require('react-dnd').DragSource;
 
-var MyComponent = React.createClass({
+var MyComponent = createReactClass({
   /* ... */
 });
 
@@ -85,11 +86,12 @@ When using [stateless components](https://facebook.github.io/react/docs/reusable
 
 -------------------
 ```js
+var createReactClass = require('create-react-class');
 var DragSource = require('react-dnd').DragSource;
 var DropTarget = require('react-dnd').DropTarget;
 var flow = require('lodash/flow');
 
-var YourComponent = React.createClass({
+var YourComponent = createReactClass({
   /* ... */
 });
 
@@ -131,6 +133,7 @@ If you are using the [HTML5 backend](docs-html5-backend.html), you can register 
 -------------------
 ```js
 var React = require('react');
+var createReactClass = require('create-react-class');
 var NativeTypes = require('react-dnd-html5-backend').NativeTypes;
 var DropTarget = require('react-dnd').DropTarget;
 
@@ -140,7 +143,7 @@ var fileTarget = {
   }
 };
 
-var FileDropZone = React.createClass({
+var FileDropZone = createReactClass({
   render() {
     var connectDropTarget = this.props.connectDropTarget;
     var isOver = this.props.isOver;
@@ -241,7 +244,9 @@ Consider this example:
 
 -------------------
 ```javascript
-var Page = React.createClass({
+var createReactClass = require('create-react-class');
+
+var Page = createReactClass({
   statics: {
     willTransitionTo: function (transition, params) {
       /* ... */
@@ -288,7 +293,9 @@ It might surprise you that your route handler's `willTransitionTo` (or a similar
 
 -------------------
 ```javascript
-var Page = React.createClass({
+var createReactClass = require('create-react-class');
+
+var Page = createReactClass({
   render: function () {
     /* ... */
   }

--- a/docs/00 Quick Start/Overview.md
+++ b/docs/00 Quick Start/Overview.md
@@ -127,9 +127,10 @@ One caveat of using them is that they require *two* function applications. For e
 
 -------------------
 ```js
+var createReactClass = require('create-react-class');
 var DragSource = require('react-dnd').DragSource;
 
-var YourComponent = React.createClass({
+var YourComponent = createReactClass({
   /* ... */
 });
 
@@ -172,11 +173,12 @@ Even if you don't plan to use ES7, the partial application can still be handy, b
 
 -------------------
 ```js
+var createReactClass = require('create-react-class');
 var DragSource = require('react-dnd').DragSource;
 var DropTarget = require('react-dnd').DropTarget;
 var flow = require('lodash/flow');
 
-var YourComponent = React.createClass({
+var YourComponent = createReactClass({
   render() {
     return this.props.connectDragSource(this.props.connectDropTarget(
       /* ... */
@@ -232,6 +234,7 @@ Below is an example of wrapping an existing `Card` component into a drag source.
 -------------------
 ```js
 var React = require('react');
+var createReactClass = require('create-react-class');
 var DragSource = require('react-dnd').DragSource;
 
 // Drag sources and drop targets only interact
@@ -278,7 +281,7 @@ function collect(connect, monitor) {
   };
 }
 
-var Card = React.createClass({
+var Card = createReactClass({
   render: function () {
     // Your component receives its own props as usual
     var id = this.props.id;

--- a/docs/00 Quick Start/Testing.md
+++ b/docs/00 Quick Start/Testing.md
@@ -98,6 +98,7 @@ Here is an example to get you started:
 -------------------
 ```js
 var React = require('react');
+var createReactClass = require('create-react-class');
 var Component = React.Component;
 var TestBackend = require('react-dnd-test-backend');
 var DragDropContext = require('react-dnd').DragDropContext;
@@ -109,7 +110,7 @@ var expect = require('expect');
  */
 function wrapInTestContext(DecoratedComponent) {
   return DragDropContext(TestBackend)(
-    React.createClass({
+    createReactClass({
       render: function () {
         return <DecoratedComponent {...this.props} />;
       }

--- a/docs/00 Quick Start/Tutorial.md
+++ b/docs/00 Quick Start/Tutorial.md
@@ -44,8 +44,9 @@ In fact I'm going to start with the `Knight`. It doesn't have any props at all, 
 -------------------
 ```js
 var React = require('react');
+var createReactClass = require('create-react-class');
 
-var Knight = React.createClass({
+var Knight = createReactClass({
   render: function () {
     return <span>♘</span>;
   }
@@ -100,9 +101,10 @@ I see my `Knight` on the screen! Time to go ahead and implement the `Square` now
 -------------------
 ```js
 var React = require('react');
-var PropTypes = React.PropTypes;
+var createReactClass = require('create-react-class');
+var PropTypes = require('prop-types');
 
-var Square = React.createClass({
+var Square = createReactClass({
   propTypes: {
     black: PropTypes.bool
   },
@@ -119,7 +121,8 @@ module.exports = Square;
 ```
 -------------------
 ```js
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 export default class Square extends Component {
   render() {
@@ -136,7 +139,8 @@ Square.propTypes = {
 ```
 -------------------
 ```js
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 export default class Square extends Component {
   static propTypes = {
@@ -198,9 +202,10 @@ Even after correcting these two mistakes, I still can't see my `Knight` when the
 -------------------
 ```js
 var React = require('react');
-var PropTypes = React.PropTypes;
+var createReactClass = require('create-react-class');
+var PropTypes = require('prop-types');
 
-var Square = React.createClass({
+var Square = createReactClass({
   propTypes: {
     black: PropTypes.bool
   },
@@ -227,7 +232,8 @@ module.exports = Square;
 ```
 -------------------
 ```js
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 export default class Square extends Component {
   render() {
@@ -254,7 +260,8 @@ Square.propTypes = {
 ```
 -------------------
 ```js
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 export default class Square extends Component {
   static propTypes = {
@@ -288,11 +295,12 @@ Finally, time to get started with the `Board`! I'm going to start with an extrem
 -------------------
 ```js
 var React = require('react');
-var PropTypes = React.PropTypes;
+var createReactClass = require('create-react-class');
+var PropTypes = require('prop-types');
 var Square = require('./Square');
 var Knight = require('./Knight');
 
-var Board = React.createClass({
+var Board = createReactClass({
   propTypes: {
     knightPosition: PropTypes.arrayOf(
       PropTypes.number.isRequired
@@ -314,7 +322,8 @@ module.exports = Board;
 ```
 -------------------
 ```js
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Square from './Square';
 import Knight from './Knight';
 
@@ -338,7 +347,8 @@ Board.propTypes = {
 ```
 -------------------
 ```js
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Square from './Square';
 import Knight from './Knight';
 
@@ -478,11 +488,12 @@ At this point, I realize that I forgot to give my squares any layout. I'm going 
 -------------------
 ```js
 var React = require('react');
-var PropTypes = React.PropTypes;
+var createReactClass = require('create-react-class');
+var PropTypes = require('prop-types');
 var Square = require('./Square');
 var Knight = require('./Knight');
 
-var Board = React.createClass({
+var Board = createReactClass({
   propTypes: {
     knightPosition: PropTypes.arrayOf(
       PropTypes.number.isRequired
@@ -533,7 +544,8 @@ module.exports = Board;
 ```
 -------------------
 ```js
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Square from './Square';
 import Knight from './Knight';
 
@@ -585,7 +597,8 @@ Board.propTypes = {
 ```
 -------------------
 ```js
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Square from './Square';
 import Knight from './Knight';
 
@@ -815,7 +828,7 @@ The `Square` does not need to know its position to render. Therefore, it's best 
 -------------------
 ```js
 var React = require('react');
-var PropTypes = React.PropTypes;
+var PropTypes = require('prop-types');
 var Square = require('./Square');
 var Knight = require('./Knight');
 var moveKnight = require('./Game').moveKnight;
@@ -850,7 +863,8 @@ handleSquareClick: function (toX, toY) {
 ```
 -------------------
 ```js
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Square from './Square';
 import Knight from './Knight';
 import { moveKnight } from './Game';
@@ -984,10 +998,11 @@ Because the `Board` is the top-level component in our app, I'm going to put the 
 -------------------
 ```js
 var React = require('react');
+var createReactClass = require('create-react-class');
 var DragDropContext = require('react-dnd').DragDropContext;
 var HTML5Backend = require('react-dnd-html5-backend');
 
-var Board = React.createClass({
+var Board = createReactClass({
   /* ... */
 });
 
@@ -1081,7 +1096,8 @@ Let's take a look at the whole `Knight` component now, including the `DragSource
 -------------------
 ```js
 var React = require('react');
-var PropTypes = React.PropTypes;
+var createReactClass = require('create-react-class');
+var PropTypes = require('prop-types');
 var ItemTypes = require('./Constants').ItemTypes;
 var DragSource = require('react-dnd').DragSource;
 
@@ -1098,7 +1114,7 @@ function collect(connect, monitor) {
   }
 }
 
-var Knight = React.createClass({
+var Knight = createReactClass({
   propTypes: {
     connectDragSource: PropTypes.func.isRequired,
     isDragging: PropTypes.bool.isRequired
@@ -1125,7 +1141,8 @@ module.exports = DragSource(ItemTypes.KNIGHT, knightSource, collect)(Knight);
 ```
 -------------------
 ```js
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { ItemTypes } from './Constants';
 import { DragSource } from 'react-dnd';
 
@@ -1167,7 +1184,8 @@ export default DragSource(ItemTypes.KNIGHT, knightSource, collect)(Knight);
 ```
 -------------------
 ```js
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { ItemTypes } from './Constants';
 import { DragSource } from 'react-dnd';
 
@@ -1221,10 +1239,11 @@ Here is the `BoardSquare` I extracted:
 -------------------
 ```js
 var React = require('react');
-var PropTypes = React.PropTypes;
+var createReactClass = require('create-react-class');
+var PropTypes = require('prop-types');
 var Square = require('./Square');
 
-var BoardSquare = React.createClass({
+var BoardSquare = createReactClass({
   propTypes: {
     x: PropTypes.number.isRequired,
     y: PropTypes.number.isRequired
@@ -1247,7 +1266,8 @@ module.exports = BoardSquare;
 ```
 -------------------
 ```js
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Square from './Square';
 
 export default class BoardSquare extends Component {
@@ -1270,7 +1290,8 @@ BoardSquare.propTypes = {
 ```
 -------------------
 ```js
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Square from './Square';
 
 export default class BoardSquare extends Component {
@@ -1388,7 +1409,8 @@ After changing the `render` function to connect the drop target and show the hig
 -------------------
 ```js
 var React = require('react');
-var PropTypes = React.PropTypes;
+var createReactClass = require('create-react-class');
+var PropTypes = require('prop-types');
 var Square = require('./Square');
 var canMoveKnight = require('./Game').canMoveKnight;
 var moveKnight = require('./Game').moveKnight;
@@ -1408,7 +1430,7 @@ function collect(connect, monitor) {
   };
 }
 
-var BoardSquare = React.createClass({
+var BoardSquare = createReactClass({
   propTypes: {
     x: PropTypes.number.isRequired,
     y: PropTypes.number.isRequired,
@@ -1452,7 +1474,8 @@ module.exports = DropTarget(ItemTypes.KNIGHT, squareTarget, collect)(BoardSquare
 ```
 -------------------
 ```js
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Square from './Square';
 import { canMoveKnight, moveKnight } from './Game';
 import { ItemTypes } from './Constants';
@@ -1512,7 +1535,8 @@ export default DropTarget(ItemTypes.KNIGHT, squareTarget, collect)(BoardSquare);
 ```
 -------------------
 ```js
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Square from './Square';
 import { canMoveKnight, moveKnight } from './Game';
 import { ItemTypes } from './Constants';
@@ -1599,7 +1623,8 @@ I'm also adding `monitor.canDrop()` to my collecting function, as well as some o
 -------------------
 ```js
 var React = require('react');
-var PropTypes = React.PropTypes;
+var createReactClass = require('create-react-class');
+var PropTypes = require('prop-types');
 var Square = require('./Square');
 var canMoveKnight = require('./Game').canMoveKnight;
 var moveKnight = require('./Game').moveKnight;
@@ -1624,7 +1649,7 @@ function collect(connect, monitor) {
   };
 }
 
-var BoardSquare = React.createClass({
+var BoardSquare = createReactClass({
   propTypes: {
     x: PropTypes.number.isRequired,
     y: PropTypes.number.isRequired,
@@ -1676,7 +1701,8 @@ module.exports = DropTarget(ItemTypes.KNIGHT, squareTarget, collect)(BoardSquare
 ```
 -------------------
 ```js
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Square from './Square';
 import { canMoveKnight, moveKnight } from './Game';
 import { ItemTypes } from './Constants';
@@ -1748,7 +1774,8 @@ export default DropTarget(ItemTypes.KNIGHT, squareTarget, collect)(BoardSquare);
 ```
 -------------------
 ```js
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Square from './Square';
 import { canMoveKnight, moveKnight } from './Game';
 import { ItemTypes } from './Constants';

--- a/docs/01 Top Level API/DragDropContext.md
+++ b/docs/01 Top Level API/DragDropContext.md
@@ -10,10 +10,11 @@ This lets you specify the backend, and sets up the shared DnD state behind the s
 
 -------------------
 ```js
+var createReactClass = require('create-react-class');
 var HTML5Backend = require('react-dnd-html5-backend');
 var DragDropContext = require('react-dnd').DragDropContext;
 
-var YourApp = React.createClass(
+var YourApp = createReactClass(
   /* ... */
 );
 

--- a/docs/01 Top Level API/DragDropContextProvider.md
+++ b/docs/01 Top Level API/DragDropContextProvider.md
@@ -11,10 +11,11 @@ injected with a backend via the `backend` prop, but it also can be injected with
 
 -------------------
 ```js
+var createReactClass = require('create-react-class');
 var HTML5Backend = require('react-dnd-html5-backend');
 var DragDropContextProvider = require('react-dnd').DragDropContextProvider;
 
-var YourApp = React.createClass(
+var YourApp = createReactClass(
   render() {
     return (
       <DragDropContextProvider backend={HTML5Backend}>

--- a/docs/01 Top Level API/DragLayer.md
+++ b/docs/01 Top Level API/DragLayer.md
@@ -17,9 +17,10 @@ To use `DragLayer`, don't forget to wrap the top-level component of your app in 
 
 -------------------
 ```js
+var createReactClass = require('create-react-class');
 var DragLayer = require('react-dnd').DragLayer;
 
-var CustomDragLayer = React.createClass({
+var CustomDragLayer = createReactClass({
   /* ... */
 });
 
@@ -78,7 +79,8 @@ For easier [testing](docs-testing.html), it provides an API to reach into the in
 -------------------
 ```js
 var React = require('react');
-var PropTypes = React.PropTypes;
+var createReactClass = require('create-react-class');
+var PropTypes = require('prop-types');
 var ItemTypes = require('./ItemTypes');
 var BoxDragPreview = require('./BoxDragPreview');
 var DragLayer = require('react-dnd').DragLayer;
@@ -119,7 +121,7 @@ function collect(monitor) {
   };
 }
 
-var CustomDragLayer = React.createClass({
+var CustomDragLayer = createReactClass({
   propTypes: {
     item: PropTypes.object,
     itemType: PropTypes.string,
@@ -161,7 +163,8 @@ module.exports = DragLayer(collect)(CustomDragLayer);
 ```
 -------------------
 ```js
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ItemTypes from './ItemTypes';
 import BoxDragPreview from './BoxDragPreview';
 import snapToGrid from './snapToGrid';
@@ -242,7 +245,8 @@ export default DragLayer(collect)(CustomDragLayer);
 ```
 -------------------
 ```js
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ItemTypes from './ItemTypes';
 import BoxDragPreview from './BoxDragPreview';
 import { DragLayer } from 'react-dnd';

--- a/docs/01 Top Level API/DragSource.md
+++ b/docs/01 Top Level API/DragSource.md
@@ -13,9 +13,10 @@ To use `DragSource`, don't forget to wrap the top-level component of your app in
 
 -------------------
 ```js
+var createReactClass = require('create-react-class');
 var DragSource = require('react-dnd').DragSource;
 
-var MyComponent = React.createClass({
+var MyComponent = createReactClass({
   /* ... */
 });
 
@@ -121,6 +122,7 @@ Check out [the tutorial](docs-tutorial.html) for more real examples!
 -------------------
 ```js
 var React = require('react');
+var createReactClass = require('create-react-class');
 var DragSource = require('react-dnd').DragSource;
 
 // Drag sources and drop targets only interact
@@ -189,7 +191,7 @@ function collect(connect, monitor) {
   };
 }
 
-var Card = React.createClass({
+var Card = createReactClass({
   render: function () {
     // Your component receives its own props as usual
     var id = this.props.id;

--- a/docs/01 Top Level API/DropTarget.md
+++ b/docs/01 Top Level API/DropTarget.md
@@ -13,9 +13,10 @@ To use `DropTarget`, don't forget to wrap the top-level component of your app in
 
 -------------------
 ```js
+var createReactClass = require('create-react-class');
 var DropTarget = require('react-dnd').DropTarget;
 
-var MyComponent = React.createClass({
+var MyComponent = createReactClass({
   /* ... */
 });
 
@@ -124,6 +125,7 @@ Check out [the tutorial](docs-tutorial.html) for more real examples!
 -------------------
 ```js
 var React = require('react');
+var createReactClass = require('create-react-class');
 var findDOMNode = require('react-dom').findDOMNode;
 var DropTarget = require('react-dnd').DropTarget;
 
@@ -199,7 +201,7 @@ function collect(connect, monitor) {
   };
 }
 
-var ChessSquare = React.createClass({
+var ChessSquare = createReactClass({
   componentWillReceiveProps: function (nextProps) {
     if (!this.props.isOver && nextProps.isOver) {
       // You can use this as enter handler

--- a/docs/02 Connecting to DOM/DragSourceConnector.md
+++ b/docs/02 Connecting to DOM/DragSourceConnector.md
@@ -36,6 +36,7 @@ Check out [the tutorial](docs-tutorial.html) for more real examples!
 -------------------
 ```js
 var React = require('react');
+var createReactClass = require('create-react-class');
 var DragSource = require('react-dnd').DragSource;
 
 /* ... */
@@ -47,7 +48,7 @@ function collect(connect, monitor) {
   };
 }
 
-var ComponentWithCopyEffect = React.createClass({
+var ComponentWithCopyEffect = createReactClass({
   render: function () {
     var connectDragSource = this.props.connectDragSource;
 
@@ -61,7 +62,7 @@ var ComponentWithCopyEffect = React.createClass({
 });
 ComponentWithCopyEffect = DragSource(/* ... */)(ComponentWithCopyEffect);
 
-var ComponentWithHandle = React.createClass({
+var ComponentWithHandle = createReactClass({
   render: function () {
     var connectDragSource = this.props.connectDragSource;
     var connectDragPreview = this.props.connectDragPreview;
@@ -78,7 +79,7 @@ var ComponentWithHandle = React.createClass({
 });
 ComponentWithHandle = DragSource(/* ... */)(ComponentWithHandle);
 
-var ComponentWithImagePreview = React.createClass({
+var ComponentWithImagePreview = createReactClass({
   componentDidMount: function () {
     var connectDragPreview = this.props.connectDragPreview;
 

--- a/docs/02 Connecting to DOM/DropTargetConnector.md
+++ b/docs/02 Connecting to DOM/DropTargetConnector.md
@@ -18,6 +18,7 @@ Check out [the tutorial](docs-tutorial.html) for more real examples!
 -------------------
 ```js
 var React = require('react');
+var createReactClass = require('create-react-class');
 var DropTarget = require('react-dnd').DropTarget;
 
 /* ... */
@@ -28,7 +29,7 @@ function collect(connect, monitor) {
   };
 }
 
-var DropZone = React.createClass({
+var DropZone = createReactClass({
   render: function () {
     var connectDropTarget = this.props.connectDropTarget;
 

--- a/docs/04 Backends/HTML5.md
+++ b/docs/04 Backends/HTML5.md
@@ -27,10 +27,11 @@ Aside from the default export, the HTML5 backend module also provides a few extr
 
 -------------------
 ```js
+var createReactClass = require('create-react-class');
 var HTML5Backend = require('react-dnd-html5-backend');
 var DragDropContext = require('react-dnd').DragDropContext;
 
-var YourApp = React.createClass(
+var YourApp = createReactClass(
   /* ... */
 );
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,9 +16,10 @@ The second package instructs React DnD to use [the HTML5 drag and drop API](http
 // Let's make <Card text='Write the docs' /> draggable!
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 var DragSource = require('react-dnd').DragSource;
 var ItemTypes = require('./Constants').ItemTypes;
-var PropTypes = React.PropTypes;
+var PropTypes = require('prop-types');
 
 /**
  * Implements the drag source contract.
@@ -41,7 +42,7 @@ function collect(connect, monitor) {
   };
 }
 
-var Card = React.createClass({
+var Card = createReactClass({
   propTypes: {
     text: PropTypes.string.isRequired,
 
@@ -70,7 +71,8 @@ module.exports = DragSource(ItemTypes.CARD, cardSource, collect)(Card);
 ```js
 // Let's make <Card text='Write the docs' /> draggable!
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { DragSource } from 'react-dnd';
 import { ItemTypes } from './Constants';
 
@@ -123,7 +125,8 @@ export default DragSource(ItemTypes.CARD, cardSource, collect)(Card);
 ```js
 // Let's make <Card text='Write the docs' /> draggable!
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { DragSource } from 'react-dnd';
 import { ItemTypes } from './Constants';
 
@@ -183,7 +186,7 @@ React DnD uses the HTML5 drag and drop under the hood, but it also lets you supp
 
 ### It is ready for the future
 
-React DnD does not export mixins, and works equally great with any components, whether they are created using ES6 classes, `createClass` or alternative React frameworks such as Omniscient. Its API shines with ES7 decorators if you like to be on the bleeding edge, but it also feels natural in both ES5 and ES6.
+React DnD does not export mixins, and works equally great with any components, whether they are created using ES6 classes, `createReactClass` or alternative React frameworks such as Omniscient. Its API shines with ES7 decorators if you like to be on the bleeding edge, but it also feels natural in both ES5 and ES6.
 
 ## Touch Support
 

--- a/examples/00 Chessboard/Tutorial App/Board.js
+++ b/examples/00 Chessboard/Tutorial App/Board.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DragDropContext } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
 import BoardSquare from './BoardSquare';

--- a/examples/00 Chessboard/Tutorial App/BoardSquare.js
+++ b/examples/00 Chessboard/Tutorial App/BoardSquare.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DropTarget } from 'react-dnd';
 import Square from './Square';
 import { canMoveKnight, moveKnight } from './Game';

--- a/examples/00 Chessboard/Tutorial App/Knight.js
+++ b/examples/00 Chessboard/Tutorial App/Knight.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DragSource } from 'react-dnd';
 import ItemTypes from './ItemTypes';
 

--- a/examples/00 Chessboard/Tutorial App/Square.js
+++ b/examples/00 Chessboard/Tutorial App/Square.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 export default class Square extends Component {
   static propTypes = {

--- a/examples/01 Dustbin/Copy or Move/Box.js
+++ b/examples/01 Dustbin/Copy or Move/Box.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DragSource } from 'react-dnd';
 import ItemTypes from '../Single Target/ItemTypes';
 

--- a/examples/01 Dustbin/Copy or Move/Dustbin.js
+++ b/examples/01 Dustbin/Copy or Move/Dustbin.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DropTarget } from 'react-dnd';
 import ItemTypes from '../Single Target/ItemTypes';
 

--- a/examples/01 Dustbin/Multiple Targets/Box.js
+++ b/examples/01 Dustbin/Multiple Targets/Box.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DragSource } from 'react-dnd';
 
 const style = {

--- a/examples/01 Dustbin/Multiple Targets/Dustbin.js
+++ b/examples/01 Dustbin/Multiple Targets/Dustbin.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DropTarget } from 'react-dnd';
 
 const style = {

--- a/examples/01 Dustbin/Single Target/Box.js
+++ b/examples/01 Dustbin/Single Target/Box.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DragSource } from 'react-dnd';
 import ItemTypes from './ItemTypes';
 

--- a/examples/01 Dustbin/Single Target/Dustbin.js
+++ b/examples/01 Dustbin/Single Target/Dustbin.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DropTarget } from 'react-dnd';
 import ItemTypes from './ItemTypes';
 

--- a/examples/01 Dustbin/Stress Test/Box.js
+++ b/examples/01 Dustbin/Stress Test/Box.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DragSource } from 'react-dnd';
 
 const style = {

--- a/examples/01 Dustbin/Stress Test/Dustbin.js
+++ b/examples/01 Dustbin/Stress Test/Dustbin.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DropTarget } from 'react-dnd';
 
 const style = {

--- a/examples/02 Drag Around/Custom Drag Layer/Box.js
+++ b/examples/02 Drag Around/Custom Drag Layer/Box.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import shouldPureComponentUpdate from './shouldPureComponentUpdate';
 
 const styles = {

--- a/examples/02 Drag Around/Custom Drag Layer/BoxDragPreview.js
+++ b/examples/02 Drag Around/Custom Drag Layer/BoxDragPreview.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import shouldPureComponentUpdate from './shouldPureComponentUpdate';
 import Box from './Box';
 

--- a/examples/02 Drag Around/Custom Drag Layer/Container.js
+++ b/examples/02 Drag Around/Custom Drag Layer/Container.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import update from 'react/lib/update';
 import { DropTarget } from 'react-dnd';
 import shouldPureComponentUpdate from './shouldPureComponentUpdate';

--- a/examples/02 Drag Around/Custom Drag Layer/CustomDragLayer.js
+++ b/examples/02 Drag Around/Custom Drag Layer/CustomDragLayer.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DragLayer } from 'react-dnd';
 import ItemTypes from './ItemTypes';
 import BoxDragPreview from './BoxDragPreview';

--- a/examples/02 Drag Around/Custom Drag Layer/DraggableBox.js
+++ b/examples/02 Drag Around/Custom Drag Layer/DraggableBox.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DragSource } from 'react-dnd';
 import { getEmptyImage } from 'react-dnd-html5-backend';
 import shouldPureComponentUpdate from './shouldPureComponentUpdate';

--- a/examples/02 Drag Around/Naive/Box.js
+++ b/examples/02 Drag Around/Naive/Box.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DragSource } from 'react-dnd';
 import ItemTypes from './ItemTypes';
 

--- a/examples/02 Drag Around/Naive/Container.js
+++ b/examples/02 Drag Around/Naive/Container.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import update from 'react/lib/update';
 import { DropTarget, DragDropContext } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';

--- a/examples/03 Nesting/Drag Sources/SourceBox.js
+++ b/examples/03 Nesting/Drag Sources/SourceBox.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DragSource } from 'react-dnd';
 import Colors from './Colors';
 

--- a/examples/03 Nesting/Drag Sources/TargetBox.js
+++ b/examples/03 Nesting/Drag Sources/TargetBox.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DropTarget } from 'react-dnd';
 import Colors from './Colors';
 

--- a/examples/03 Nesting/Drop Targets/Box.js
+++ b/examples/03 Nesting/Drop Targets/Box.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DragSource } from 'react-dnd';
 import ItemTypes from './ItemTypes';
 

--- a/examples/03 Nesting/Drop Targets/Dustbin.js
+++ b/examples/03 Nesting/Drop Targets/Dustbin.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DropTarget } from 'react-dnd';
 import ItemTypes from './ItemTypes';
 

--- a/examples/04 Sortable/Cancel on Drop Outside/Card.js
+++ b/examples/04 Sortable/Cancel on Drop Outside/Card.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DragSource, DropTarget } from 'react-dnd';
 import ItemTypes from './ItemTypes';
 

--- a/examples/04 Sortable/Cancel on Drop Outside/Container.js
+++ b/examples/04 Sortable/Cancel on Drop Outside/Container.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import update from 'react/lib/update';
 import { DropTarget, DragDropContext } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';

--- a/examples/04 Sortable/Simple/Card.js
+++ b/examples/04 Sortable/Simple/Card.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import { DragSource, DropTarget } from 'react-dnd';
 import ItemTypes from './ItemTypes';

--- a/examples/04 Sortable/Stress Test/Card.js
+++ b/examples/04 Sortable/Stress Test/Card.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DragSource, DropTarget } from 'react-dnd';
 import ItemTypes from './ItemTypes';
 

--- a/examples/05 Customize/Drop Effects/SourceBox.js
+++ b/examples/05 Customize/Drop Effects/SourceBox.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DragSource } from 'react-dnd';
 import ItemTypes from './ItemTypes';
 

--- a/examples/05 Customize/Drop Effects/TargetBox.js
+++ b/examples/05 Customize/Drop Effects/TargetBox.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DropTarget } from 'react-dnd';
 import ItemTypes from './ItemTypes';
 

--- a/examples/05 Customize/Handles and Previews/BoxWithHandle.js
+++ b/examples/05 Customize/Handles and Previews/BoxWithHandle.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DragSource } from 'react-dnd';
 import ItemTypes from './ItemTypes';
 

--- a/examples/05 Customize/Handles and Previews/BoxWithImage.js
+++ b/examples/05 Customize/Handles and Previews/BoxWithImage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DragSource } from 'react-dnd';
 import ItemTypes from './ItemTypes';
 

--- a/examples/06 Other/Native Files/FileList.js
+++ b/examples/06 Other/Native Files/FileList.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 export default class FileList extends Component {
   static propTypes = {

--- a/examples/06 Other/Native Files/TargetBox.js
+++ b/examples/06 Other/Native Files/TargetBox.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DropTarget } from 'react-dnd';
 
 const style = {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "npm-run-all": "^4.0.1",
     "null-loader": "^0.1.0",
     "postcss": "^5.2.12",
+    "prop-types": "^15.5.4",
     "react": "^15.4.2",
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.4.2",

--- a/packages/react-dnd/package.json
+++ b/packages/react-dnd/package.json
@@ -18,7 +18,8 @@
     "dnd-core": "^2.3.0",
     "hoist-non-react-statics": "^1.2.0",
     "invariant": "^2.1.0",
-    "lodash": "^4.2.0"
+    "lodash": "^4.2.0",
+    "prop-types": "^15.5.8"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0-0"

--- a/packages/react-dnd/src/DragDropContext.js
+++ b/packages/react-dnd/src/DragDropContext.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DragDropManager } from 'dnd-core';
 import invariant from 'invariant';
 import hoistStatics from 'hoist-non-react-statics';

--- a/packages/react-dnd/src/DragDropContextProvider.js
+++ b/packages/react-dnd/src/DragDropContextProvider.js
@@ -1,4 +1,5 @@
-import { PropTypes, Component, Children } from 'react';
+import { Component, Children } from 'react';
+import PropTypes from 'prop-types';
 import {
   CHILD_CONTEXT_TYPES,
   createChildContext,

--- a/packages/react-dnd/src/DragLayer.js
+++ b/packages/react-dnd/src/DragLayer.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import hoistStatics from 'hoist-non-react-statics';
 import isPlainObject from 'lodash/isPlainObject';
 import invariant from 'invariant';

--- a/packages/react-dnd/src/decorateHandler.js
+++ b/packages/react-dnd/src/decorateHandler.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Disposable, CompositeDisposable, SerialDisposable } from 'disposables';
 import isPlainObject from 'lodash/isPlainObject';
 import invariant from 'invariant';

--- a/packages/react-dnd/yarn.lock
+++ b/packages/react-dnd/yarn.lock
@@ -2,32 +2,69 @@
 # yarn lockfile v1
 
 
-asap@^2.0.3:
+asap@^2.0.3, asap@~2.0.3:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.5.tgz#522765b50c3510490e52d7dcfe085ef9ba96958f"
+
+core-js@^1.0.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
 disposables@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/disposables/-/disposables-1.0.1.tgz#064727a25b54f502bd82b89aa2dfb8df9f1b39e3"
 
-dnd-core@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-2.2.3.tgz#91acba9e1a377be1e9a02e890dcd9907ac9eb829"
+dnd-core@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-2.3.0.tgz#f7b29ac37e2c78efe89e911ca5a534f280390450"
   dependencies:
     asap "^2.0.3"
     invariant "^2.0.0"
     lodash "^4.2.0"
     redux "^3.2.0"
 
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  dependencies:
+    iconv-lite "~0.4.13"
+
+fbjs@^0.8.9:
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
 hoist-non-react-statics@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
+
+iconv-lite@~0.4.13:
+  version "0.4.15"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
 invariant@^2.0.0, invariant@^2.1.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
     loose-envify "^1.0.0"
+
+is-stream@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+isomorphic-fetch@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
 
 js-tokens@^3.0.0:
   version "3.0.0"
@@ -47,6 +84,29 @@ loose-envify@^1.0.0, loose-envify@^1.1.0:
   dependencies:
     js-tokens "^3.0.0"
 
+node-fetch@^1.0.1:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.6.3.tgz#dc234edd6489982d58e8f0db4f695029abcd8c04"
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
+
+object-assign@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+promise@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
+  dependencies:
+    asap "~2.0.3"
+
+prop-types@^15.5.8:
+  version "15.5.8"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
+  dependencies:
+    fbjs "^0.8.9"
+
 redux@^3.2.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.6.0.tgz#887c2b3d0b9bd86eca2be70571c27654c19e188d"
@@ -56,6 +116,18 @@ redux@^3.2.0:
     loose-envify "^1.1.0"
     symbol-observable "^1.0.2"
 
+setimmediate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+
 symbol-observable@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
+
+ua-parser-js@^0.7.9:
+  version "0.7.12"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
+
+whatwg-fetch@>=0.10.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"

--- a/site/components/CodeBlock.js
+++ b/site/components/CodeBlock.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import ReactUpdates from 'react-dom/lib/ReactUpdates';
 import StaticHTMLBlock from './StaticHTMLBlock';

--- a/site/components/Header.js
+++ b/site/components/Header.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import NavBar from './NavBar';
 import Cover from './Cover';
 import './Header.less';

--- a/site/components/PageBody.js
+++ b/site/components/PageBody.js
@@ -1,9 +1,10 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import './PageBody.less';
 
 export default class PageBody extends Component {
   static propTypes = {
-    hasSidebar: React.PropTypes.bool
+    hasSidebar: PropTypes.bool
   };
 
   render() {

--- a/site/components/StaticHTMLBlock.js
+++ b/site/components/StaticHTMLBlock.js
@@ -1,9 +1,10 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import CodeBlock from './CodeBlock';
 
 export default class StaticHTMLBlock extends Component {
   static propTypes = {
-    html: React.PropTypes.string.isRequired
+    html: PropTypes.string.isRequired
   };
 
   render() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2085,7 +2085,7 @@ fb-watchman@^1.8.0, fb-watchman@^1.9.0:
   dependencies:
     bser "1.0.2"
 
-fbjs@^0.8.1, fbjs@^0.8.4:
+fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.9"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.9.tgz#180247fbd347dcc9004517b904f865400a0c8f14"
   dependencies:
@@ -4194,6 +4194,12 @@ promise@^7.1.1:
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
   dependencies:
     asap "~2.0.3"
+
+prop-types@^15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.4.tgz#2ed3692716a5060f8cc020946d8238e7419d92c0"
+  dependencies:
+    fbjs "^0.8.9"
 
 proxy-addr@~1.1.3:
   version "1.1.3"


### PR DESCRIPTION
…eClass in docs

I think we should migrate docs to the es6 `class` syntax and stop using `React.createClass`, but that would be another step. For now just created this PR, so people don't end up with deprecation warnings on React v15.5.

If you feel the same about `class`, I'll create an issue about it, so the matter won't get forgotten and neglected.