### PR TITLE
Replace setImmediate with asap

### DIFF
--- a/packages/dnd-core/package.json
+++ b/packages/dnd-core/package.json
@@ -19,6 +19,7 @@
 	"dependencies": {
 		"@types/invariant": "^2.2.29",
 		"@types/lodash": "^4.14.109",
+		"asap": "^2.0.6",
 		"invariant": "^2.2.4",
 		"lodash": "^4.17.10",
 		"redux": "^4.0.0"

--- a/packages/dnd-core/src/HandlerRegistryImpl.ts
+++ b/packages/dnd-core/src/HandlerRegistryImpl.ts
@@ -23,6 +23,8 @@ import {
 	validateTargetContract,
 	validateType,
 } from './contracts'
+// @ts-ignore
+import asap from 'asap'
 
 function getNextHandlerId(role: HandlerRole): string {
 	const id = getNextUniqueId().toString()
@@ -129,7 +131,7 @@ export default class HandlerRegistryImpl implements HandlerRegistry {
 	public removeSource(sourceId: string) {
 		invariant(this.getSource(sourceId), 'Expected an existing source.')
 		this.store.dispatch(removeSource(sourceId))
-		setImmediate(() => {
+		asap(() => {
 			this.dragSources.delete(sourceId)
 			this.types.delete(sourceId)
 		})

--- a/packages/dnd-core/tsconfig.json
+++ b/packages/dnd-core/tsconfig.json
@@ -2,8 +2,8 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"declaration": true,
-		"sourceMap": true,
-		"outDir": "./lib",
+    "sourceMap": true,
+    "outDir": "./lib",
 		"baseUrl": "./src"
 	},
 	"include": ["src/index.ts"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -350,7 +350,7 @@ arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-asap@~2.0.3:
+asap@^2.0.6, asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 


### PR DESCRIPTION
setImmediate is not a broadly supported API and requires a shim. This PR reverts to using `asap`

Fixes #1056 
