### PR TITLE
Upgrade to Typescript 2.9

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.9.0",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": [

--- a/packages/dnd-core/package.json
+++ b/packages/dnd-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dnd-core",
-	"version": "4.0.2",
+	"version": "4.0.3",
 	"description": "Drag and drop sans the GUI",
 	"license": "BSD-3-Clause",
 	"main": "./lib/index.js",

--- a/packages/dnd-core/package.json
+++ b/packages/dnd-core/package.json
@@ -8,7 +8,7 @@
 	"scripts": {
 		"clean": "rimraf lib",
 		"build": "tsc",
-		"watch": "tsc -w",
+		"watch": "tsc -w --preserveWatchOutput",
 		"start": "npm run watch",
 		"test": "run-s clean build"
 	},

--- a/packages/dnd-core/tsconfig.json
+++ b/packages/dnd-core/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"declaration": true,
-    "sourceMap": true,
     "outDir": "./lib",
 		"baseUrl": "./src"
 	},

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-dnd-documentation",
-	"version": "4.0.2",
+	"version": "4.0.3",
 	"private": true,
 	"scripts": {
 		"clean": "rimraf __site__ __site_prerender__",
@@ -48,7 +48,7 @@
 		"lodash": "^4.17.10",
 		"prop-types": "^15.6.1",
 		"react": "^16.4.0",
-		"react-dnd-test-backend": "^4.0.2",
+		"react-dnd-test-backend": "^4.0.3",
 		"react-dom": "^16.4.0",
 		"react-frame-component": "^3.0.0",
 		"shallowequal": "^1.0.2"

--- a/packages/react-dnd-html5-backend/package.json
+++ b/packages/react-dnd-html5-backend/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-dnd-html5-backend",
-	"version": "4.0.2",
+	"version": "4.0.3",
 	"description": "HTML5 backend for React DnD",
 	"main": "lib/index.js",
 	"types": "lib/index.d.ts",
@@ -24,7 +24,7 @@
 		"@types/react": "^16.3.16",
 		"@types/shallowequal": "^0.2.2",
 		"autobind-decorator": "^2.1.0",
-		"dnd-core": "^4.0.2",
+		"dnd-core": "^4.0.3",
 		"lodash": "^4.17.10",
 		"shallowequal": "^1.0.2"
 	},
@@ -32,8 +32,8 @@
 		"@types/node": "^10.3.0",
 		"npm-run-all": "^4.1.2",
 		"react": "^16.4.0",
-		"react-dnd": "^4.0.2",
-		"react-dnd-test-backend": "^4.0.2",
+		"react-dnd": "^4.0.3",
+		"react-dnd-test-backend": "^4.0.3",
 		"rimraf": "^2.6.2",
 		"ts-loader": "^4.2.0",
 		"typescript": "^2.8.3",

--- a/packages/react-dnd-html5-backend/package.json
+++ b/packages/react-dnd-html5-backend/package.json
@@ -16,7 +16,7 @@
 		"bundle:min": "webpack --mode production --output-filename=ReactDnDHTML5Backend.min.js",
 		"build": "run-p bundle:* transpile",
 		"test": "run-s clean build",
-		"watch": "tsc -w",
+		"watch": "tsc -w --preserveWatchOutput",
 		"start": "npm run watch"
 	},
 	"dependencies": {
@@ -36,7 +36,7 @@
 		"react-dnd-test-backend": "^4.0.3",
 		"rimraf": "^2.6.2",
 		"ts-loader": "^4.2.0",
-		"typescript": "^2.8.3",
+		"typescript": "^2.9.1",
 		"webpack": "^4.6.0"
 	},
 	"peerDependencies": {

--- a/packages/react-dnd-html5-backend/tsconfig.json
+++ b/packages/react-dnd-html5-backend/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"declaration": true,
-		"sourceMap": true,
 		"outDir": "./lib",
 		"baseUrl": "./src"
 	},

--- a/packages/react-dnd-test-backend/package.json
+++ b/packages/react-dnd-test-backend/package.json
@@ -25,6 +25,6 @@
 	"devDependencies": {
 		"npm-run-all": "^4.1.2",
 		"rimraf": "^2.6.2",
-		"typescript": "^2.8.3"
+		"typescript": "^2.9.1"
 	}
 }

--- a/packages/react-dnd-test-backend/package.json
+++ b/packages/react-dnd-test-backend/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-dnd-test-backend",
-	"version": "4.0.2",
+	"version": "4.0.3",
 	"description": "A mock backend for testing React DnD apps",
 	"main": "lib/index.js",
 	"types": "lib/index.d.ts",
@@ -16,7 +16,7 @@
 	},
 	"dependencies": {
 		"@types/lodash": "^4.14.109",
-		"dnd-core": "^4.0.2",
+		"dnd-core": "^4.0.3",
 		"lodash": "^4.17.10"
 	},
 	"peerDependencies": {

--- a/packages/react-dnd-test-backend/tsconfig.json
+++ b/packages/react-dnd-test-backend/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"declaration": true,
-		"sourceMap": true,
 		"outDir": "./lib",
 		"baseUrl": "./src"
 	},

--- a/packages/react-dnd/package.json
+++ b/packages/react-dnd/package.json
@@ -16,7 +16,7 @@
 		"transpile": "tsc",
 		"build": "run-p bundle:* transpile",
 		"test": "run-s clean build",
-		"watch": "tsc -w",
+		"watch": "tsc -w --preserveWatchOutput",
 		"start": "npm run watch"
 	},
 	"dependencies": {
@@ -41,7 +41,7 @@
 		"react": "^16.4.0",
 		"rimraf": "^2.6.2",
 		"ts-loader": "^4.2.0",
-		"typescript": "^2.8.3",
+		"typescript": "^2.9.1",
 		"webpack": "^4.6.0",
 		"webpack-cli": "^2.1.2"
 	},

--- a/packages/react-dnd/package.json
+++ b/packages/react-dnd/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-dnd",
-	"version": "4.0.2",
+	"version": "4.0.3",
 	"description": "Drag and Drop for React",
 	"main": "lib/index.js",
 	"types": "lib/index.d.ts",
@@ -27,7 +27,7 @@
 		"@types/react": "^16.3.14",
 		"@types/react-dom": "^16.0.5",
 		"@types/shallowequal": "^0.2.2",
-		"dnd-core": "^4.0.2",
+		"dnd-core": "^4.0.3",
 		"hoist-non-react-statics": "^2.5.0",
 		"invariant": "^2.1.0",
 		"lodash": "^4.17.10",

--- a/packages/react-dnd/tsconfig.json
+++ b/packages/react-dnd/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"declaration": true,
-		"sourceMap": true,
 		"outDir": "./lib",
 		"baseUrl": "./"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -8497,9 +8497,9 @@ typescript@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.1.tgz#6160e4f8f195d5ba81d4876f9c0cc1fbc0820624"
 
-typescript@^2.8.3:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.3.tgz#5d817f9b6f31bb871835f4edf0089f21abe6c170"
+typescript@^2.9.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.1.tgz#fdb19d2c67a15d11995fd15640e373e09ab09961"
 
 ua-parser-js@^0.7.9:
   version "0.7.14"


### PR DESCRIPTION
* Add preserveOutput flag to tsc watchers
* Remove sourcemaps from tsc output to resolve errors users were having with source-maps-loader.

Fixes #1060 