### PR TITLE
Use ES5 as the typescript target to support users in older browsers

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
-		"target": "es2015",
+		"target": "es5",
 		"module": "commonjs",
 		"lib": ["esnext", "dom"],
 		"strict": true,


### PR DESCRIPTION
Fixes #1025, #1029