### PR TITLE
Check for presence of add/removeEventListener on target object

### DIFF
--- a/packages/react-dnd-html5-backend/src/HTML5Backend.js
+++ b/packages/react-dnd-html5-backend/src/HTML5Backend.js
@@ -81,6 +81,9 @@ export default class HTML5Backend {
   }
 
   addEventListeners(target) {
+    if (!target.addEventListener) {
+      return;
+    }
     target.addEventListener('dragstart', this.handleTopDragStart);
     target.addEventListener('dragstart', this.handleTopDragStartCapture, true);
     target.addEventListener('dragend', this.handleTopDragEndCapture, true);
@@ -94,6 +97,9 @@ export default class HTML5Backend {
   }
 
   removeEventListeners(target) {
+    if (!target.removeEventListener) {
+      return;
+    }
     target.removeEventListener('dragstart', this.handleTopDragStart);
     target.removeEventListener('dragstart', this.handleTopDragStartCapture, true);
     target.removeEventListener('dragend', this.handleTopDragEndCapture, true);


### PR DESCRIPTION
I am currently using React-DND on our website, and client-side it works like a charm. However, with our server-side setup, it blows up. After doing a little digging, I found the code that was causing this was the `addEventListeners()` and `removeEventListeners()` methods in the `HTML5Backend.js` file.

The cause was that through our Express middleware, we assign some values to the `window` object server-side, primarily for things like translation strings, environment variables we need access to and so forth.

Because the check to fire these methods in HTML5Backend.js only checks whether `this.window` is undefined – and because technically the `window` object in our case is defined, but not an expected full client-side `window` object, we get the error when trying to run the `addEventListener()` and `removeEventListener()`.

So in this PR I propose a fix to simply return from the function early if the methods don't exist on the parent `target` object within these methods.