### PR TITLE
Fix HTML5Backend intervene functioning of other file drag and drop library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,9 @@
-[![npm version](https://img.shields.io/npm/v/react-dnd.svg?style=flat-square)](https://www.npmjs.com/package/react-dnd)
-[![npm downloads](https://img.shields.io/npm/dm/react-dnd.svg?style=flat-square)](https://www.npmjs.com/package/react-dnd)
-[![Build Status](https://travis-ci.org/react-dnd/react-dnd.svg?branch=master)](https://travis-ci.org/react-dnd/react-dnd)
-[![bitHound Overall Score](https://www.bithound.io/github/react-dnd/react-dnd/badges/score.svg)](https://www.bithound.io/github/react-dnd/react-dnd)
-[![bitHound Code](https://www.bithound.io/github/react-dnd/react-dnd/badges/code.svg)](https://www.bithound.io/github/react-dnd/react-dnd)
-[![bitHound Dependencies](https://www.bithound.io/github/react-dnd/react-dnd/badges/dependencies.svg)](https://www.bithound.io/github/react-dnd/react-dnd/master/dependencies/npm)
-[![bitHound Dev Dependencies](https://www.bithound.io/github/react-dnd/react-dnd/badges/devDependencies.svg)](https://www.bithound.io/github/react-dnd/react-dnd/master/dependencies/npm)
-![gzip size](http://img.badgesize.io/https://npmcdn.com/react-dnd/dist/ReactDnD.min.js?compression=gzip)
-![gzip size](http://img.badgesize.io/https://npmcdn.com/react-dnd-html5-backend/dist/ReactDnDHTML5Backend.min.js?compression=gzip&label=HTML5%20backend%20gzip%20size)
+Patched version of [react-dnd](https://github.com/react-dnd/react-dnd).
 
+## Changelogs
 
-React *DnD*
-===========
+__Fix HTML5Backend prevent default NativeTypes drag event__
 
-Drag and Drop for React.
+HTML5Backend should not prevent default NativeTypes drag event even when there are no valid DropTarget
 
-See the docs, tutorials and examples on the website:
-
-http://react-dnd.github.io/react-dnd/
-
-See the changelog on the Releases page:
-
-https://github.com/react-dnd/react-dnd/releases
-
-Questions? Find us on the Reactiflux Discord Server (**#need-help**)
-
-https://www.reactiflux.com/
-
-Big thanks to [BrowserStack](https://www.browserstack.com) for letting the maintainers use their service to debug browser issues.
+Becuase doing so would aggressively affect the functioning of other drag and drop UI library

--- a/packages/react-dnd-html5-backend/package.json
+++ b/packages/react-dnd-html5-backend/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "react-dnd-html5-backend",
+  "name": "@doist/react-dnd-html5-backend",
   "version": "2.5.4",
-  "description": "HTML5 backend for React DnD",
+  "description": "This is a fork of react-dnd-html5-backend with some issue patches",
   "main": "lib/index.js",
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
-    "url": "https://github.com/react-dnd/react-dnd.git"
+    "url": "https://github.com/Doist/react-dnd.git"
   },
   "scripts": {
     "clean": "../../node_modules/.bin/rimraf lib",

--- a/packages/react-dnd-html5-backend/src/HTML5Backend.js
+++ b/packages/react-dnd-html5-backend/src/HTML5Backend.js
@@ -545,11 +545,6 @@ export default class HTML5Backend {
 			// Show user-specified drop effect.
 			e.preventDefault()
 			e.dataTransfer.dropEffect = this.getCurrentDropEffect()
-		} else if (this.isDraggingNativeItem()) {
-			// Don't show a nice cursor but still prevent default
-			// "drop and blow away the whole document" action.
-			e.preventDefault()
-			e.dataTransfer.dropEffect = 'none'
 		} else if (this.checkIfCurrentDragSourceRectChanged()) {
 			// Prevent animating to incorrect position.
 			// Drop effect must be other than 'none' to prevent animation.


### PR DESCRIPTION
We notice an issue after integrating react-dnd into our app: Our existing drag-and-drop file upload function (which is not built on top react-dnd) failed to work. 

It seems like the event handling code `handleTopDragOver` in html5 backend will aggressively intervene the functioning of other DnD lib. 

```
if (canDrop) {
...
} else if (this.isDraggingNativeItem()) {
    // Don't show a nice cursor but still prevent default
    // "drop and blow away the whole document" action.
    e.preventDefault()
    e.dataTransfer.dropEffect = 'none'
} else if (this.checkIfCurrentDragSourceRectChanged()) {
...
}
```

I think it is ok to remove this part of the code, since it is not part this library's concern to prevent "blow way" scenario. 

(Please ignore `package.json` in the change file list 😅, I will remove this file if you think this PR makes sense)