### PR TITLE
feat(NativeDragSources): expose dataTransfer.items

### DIFF
--- a/packages/react-dnd-html5-backend/package.json
+++ b/packages/react-dnd-html5-backend/package.json
@@ -1,6 +1,6 @@
 {
-	"name": "react-dnd-html5-backend",
-	"version": "2.6.0",
+	"name": "@frameio/react-dnd-html5-backend",
+	"version": "1.0.0",
 	"description": "HTML5 backend for React DnD",
 	"main": "lib/index.js",
 	"license": "BSD-3-Clause",

--- a/packages/react-dnd-html5-backend/src/NativeDragSources.js
+++ b/packages/react-dnd-html5-backend/src/NativeDragSources.js
@@ -13,9 +13,12 @@ function getDataFromDataTransfer(dataTransfer, typesToTry, defaultValue) {
 
 const nativeTypesConfig = {
 	[NativeTypes.FILE]: {
-		exposeProperty: 'files',
+		exposeProperty: 'dataTransfer',
 		matchesTypes: ['Files'],
-		getData: dataTransfer => Array.prototype.slice.call(dataTransfer.files),
+		getData: dataTransfer => ({
+			files: Array.prototype.slice.call(dataTransfer.files),
+			items: Array.prototype.slice.call(dataTransfer.items),
+		}),
 	},
 	[NativeTypes.URL]: {
 		exposeProperty: 'urls',


### PR DESCRIPTION
This is a known issue: https://github.com/react-dnd/react-dnd/issues/712

It doesn't look like the API will change anytime soon, so changing the
object exposed by `getItem()` to `dataTransfer`, and include `items` in
there as well.

BREAKING CHANGE: for `NativeTypes.FILE`, `monitor.getItem()` no longer
returns `{ files }` and returns `{ dataTransfer: { files, items } }`
instead.