### PR TITLE
Fix typo in native files example

### DIFF
--- a/examples/06 Other/Native Files/FileList.js
+++ b/examples/06 Other/Native Files/FileList.js
@@ -7,7 +7,7 @@ export default class FileList extends Component {
   };
 
   list(files) {
-    return files.map(file => <li key={file.name}>{`'${file.name}'' of size '${file.size}' and type '${file.type}'`}</li>);
+    return files.map(file => <li key={file.name}>{`'${file.name}' of size '${file.size}' and type '${file.type}'`}</li>);
   }
 
   render() {


### PR DESCRIPTION
This is just a super minor typo fix where there was an extra single quote around the dragged file's name.