### PR TITLE
Fixing DragLayer sample code bug

### DIFF
--- a/docs/01 Top Level API/DragLayer.md
+++ b/docs/01 Top Level API/DragLayer.md
@@ -196,7 +196,7 @@ function getItemStyles(props) {
   };
 }
 
-class CustomDragLayer {
+class CustomDragLayer extends React.Component {
   renderItem(type, item) {
     switch (type) {
     case ItemTypes.BOX:


### PR DESCRIPTION
The `CustomDragLayer` class signature in the final ES6 example on the DragLayer page omits `extends React.Component`. Thus, if someone copy and pastes this code (which is likely to happen since not only is this the exact implementation that allows simply custom drag previews (with no other bells and whistles), but it is likely a very common use case) it will not work out of the box.