### PR TITLE
Update some deprecated references

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+BSD License
+
+Copyright (c) 2015, Facebook, Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name Facebook nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/examples/01 Dustbin/Multiple Targets/Container.js
+++ b/examples/01 Dustbin/Multiple Targets/Container.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import update from 'react/lib/update';
+import update from 'immutability-helper';
 import { DragDropContext } from 'react-dnd';
 import HTML5Backend, { NativeTypes } from 'react-dnd-html5-backend';
 import Dustbin from './Dustbin';

--- a/examples/01 Dustbin/Stress Test/Container.js
+++ b/examples/01 Dustbin/Stress Test/Container.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import update from 'react/lib/update';
+import update from 'immutability-helper';
 import { DragDropContext } from 'react-dnd';
 import HTML5Backend, { NativeTypes } from 'react-dnd-html5-backend';
 import shuffle from 'lodash/shuffle';

--- a/examples/02 Drag Around/Custom Drag Layer/Container.js
+++ b/examples/02 Drag Around/Custom Drag Layer/Container.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import update from 'react/lib/update';
+import update from 'immutability-helper';
 import { DropTarget } from 'react-dnd';
 import shouldPureComponentUpdate from './shouldPureComponentUpdate';
 import ItemTypes from './ItemTypes';

--- a/examples/02 Drag Around/Naive/Container.js
+++ b/examples/02 Drag Around/Naive/Container.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import update from 'react/lib/update';
+import update from 'immutability-helper';
 import { DropTarget, DragDropContext } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
 import ItemTypes from './ItemTypes';

--- a/examples/04 Sortable/Cancel on Drop Outside/Container.js
+++ b/examples/04 Sortable/Cancel on Drop Outside/Container.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import update from 'react/lib/update';
+import update from 'immutability-helper';
 import { DropTarget, DragDropContext } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
 import Card from './Card';

--- a/examples/04 Sortable/Simple/Container.js
+++ b/examples/04 Sortable/Simple/Container.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import update from 'react/lib/update';
+import update from 'immutability-helper';
 import { DragDropContext } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
 import Card from './Card';

--- a/examples/04 Sortable/Stress Test/Container.js
+++ b/examples/04 Sortable/Stress Test/Container.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import update from 'react/lib/update';
+import update from 'immutability-helper';
 import { DragDropContext } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
 import { name } from 'faker';

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "Jordan Gensler (http://github.com/kesne)",
     "Gagan (https://github.com/thetechie)"
   ],
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/react-dnd/react-dnd/issues"
   },
@@ -73,11 +73,11 @@
     "npm-run-all": "^4.0.2",
     "null-loader": "^0.1.0",
     "postcss": "^6.0.6",
-    "prop-types": "^15.5.10",
-    "react": "^16.0.0-rc.2",
-    "react-dom": "^16.0.0-rc.2",
+    "prop-types": "^15.6.0",
+    "react": "^16.x",
+    "react-dom": "^16.x",
     "react-frame-component": "^1.1.0",
-    "react-hot-loader": "^1.2.3",
+    "react-hot-loader": "3.0.0-beta.7",
     "rimraf": "^2.6.1",
     "style-loader": "^0.18.2",
     "url-loader": "^0.5.9",

--- a/packages/dnd-core/package.json
+++ b/packages/dnd-core/package.json
@@ -2,7 +2,7 @@
   "name": "dnd-core",
   "version": "2.5.2",
   "description": "Drag and drop sans the GUI",
-  "license": "MIT",
+  "license": "BSD",
   "main": "lib/index.js",
   "scripts": {
     "clean": "../../node_modules/.bin/rimraf lib",

--- a/packages/dnd-core/package.json
+++ b/packages/dnd-core/package.json
@@ -2,7 +2,7 @@
   "name": "dnd-core",
   "version": "2.5.2",
   "description": "Drag and drop sans the GUI",
-  "license": "BSD",
+  "license": "BSD-3-Clause",
   "main": "lib/index.js",
   "scripts": {
     "clean": "../../node_modules/.bin/rimraf lib",

--- a/packages/react-dnd-html5-backend/package.json
+++ b/packages/react-dnd-html5-backend/package.json
@@ -3,7 +3,7 @@
   "version": "2.5.2",
   "description": "HTML5 backend for React DnD",
   "main": "lib/index.js",
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
     "url": "https://github.com/react-dnd/react-dnd.git"

--- a/packages/react-dnd/package.json
+++ b/packages/react-dnd/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/react-dnd/react-dnd.git"
   },
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "scripts": {
     "clean": "../../node_modules/.bin/rimraf lib dist",
     "bundle:unmin": "../../node_modules/.bin/webpack --output-filename=dist/ReactDnD.js",
@@ -25,7 +25,10 @@
     "lodash": "^4.2.0",
     "prop-types": "^15.5.10"
   },
+  "devDependencies": {
+    "react": "^16.0.0"
+  },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0-0 || ^16.0.0-0"
+    "react": "*"
   }
 }

--- a/site/components/CodeBlock.js
+++ b/site/components/CodeBlock.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
-// import ReactUpdates from 'react-dom/lib/ReactUpdates';
 import StaticHTMLBlock from './StaticHTMLBlock';
 
 import './CodeBlock.less';
@@ -73,7 +72,6 @@ export default class CodeBlock extends Component {
 
     const scrollTopBefore = findDOMNode(this).getBoundingClientRect().top;
     setPreferredSyntax(syntax);
-    // ReactUpdates.flushBatchedUpdates();
     const scrollTopAfter = findDOMNode(this).getBoundingClientRect().top;
 
     window.scroll(

--- a/site/components/CodeBlock.js
+++ b/site/components/CodeBlock.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
-import ReactUpdates from 'react-dom/lib/ReactUpdates';
+// import ReactUpdates from 'react-dom/lib/ReactUpdates';
 import StaticHTMLBlock from './StaticHTMLBlock';
 
 import './CodeBlock.less';
@@ -73,7 +73,7 @@ export default class CodeBlock extends Component {
 
     const scrollTopBefore = findDOMNode(this).getBoundingClientRect().top;
     setPreferredSyntax(syntax);
-    ReactUpdates.flushBatchedUpdates();
+    // ReactUpdates.flushBatchedUpdates();
     const scrollTopAfter = findDOMNode(this).getBoundingClientRect().top;
 
     window.scroll(

--- a/site/webpack-client.config.js
+++ b/site/webpack-client.config.js
@@ -41,7 +41,7 @@ module.exports = {
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        use: isDev ? ['react-hot-loader', 'babel-loader'] : ['babel-loader']
+        use: isDev ? ['react-hot-loader/webpack', 'babel-loader'] : ['babel-loader']
       },
       {
         test: /\.less$/,


### PR DESCRIPTION
* There were some react/lib/x imports in the examples, replacing those with the recommended 'immutability-helper'.
* Updating react-hot-loader
* Adding a LICENSE file to the top-level project. Correcting SPDX license fields across the packages.