### PR TITLE
Pass offsetX and offsetY as createDragPreview options to force offsets

### DIFF
--- a/docs/02 Connecting to DOM/DragSourceConnector.md
+++ b/docs/02 Connecting to DOM/DragSourceConnector.md
@@ -29,6 +29,10 @@ The functions returned by the connector methods also accept options. They need t
 
 * `anchorY`: Optional. A number betwen `0` and `1`. By default, `0.5`. Specifies how the offset relative to the drag source node is translated into the the vertical offset of the drag preview when their sizes don't match. `0` means “dock the preview to the top, `0.5` means “interpolate linearly” and `1` means “dock the preview to the bottom.
 
+* `offsetX`: Optional. A number or null if not needed. By default, null. Specifies the vertical offset between the cursor and the drag preview element. If offsetX has a value, anchorX won't be used.
+
+* `offsetY`: Optional. A number or null if not needed. By default, null. Specifies the vertical offset between the cursor and the drag preview element. If offsetY has a value, anchorY won't be used.
+
 ### Example
 
 Check out [the tutorial](docs-tutorial.html) for more real examples!

--- a/packages/react-dnd-html5-backend/src/HTML5Backend.js
+++ b/packages/react-dnd-html5-backend/src/HTML5Backend.js
@@ -322,7 +322,9 @@ export default class HTML5Backend {
           clientOffset,
           anchorPoint,
         );
-        dataTransfer.setDragImage(dragPreview, offsetX || dragPreviewOffset.x, offsetY || dragPreviewOffset.y);
+        const forceOffsetX = offsetX === 0 || offsetX;
+        const forceOffsetY = offsetY === 0 || offsetY;
+        dataTransfer.setDragImage(dragPreview, forceOffsetX ? offsetX : dragPreviewOffset.x, forceOffsetY ? offsetY : dragPreviewOffset.y);
       }
 
       try {

--- a/packages/react-dnd-html5-backend/src/HTML5Backend.js
+++ b/packages/react-dnd-html5-backend/src/HTML5Backend.js
@@ -316,18 +316,19 @@ export default class HTML5Backend {
         const dragPreview = this.sourcePreviewNodes[sourceId] || sourceNode;
         const { anchorX, anchorY, offsetX, offsetY } = this.getCurrentSourcePreviewNodeOptions();
         const anchorPoint = { anchorX, anchorY };
+        const offsetPoint = { offsetX, offsetY };
         const dragPreviewOffset = getDragPreviewOffset(
           sourceNode,
           dragPreview,
           clientOffset,
           anchorPoint,
+          offsetPoint,
         );
-        const forceOffsetX = offsetX === 0 || offsetX;
-        const forceOffsetY = offsetY === 0 || offsetY;
+
         dataTransfer.setDragImage(
           dragPreview,
-          forceOffsetX ? offsetX : dragPreviewOffset.x,
-          forceOffsetY ? offsetY : dragPreviewOffset.y,
+          dragPreviewOffset.x,
+          dragPreviewOffset.y,
         );
       }
 

--- a/packages/react-dnd-html5-backend/src/HTML5Backend.js
+++ b/packages/react-dnd-html5-backend/src/HTML5Backend.js
@@ -314,7 +314,7 @@ export default class HTML5Backend {
         const sourceId = this.monitor.getSourceId();
         const sourceNode = this.sourceNodes[sourceId];
         const dragPreview = this.sourcePreviewNodes[sourceId] || sourceNode;
-        const { anchorX, anchorY } = this.getCurrentSourcePreviewNodeOptions();
+        const { anchorX, anchorY, offsetX, offsetY } = this.getCurrentSourcePreviewNodeOptions();
         const anchorPoint = { anchorX, anchorY };
         const dragPreviewOffset = getDragPreviewOffset(
           sourceNode,
@@ -322,7 +322,7 @@ export default class HTML5Backend {
           clientOffset,
           anchorPoint,
         );
-        dataTransfer.setDragImage(dragPreview, dragPreviewOffset.x, dragPreviewOffset.y);
+        dataTransfer.setDragImage(dragPreview, offsetX || dragPreviewOffset.x, offsetY || dragPreviewOffset.y);
       }
 
       try {

--- a/packages/react-dnd-html5-backend/src/HTML5Backend.js
+++ b/packages/react-dnd-html5-backend/src/HTML5Backend.js
@@ -324,7 +324,11 @@ export default class HTML5Backend {
         );
         const forceOffsetX = offsetX === 0 || offsetX;
         const forceOffsetY = offsetY === 0 || offsetY;
-        dataTransfer.setDragImage(dragPreview, forceOffsetX ? offsetX : dragPreviewOffset.x, forceOffsetY ? offsetY : dragPreviewOffset.y);
+        dataTransfer.setDragImage(
+          dragPreview,
+          forceOffsetX ? offsetX : dragPreviewOffset.x,
+          forceOffsetY ? offsetY : dragPreviewOffset.y,
+        );
       }
 
       try {

--- a/packages/react-dnd-html5-backend/src/OffsetUtils.js
+++ b/packages/react-dnd-html5-backend/src/OffsetUtils.js
@@ -26,7 +26,13 @@ export function getEventClientOffset(e) {
   };
 }
 
-export function getDragPreviewOffset(sourceNode, dragPreview, clientOffset, anchorPoint, offsetPoint) {
+export function getDragPreviewOffset(
+  sourceNode,
+  dragPreview,
+  clientOffset,
+  anchorPoint,
+  offsetPoint,
+  ) {
   // The browsers will use the image intrinsic size under different conditions.
   // Firefox only cares if it's an image, but WebKit also wants it to be detached.
   const isImage = dragPreview.nodeName === 'IMG' && (

--- a/packages/react-dnd-html5-backend/src/OffsetUtils.js
+++ b/packages/react-dnd-html5-backend/src/OffsetUtils.js
@@ -26,7 +26,7 @@ export function getEventClientOffset(e) {
   };
 }
 
-export function getDragPreviewOffset(sourceNode, dragPreview, clientOffset, anchorPoint) {
+export function getDragPreviewOffset(sourceNode, dragPreview, clientOffset, anchorPoint, offsetPoint) {
   // The browsers will use the image intrinsic size under different conditions.
   // Firefox only cares if it's an image, but WebKit also wants it to be detached.
   const isImage = dragPreview.nodeName === 'IMG' && (
@@ -71,7 +71,7 @@ export function getDragPreviewOffset(sourceNode, dragPreview, clientOffset, anch
     // Dock to the bottom
     offsetFromDragPreview.y + dragPreviewHeight - sourceHeight,
   ]);
-  const x = interpolantX.interpolate(anchorX);
+  let x = interpolantX.interpolate(anchorX);
   let y = interpolantY.interpolate(anchorY);
 
   // Work around Safari 8 positioning bug
@@ -79,6 +79,13 @@ export function getDragPreviewOffset(sourceNode, dragPreview, clientOffset, anch
     // We'll have to wait for @3x to see if this is entirely correct
     y += (window.devicePixelRatio - 1) * dragPreviewHeight;
   }
+
+  // Force offsets if specified in the options.
+  const { offsetX, offsetY } = offsetPoint;
+  const forceOffsetX = offsetX === 0 || offsetX;
+  const forceOffsetY = offsetY === 0 || offsetY;
+  x = forceOffsetX ? offsetX : x;
+  y = forceOffsetY ? offsetY : y;
 
   return { x, y };
 }


### PR DESCRIPTION
Added two optionals fields (offsetX and offsetY) to createDragPreview options.
Those fields allow to force specific offsets values.

Linked to #775