### PR TITLE
HTML5Backend should not prevent default NativeTypes drag event even w…

### DIFF
--- a/packages/react-dnd-html5-backend/src/HTML5Backend.js
+++ b/packages/react-dnd-html5-backend/src/HTML5Backend.js
@@ -547,11 +547,6 @@ export default class HTML5Backend {
 			// Show user-specified drop effect.
 			e.preventDefault()
 			e.dataTransfer.dropEffect = this.getCurrentDropEffect()
-		} else if (this.isDraggingNativeItem()) {
-			// Don't show a nice cursor but still prevent default
-			// "drop and blow away the whole document" action.
-			e.preventDefault()
-			e.dataTransfer.dropEffect = 'none'
 		} else if (this.checkIfCurrentDragSourceRectChanged()) {
 			// Prevent animating to incorrect position.
 			// Drop effect must be other than 'none' to prevent animation.


### PR DESCRIPTION
(this PR intent to replace this [original PR](https://github.com/react-dnd/react-dnd/pull/921), as the change is made in a different branch now)

___

We notice an issue after integrating react-dnd into our app: Our existing drag-and-drop file upload function (which is not built on top react-dnd) failed to work. 

It seems like the event handling code `handleTopDragOver` in html5 backend will aggressively intervene the functioning of other DnD lib. 

```
if (canDrop) {
...
} else if (this.isDraggingNativeItem()) {
    // Don't show a nice cursor but still prevent default
    // "drop and blow away the whole document" action.
    e.preventDefault()
    e.dataTransfer.dropEffect = 'none'
} else if (this.checkIfCurrentDragSourceRectChanged()) {
...
}
```

I think it is ok to remove this part of the code, since it is not part this library's concern to prevent "blow way" scenario. 

