### PR TITLE
[react-dnd-html5-backend] Remove peerDependency upon `react-dnd`.

### DIFF
--- a/packages/react-dnd-html5-backend/package.json
+++ b/packages/react-dnd-html5-backend/package.json
@@ -21,8 +21,5 @@
   },
   "dependencies": {
     "lodash": "^4.2.0"
-  },
-  "peerDependencies": {
-    "react-dnd": "^2.5.1"
   }
 }


### PR DESCRIPTION
As proposed in [`react-dnd-html5-backend#40`](https://github.com/react-dnd/react-dnd-html5-backend/issues/40). The discussion there seemed to have halted for now, if there is any way I can move this along I would really love to use `react-dnd-html5-backend` without having unmet peer dependencies.

For context, this is because I want to use the `react-dnd-html5-backend` with [`preact-dnd`](https://github.com/NekR/preact-dnd). Everything works fine, but the unmet `peerDependency` makes `npm prune` fail in continuous integration.

If I have misunderstood the reason for the `peerDependency`, I would be happy to work towards a different solution, thanks.