### PR TITLE
[HTML5 Backend] React should be a dev dependency

### DIFF
--- a/packages/react-dnd-html5-backend/package.json
+++ b/packages/react-dnd-html5-backend/package.json
@@ -26,12 +26,12 @@
 		"autobind-decorator": "^2.1.0",
 		"dnd-core": "^4.0.0",
 		"lodash": "^4.17.10",
-		"react": "^16.4.0",
 		"shallowequal": "^1.0.2"
 	},
 	"devDependencies": {
 		"@types/node": "^10.3.0",
 		"npm-run-all": "^4.1.2",
+		"react": "^16.4.0",
 		"react-dnd": "^4.0.0",
 		"react-dnd-test-backend": "^4.0.0",
 		"rimraf": "^2.6.2",


### PR DESCRIPTION
HTML5 Backend listed React as a core dependency, which is incorrect as it is also listed as a peer dependency.

Instead, move this as a devDependency