### PR TITLE
Remove isClassComponent check from decorateHandler

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,9 @@
 		"prettify":
 			"prettier 'packages/*/**/*.js' 'examples/**/*.js' 'site/**/*.js'",
 		"precommit": "lint-staged",
-		"start": "lerna run --stream start",
-		"prepublish": "npm test"
+    "prepublish": "npm test",
+		"start": "lerna run --parallel --stream start",
+    "watch": "lerna run --parallel --stream watch"
 	},
 	"devDependencies": {
 		"@types/jest": "^22.2.3",

--- a/packages/dnd-core/package.json
+++ b/packages/dnd-core/package.json
@@ -7,7 +7,9 @@
 	"types": "./lib/index.d.ts",
 	"scripts": {
 		"clean": "rimraf lib",
-		"build": "tsc",
+    "build": "tsc",
+    "watch": "tsc -w",
+    "start": "npm run watch",
 		"test": "run-s clean build"
 	},
 	"repository": {

--- a/packages/react-dnd-html5-backend/package.json
+++ b/packages/react-dnd-html5-backend/package.json
@@ -15,7 +15,9 @@
 		"bundle:unmin": "webpack --mode development --output-filename=ReactDnDHTML5Backend.js",
 		"bundle:min": "webpack --mode production --output-filename=ReactDnDHTML5Backend.min.js",
 		"build": "run-p bundle:* transpile",
-		"test": "run-s clean build"
+    "test": "run-s clean build",
+    "watch": "tsc -w",
+    "start": "npm run watch"
 	},
 	"dependencies": {
 		"@types/lodash": "^4.14.109",

--- a/packages/react-dnd/package.json
+++ b/packages/react-dnd/package.json
@@ -15,7 +15,9 @@
 		"bundle:min": "webpack --mode production --output-filename=ReactDnD.min.js",
 		"transpile": "tsc",
 		"build": "run-p bundle:* transpile",
-		"test": "run-s clean build"
+    "test": "run-s clean build",
+    "watch": "tsc -w",
+    "start": "npm run watch"
 	},
 	"dependencies": {
 		"@types/invariant": "^2.2.29",

--- a/packages/react-dnd/src/createSourceFactory.ts
+++ b/packages/react-dnd/src/createSourceFactory.ts
@@ -93,6 +93,7 @@ export default function createSourceFactory<
 			if (!this.props || !this.component) {
 				return
 			}
+
 			const item = spec.beginDrag(this.props, this.monitor, this.component)
 			if (process.env.NODE_ENV !== 'production') {
 				invariant(

--- a/packages/react-dnd/src/decorateHandler.tsx
+++ b/packages/react-dnd/src/decorateHandler.tsx
@@ -13,12 +13,6 @@ import {
 	SerialDisposable,
 } from './utils/disposables'
 
-const isClassComponent = (Comp: any) => {
-	return (
-		!!Comp && !!Comp.prototype && typeof Comp.prototype.render === 'function'
-	)
-}
-
 export interface DecorateHandlerArgs<
 	P,
 	ComponentClass extends React.ComponentClass<P>,
@@ -240,11 +234,7 @@ export default function decorateHandler<
 							<DecoratedComponent
 								{...this.props}
 								{...this.state}
-								ref={
-									isClassComponent(DecoratedComponent)
-										? this.handleChildRef
-										: null
-								}
+								ref={this.handleChildRef}
 							/>
 						)
 					}}


### PR DESCRIPTION
This isClassComponent check is failing in some instances where it shouldn't. Removing this check will allow React's default invariant message emerge, which will be more useful that silently failing.

Also adding a watch mode to the libs.

Fixes #1051