### PR TITLE
support react 16.3 statics

### DIFF
--- a/packages/react-dnd/package.json
+++ b/packages/react-dnd/package.json
@@ -20,7 +20,7 @@
 	"dependencies": {
 		"disposables": "^1.0.1",
 		"dnd-core": "^2.6.0",
-		"hoist-non-react-statics": "^2.1.0",
+		"hoist-non-react-statics": "^2.5.0",
 		"invariant": "^2.1.0",
 		"lodash": "^4.2.0",
 		"prop-types": "^15.5.10"


### PR DESCRIPTION
this will squelch the warning for using getDerivedStateFromProps