### PR TITLE
Task/remove proptypes

### DIFF
--- a/packages/dnd-core/src/HandlerRegistryImpl.ts
+++ b/packages/dnd-core/src/HandlerRegistryImpl.ts
@@ -1,6 +1,5 @@
 import { Store } from 'redux'
 import invariant from 'invariant'
-import isArray from 'lodash/isArray'
 import {
 	addSource,
 	addTarget,

--- a/packages/documentation/examples/00 Chessboard/Tutorial App/Board.tsx
+++ b/packages/documentation/examples/00 Chessboard/Tutorial App/Board.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { DragDropContext } from 'react-dnd'
 import HTML5Backend, { HTML5BackendContext } from 'react-dnd-html5-backend'
 import BoardSquare from './BoardSquare'
@@ -12,10 +11,6 @@ export interface BoardProps {
 
 @DragDropContext<BoardProps, {}, Board>(HTML5Backend)
 export default class Board extends React.Component<BoardProps> {
-	public static propTypes = {
-		knightPosition: PropTypes.arrayOf(PropTypes.number.isRequired).isRequired,
-	}
-
 	public render() {
 		const squares = []
 		for (let i = 0; i < 64; i += 1) {

--- a/packages/documentation/examples/00 Chessboard/Tutorial App/BoardSquare.tsx
+++ b/packages/documentation/examples/00 Chessboard/Tutorial App/BoardSquare.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import {
 	DropTarget,
 	DropTargetMonitor,
@@ -45,15 +44,6 @@ const collect: DropTargetCollector<CollectedProps> = (
 
 @DropTarget(ItemTypes.KNIGHT, squareTarget, collect)
 export default class BoardSquare extends React.Component<BoardSquareProps> {
-	public static propTypes = {
-		x: PropTypes.number.isRequired,
-		y: PropTypes.number.isRequired,
-		isOver: PropTypes.bool.isRequired,
-		canDrop: PropTypes.bool.isRequired,
-		connectDropTarget: PropTypes.func.isRequired,
-		children: PropTypes.node,
-	}
-
 	public render() {
 		const { x, y, connectDropTarget, isOver, canDrop, children } = this.props
 		const black = (x + y) % 2 === 1

--- a/packages/documentation/examples/00 Chessboard/Tutorial App/Knight.tsx
+++ b/packages/documentation/examples/00 Chessboard/Tutorial App/Knight.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import {
 	DragSource,
 	ConnectDragSource,
@@ -33,12 +32,6 @@ export interface KnightProps {
 
 @DragSource(ItemTypes.KNIGHT, knightSource, collect)
 export default class Knight extends React.Component<KnightProps> {
-	public static propTypes = {
-		connectDragSource: PropTypes.func.isRequired,
-		connectDragPreview: PropTypes.func.isRequired,
-		isDragging: PropTypes.bool.isRequired,
-	}
-
 	public componentDidMount() {
 		const img = new Image()
 		img.src =

--- a/packages/documentation/examples/00 Chessboard/Tutorial App/Square.tsx
+++ b/packages/documentation/examples/00 Chessboard/Tutorial App/Square.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
 export interface SquareProps {
 	black: boolean
@@ -7,11 +6,6 @@ export interface SquareProps {
 }
 
 export default class Square extends React.Component<SquareProps> {
-	public static propTypes = {
-		black: PropTypes.bool,
-		children: PropTypes.node,
-	}
-
 	public render() {
 		const { black } = this.props
 		const backgroundColor = black ? 'black' : 'white'

--- a/packages/documentation/examples/01 Dustbin/Copy or Move/Box.tsx
+++ b/packages/documentation/examples/01 Dustbin/Copy or Move/Box.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import {
 	DragSource,
 	ConnectDragSource,
@@ -7,7 +6,6 @@ import {
 	DragSourceMonitor,
 } from 'react-dnd'
 import ItemTypes from '../Single Target/ItemTypes'
-import { DragDropManager } from 'dnd-core'
 
 const style: React.CSSProperties = {
 	border: '1px dashed gray',
@@ -64,12 +62,6 @@ export interface BoxProps {
 	}),
 )
 export default class Box extends React.Component<BoxProps> {
-	public static propTypes = {
-		connectDragSource: PropTypes.func.isRequired,
-		isDragging: PropTypes.bool.isRequired,
-		name: PropTypes.string.isRequired,
-	}
-
 	public render() {
 		const { isDragging, connectDragSource } = this.props
 		const { name } = this.props

--- a/packages/documentation/examples/01 Dustbin/Copy or Move/Dustbin.tsx
+++ b/packages/documentation/examples/01 Dustbin/Copy or Move/Dustbin.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { DropTarget, ConnectDropTarget } from 'react-dnd'
 import ItemTypes from '../Single Target/ItemTypes'
 
@@ -38,13 +37,6 @@ export interface DustbinProps {
 	canDrop: monitor.canDrop(),
 }))
 export default class Dustbin extends React.Component<DustbinProps> {
-	public static propTypes = {
-		connectDropTarget: PropTypes.func.isRequired,
-		isOver: PropTypes.bool.isRequired,
-		canDrop: PropTypes.bool.isRequired,
-		allowedDropEffect: PropTypes.string.isRequired,
-	}
-
 	public render() {
 		const { canDrop, isOver, allowedDropEffect, connectDropTarget } = this.props
 		const isActive = canDrop && isOver

--- a/packages/documentation/examples/01 Dustbin/Multiple Targets/Box.tsx
+++ b/packages/documentation/examples/01 Dustbin/Multiple Targets/Box.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import {
 	DragSource,
 	ConnectDragSource,
@@ -41,14 +40,6 @@ export interface BoxProps {
 	}),
 )
 export default class Box extends React.Component<BoxProps> {
-	public static propTypes = {
-		connectDragSource: PropTypes.func.isRequired,
-		isDragging: PropTypes.bool.isRequired,
-		name: PropTypes.string.isRequired,
-		type: PropTypes.string.isRequired,
-		isDropped: PropTypes.bool.isRequired,
-	}
-
 	public render() {
 		const { name, isDropped, isDragging, connectDragSource } = this.props
 		const opacity = isDragging ? 0.4 : 1

--- a/packages/documentation/examples/01 Dustbin/Multiple Targets/Dustbin.tsx
+++ b/packages/documentation/examples/01 Dustbin/Multiple Targets/Dustbin.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { DropTarget, ConnectDropTarget, DropTargetMonitor } from 'react-dnd'
 
 const style: React.CSSProperties = {
@@ -40,15 +39,6 @@ export interface DustbinProps {
 	}),
 )
 export default class Dustbin extends React.Component<DustbinProps> {
-	public static propTypes = {
-		connectDropTarget: PropTypes.func.isRequired,
-		isOver: PropTypes.bool.isRequired,
-		canDrop: PropTypes.bool.isRequired,
-		accepts: PropTypes.arrayOf(PropTypes.string).isRequired,
-		lastDroppedItem: PropTypes.object,
-		onDrop: PropTypes.func.isRequired,
-	}
-
 	public render() {
 		const {
 			accepts,

--- a/packages/documentation/examples/01 Dustbin/Single Target in iframe/Container.tsx
+++ b/packages/documentation/examples/01 Dustbin/Single Target in iframe/Container.tsx
@@ -1,35 +1,23 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { DragDropContextProvider } from 'react-dnd'
 import HTML5Backend from 'react-dnd-html5-backend'
 import Dustbin from '../Single Target/Dustbin'
 import Box from '../Single Target/Box'
-
-// TODO: Update this example when react-frame-component uses the official context API
-const Frame = require('react-frame-component').default
+const {
+	default: Frame,
+	FrameContextConsumer,
+} = require('react-frame-component')
 
 class FrameBindingContext extends React.Component {
-	public static contextTypes = {
-		window: PropTypes.object,
-	}
-	public static propTypes = {
-		children: PropTypes.node,
-	}
-
-	get dragDropContext() {
-		return {
-			window: this.context.window,
-		}
-	}
-
 	public render() {
 		return (
-			<DragDropContextProvider
-				backend={HTML5Backend}
-				context={this.dragDropContext}
-			>
-				{this.props.children}
-			</DragDropContextProvider>
+			<FrameContextConsumer>
+				{({ window }: any) => (
+					<DragDropContextProvider backend={HTML5Backend} context={window}>
+						{this.props.children}
+					</DragDropContextProvider>
+				)}
+			</FrameContextConsumer>
 		)
 	}
 }

--- a/packages/documentation/examples/01 Dustbin/Single Target/Box.tsx
+++ b/packages/documentation/examples/01 Dustbin/Single Target/Box.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import {
 	ConnectDragSource,
 	DragSource,
@@ -50,12 +49,6 @@ const boxSource = {
 	}),
 )
 export default class Box extends React.Component<BoxProps> {
-	public static propTypes = {
-		connectDragSource: PropTypes.func.isRequired,
-		isDragging: PropTypes.bool.isRequired,
-		name: PropTypes.string.isRequired,
-	}
-
 	public render() {
 		const { isDragging, connectDragSource } = this.props
 		const { name } = this.props

--- a/packages/documentation/examples/01 Dustbin/Single Target/Dustbin.tsx
+++ b/packages/documentation/examples/01 Dustbin/Single Target/Dustbin.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import {
 	DropTarget,
 	DropTargetConnector,
@@ -43,12 +42,6 @@ export interface DustbinProps {
 	}),
 )
 export default class Dustbin extends React.Component<DustbinProps> {
-	public static propTypes = {
-		connectDropTarget: PropTypes.func.isRequired,
-		isOver: PropTypes.bool.isRequired,
-		canDrop: PropTypes.bool.isRequired,
-	}
-
 	public render() {
 		const { canDrop, isOver, connectDropTarget } = this.props
 		const isActive = canDrop && isOver

--- a/packages/documentation/examples/01 Dustbin/Stress Test/Box.tsx
+++ b/packages/documentation/examples/01 Dustbin/Stress Test/Box.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import {
 	DragSource,
 	DragSourceConnector,
@@ -47,13 +46,6 @@ export interface BoxProps {
 	}),
 )
 export default class Box extends React.Component<BoxProps> {
-	public static propTypes = {
-		connectDragSource: PropTypes.func.isRequired,
-		isDragging: PropTypes.bool.isRequired,
-		name: PropTypes.string.isRequired,
-		type: PropTypes.string.isRequired,
-		isDropped: PropTypes.bool.isRequired,
-	}
 	public render() {
 		const { name, isDropped, isDragging, connectDragSource } = this.props
 		const opacity = isDragging ? 0.4 : 1

--- a/packages/documentation/examples/01 Dustbin/Stress Test/Dustbin.tsx
+++ b/packages/documentation/examples/01 Dustbin/Stress Test/Dustbin.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import {
 	ConnectDropTarget,
 	DropTarget,
@@ -45,15 +44,6 @@ export interface DustbinProps {
 	}),
 )
 export default class Dustbin extends React.Component<DustbinProps> {
-	public static propTypes = {
-		connectDropTarget: PropTypes.func.isRequired,
-		isOver: PropTypes.bool.isRequired,
-		canDrop: PropTypes.bool.isRequired,
-		accepts: PropTypes.arrayOf(PropTypes.string).isRequired,
-		lastDroppedItem: PropTypes.object,
-		onDrop: PropTypes.func.isRequired,
-	}
-
 	public render() {
 		const {
 			accepts,

--- a/packages/documentation/examples/02 Drag Around/Custom Drag Layer/Box.tsx
+++ b/packages/documentation/examples/02 Drag Around/Custom Drag Layer/Box.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
 const styles: React.CSSProperties = {
 	border: '1px dashed gray',
@@ -13,11 +12,6 @@ export interface BoxProps {
 }
 
 export default class Box extends React.PureComponent<BoxProps> {
-	public static propTypes = {
-		title: PropTypes.string.isRequired,
-		yellow: PropTypes.bool,
-	}
-
 	public render() {
 		const { title, yellow } = this.props
 		const backgroundColor = yellow ? 'yellow' : 'white'

--- a/packages/documentation/examples/02 Drag Around/Custom Drag Layer/BoxDragPreview.tsx
+++ b/packages/documentation/examples/02 Drag Around/Custom Drag Layer/BoxDragPreview.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import Box from './Box'
 
 const styles = {
@@ -20,10 +19,6 @@ export default class BoxDragPreview extends React.PureComponent<
 	BoxDragPreviewProps,
 	BoxDragPreviewState
 > {
-	public static propTypes = {
-		title: PropTypes.string.isRequired,
-	}
-
 	private interval: any
 
 	constructor(props: BoxDragPreviewProps) {

--- a/packages/documentation/examples/02 Drag Around/Custom Drag Layer/Container.tsx
+++ b/packages/documentation/examples/02 Drag Around/Custom Drag Layer/Container.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import {
 	DropTarget,
 	ConnectDropTarget,
@@ -56,11 +55,6 @@ export default class Container extends React.PureComponent<
 	ContainerProps,
 	ContainerState
 > {
-	public static propTypes = {
-		connectDropTarget: PropTypes.func.isRequired,
-		snapToGrid: PropTypes.bool.isRequired,
-	}
-
 	constructor(props: ContainerProps) {
 		super(props)
 		this.state = {

--- a/packages/documentation/examples/02 Drag Around/Custom Drag Layer/CustomDragLayer.tsx
+++ b/packages/documentation/examples/02 Drag Around/Custom Drag Layer/CustomDragLayer.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { DragLayer, XYCoord } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 import BoxDragPreview from './BoxDragPreview'
@@ -59,21 +58,6 @@ export interface CustomDragLayerProps {
 export default class CustomDragLayer extends React.Component<
 	CustomDragLayerProps
 > {
-	public static propTypes = {
-		item: PropTypes.object,
-		itemType: PropTypes.string,
-		initialOffset: PropTypes.shape({
-			x: PropTypes.number.isRequired,
-			y: PropTypes.number.isRequired,
-		}),
-		currentOffset: PropTypes.shape({
-			x: PropTypes.number.isRequired,
-			y: PropTypes.number.isRequired,
-		}),
-		isDragging: PropTypes.bool.isRequired,
-		snapToGrid: PropTypes.bool.isRequired,
-	}
-
 	public renderItem(type: any, item: any) {
 		switch (type) {
 			case ItemTypes.BOX:

--- a/packages/documentation/examples/02 Drag Around/Custom Drag Layer/DraggableBox.tsx
+++ b/packages/documentation/examples/02 Drag Around/Custom Drag Layer/DraggableBox.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { DragSource, ConnectDragSource, ConnectDragPreview } from 'react-dnd'
 import { getEmptyImage } from 'react-dnd-html5-backend'
 import ItemTypes from './ItemTypes'
@@ -45,16 +44,6 @@ export interface DraggableBoxProps {
 export default class DraggableBox extends React.PureComponent<
 	DraggableBoxProps
 > {
-	public static propTypes = {
-		connectDragSource: PropTypes.func.isRequired,
-		connectDragPreview: PropTypes.func.isRequired,
-		isDragging: PropTypes.bool.isRequired,
-		id: PropTypes.any.isRequired,
-		title: PropTypes.string.isRequired,
-		left: PropTypes.number.isRequired,
-		top: PropTypes.number.isRequired,
-	}
-
 	public componentDidMount() {
 		const { connectDragPreview } = this.props
 		if (connectDragPreview) {

--- a/packages/documentation/examples/02 Drag Around/Naive/Box.tsx
+++ b/packages/documentation/examples/02 Drag Around/Naive/Box.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { DragSource, ConnectDragSource } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 
@@ -32,16 +31,6 @@ export interface BoxProps {
 	isDragging: monitor.isDragging(),
 }))
 export default class Box extends React.Component<BoxProps> {
-	public static propTypes = {
-		connectDragSource: PropTypes.func.isRequired,
-		isDragging: PropTypes.bool.isRequired,
-		id: PropTypes.any.isRequired,
-		left: PropTypes.number.isRequired,
-		top: PropTypes.number.isRequired,
-		hideSourceOnDrag: PropTypes.bool.isRequired,
-		children: PropTypes.node,
-	}
-
 	public render() {
 		const {
 			hideSourceOnDrag,

--- a/packages/documentation/examples/02 Drag Around/Naive/Container.tsx
+++ b/packages/documentation/examples/02 Drag Around/Naive/Container.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import {
 	DropTarget,
 	DragDropContext,
@@ -51,11 +50,6 @@ export default class Container extends React.Component<
 	ContainerProps,
 	ContainerState
 > {
-	public static propTypes = {
-		hideSourceOnDrag: PropTypes.bool.isRequired,
-		connectDropTarget: PropTypes.func.isRequired,
-	}
-
 	constructor(props: ContainerProps) {
 		super(props)
 		this.state = {

--- a/packages/documentation/examples/03 Nesting/Drag Sources/SourceBox.tsx
+++ b/packages/documentation/examples/03 Nesting/Drag Sources/SourceBox.tsx
@@ -1,6 +1,5 @@
 // tslint:disable max-classes-per-file jsx-no-lambda
 import React from 'react'
-import PropTypes from 'prop-types'
 import {
 	DragSource,
 	ConnectDragSource,
@@ -42,15 +41,6 @@ export interface SourceBoxProps {
 	}),
 )
 class SourceBox extends React.Component<SourceBoxProps> {
-	public static propTypes = {
-		connectDragSource: PropTypes.func.isRequired,
-		isDragging: PropTypes.bool.isRequired,
-		color: PropTypes.string.isRequired,
-		forbidDrag: PropTypes.bool.isRequired,
-		onToggleForbidDrag: PropTypes.func.isRequired,
-		children: PropTypes.node,
-	}
-
 	public render() {
 		const {
 			color,

--- a/packages/documentation/examples/03 Nesting/Drag Sources/TargetBox.tsx
+++ b/packages/documentation/examples/03 Nesting/Drag Sources/TargetBox.tsx
@@ -1,6 +1,5 @@
 // tslint:disable max-classes-per-file
 import React from 'react'
-import PropTypes from 'prop-types'
 import { DropTarget, ConnectDropTarget, DropTargetMonitor } from 'react-dnd'
 import Colors from './Colors'
 
@@ -34,15 +33,6 @@ export interface TargetBoxProps {
 	draggingColor: monitor.getItemType(),
 }))
 class TargetBox extends React.Component<TargetBoxProps> {
-	public static propTypes = {
-		isOver: PropTypes.bool.isRequired,
-		canDrop: PropTypes.bool.isRequired,
-		draggingColor: PropTypes.string,
-		lastDroppedColor: PropTypes.string,
-		connectDropTarget: PropTypes.func.isRequired,
-		onDrop: PropTypes.func.isRequired,
-	}
-
 	public render() {
 		const {
 			canDrop,

--- a/packages/documentation/examples/03 Nesting/Drop Targets/Box.tsx
+++ b/packages/documentation/examples/03 Nesting/Drop Targets/Box.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { DragSource, ConnectDragSource } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 
@@ -25,10 +24,6 @@ export interface BoxProps {
 	connectDragSource: connect.dragSource(),
 }))
 export default class Box extends React.Component<BoxProps> {
-	public static propTypes = {
-		connectDragSource: PropTypes.func.isRequired,
-	}
-
 	public render() {
 		const { connectDragSource } = this.props
 

--- a/packages/documentation/examples/03 Nesting/Drop Targets/Dustbin.tsx
+++ b/packages/documentation/examples/03 Nesting/Drop Targets/Dustbin.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { DropTarget, ConnectDropTarget, DropTargetMonitor } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 
@@ -58,14 +57,6 @@ export default class Dustbin extends React.Component<
 	DustbinProps,
 	DustbinState
 > {
-	public static propTypes = {
-		connectDropTarget: PropTypes.func.isRequired,
-		isOver: PropTypes.bool.isRequired,
-		isOverCurrent: PropTypes.bool.isRequired,
-		greedy: PropTypes.bool,
-		children: PropTypes.node,
-	}
-
 	constructor(props: DustbinProps) {
 		super(props)
 		this.state = {

--- a/packages/documentation/examples/04 Sortable/Cancel on Drop Outside/Card.tsx
+++ b/packages/documentation/examples/04 Sortable/Cancel on Drop Outside/Card.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import {
 	DragSource,
 	DropTarget,
@@ -70,16 +69,6 @@ export interface CardProps {
 	isDragging: monitor.isDragging(),
 }))
 export default class Card extends React.Component<CardProps> {
-	public static propTypes = {
-		connectDragSource: PropTypes.func.isRequired,
-		connectDropTarget: PropTypes.func.isRequired,
-		isDragging: PropTypes.bool.isRequired,
-		id: PropTypes.any.isRequired,
-		text: PropTypes.string.isRequired,
-		moveCard: PropTypes.func.isRequired,
-		findCard: PropTypes.func.isRequired,
-	}
-
 	public render() {
 		const {
 			text,

--- a/packages/documentation/examples/04 Sortable/Cancel on Drop Outside/Container.tsx
+++ b/packages/documentation/examples/04 Sortable/Cancel on Drop Outside/Container.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { DropTarget, DragDropContext, ConnectDropTarget } from 'react-dnd'
 import HTML5Backend from 'react-dnd-html5-backend'
 import Card from './Card'
@@ -32,10 +31,6 @@ export default class Container extends React.Component<
 	ContainerProps,
 	ContainerState
 > {
-	public static propTypes = {
-		connectDropTarget: PropTypes.func.isRequired,
-	}
-
 	constructor(props: ContainerProps) {
 		super(props)
 		this.moveCard = this.moveCard.bind(this)

--- a/packages/documentation/examples/04 Sortable/Simple/Card.tsx
+++ b/packages/documentation/examples/04 Sortable/Simple/Card.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { findDOMNode } from 'react-dom'
 import {
 	DragSource,
@@ -102,16 +101,6 @@ export interface CardProps {
 	}),
 )
 export default class Card extends React.Component<CardProps> {
-	public static propTypes = {
-		connectDragSource: PropTypes.func.isRequired,
-		connectDropTarget: PropTypes.func.isRequired,
-		index: PropTypes.number.isRequired,
-		isDragging: PropTypes.bool.isRequired,
-		id: PropTypes.any.isRequired,
-		text: PropTypes.string.isRequired,
-		moveCard: PropTypes.func.isRequired,
-	}
-
 	public render() {
 		const {
 			text,

--- a/packages/documentation/examples/04 Sortable/Stress Test/Card.tsx
+++ b/packages/documentation/examples/04 Sortable/Stress Test/Card.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import {
 	DragSource,
 	DropTarget,
@@ -50,15 +49,6 @@ export interface CardProps {
 	isDragging: monitor.isDragging(),
 }))
 export default class Card extends React.Component<CardProps> {
-	public static propTypes = {
-		connectDragSource: PropTypes.func.isRequired,
-		connectDropTarget: PropTypes.func.isRequired,
-		isDragging: PropTypes.bool.isRequired,
-		id: PropTypes.any.isRequired,
-		text: PropTypes.string.isRequired,
-		moveCard: PropTypes.func.isRequired,
-	}
-
 	public render() {
 		const {
 			text,

--- a/packages/documentation/examples/05 Customize/Drop Effects/SourceBox.tsx
+++ b/packages/documentation/examples/05 Customize/Drop Effects/SourceBox.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { DragSource, ConnectDragSource } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 
@@ -29,12 +28,6 @@ export interface SourceBoxProps {
 	isDragging: monitor.isDragging(),
 }))
 export default class SourceBox extends React.Component<SourceBoxProps> {
-	public static propTypes = {
-		isDragging: PropTypes.bool.isRequired,
-		connectDragSource: PropTypes.func.isRequired,
-		showCopyIcon: PropTypes.bool,
-	}
-
 	public render() {
 		const { isDragging, connectDragSource, showCopyIcon } = this.props
 		const opacity = isDragging ? 0.4 : 1

--- a/packages/documentation/examples/05 Customize/Drop Effects/TargetBox.tsx
+++ b/packages/documentation/examples/05 Customize/Drop Effects/TargetBox.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { DropTarget, ConnectDropTarget } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 
@@ -29,12 +28,6 @@ export interface TargetBoxProps {
 	canDrop: monitor.canDrop(),
 }))
 export default class TargetBox extends React.Component<TargetBoxProps> {
-	public static propTypes = {
-		connectDropTarget: PropTypes.func.isRequired,
-		isOver: PropTypes.bool.isRequired,
-		canDrop: PropTypes.bool.isRequired,
-	}
-
 	public render() {
 		const { canDrop, isOver, connectDropTarget } = this.props
 		const isActive = canDrop && isOver

--- a/packages/documentation/examples/05 Customize/Handles and Previews/BoxWithHandle.tsx
+++ b/packages/documentation/examples/05 Customize/Handles and Previews/BoxWithHandle.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { DragSource, ConnectDragPreview, ConnectDragSource } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 
@@ -38,12 +37,6 @@ export interface BoxWithHandleProps {
 	isDragging: monitor.isDragging(),
 }))
 export default class BoxWithHandle extends React.Component<BoxWithHandleProps> {
-	public static propTypes = {
-		connectDragSource: PropTypes.func.isRequired,
-		connectDragPreview: PropTypes.func.isRequired,
-		isDragging: PropTypes.bool.isRequired,
-	}
-
 	public render() {
 		const { isDragging, connectDragSource, connectDragPreview } = this.props
 		const opacity = isDragging ? 0.4 : 1

--- a/packages/documentation/examples/05 Customize/Handles and Previews/BoxWithImage.tsx
+++ b/packages/documentation/examples/05 Customize/Handles and Previews/BoxWithImage.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { DragSource, ConnectDragPreview, ConnectDragSource } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 
@@ -30,12 +29,6 @@ export interface BoxWithImageProps {
 	isDragging: monitor.isDragging(),
 }))
 export default class BoxWithImage extends React.Component<BoxWithImageProps> {
-	public static propTypes = {
-		connectDragSource: PropTypes.func.isRequired,
-		connectDragPreview: PropTypes.func.isRequired,
-		isDragging: PropTypes.bool.isRequired,
-	}
-
 	public componentDidMount() {
 		const img = new Image()
 		img.onload = () =>

--- a/packages/documentation/examples/06 Other/Native Files/FileList.tsx
+++ b/packages/documentation/examples/06 Other/Native Files/FileList.tsx
@@ -1,15 +1,10 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
 export interface FileListProps {
 	files: any[]
 }
 
 export default class FileList extends React.Component<FileListProps> {
-	public static propTypes = {
-		files: PropTypes.arrayOf(PropTypes.object),
-	}
-
 	public render() {
 		const { files } = this.props
 		if (files.length === 0) {

--- a/packages/documentation/examples/06 Other/Native Files/TargetBox.tsx
+++ b/packages/documentation/examples/06 Other/Native Files/TargetBox.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import {
 	DropTarget,
 	DropTargetConnector,
@@ -41,14 +40,6 @@ export interface TargetBoxProps {
 	}),
 )
 export default class TargetBox extends React.Component<TargetBoxProps> {
-	public static propTypes = {
-		connectDropTarget: PropTypes.func.isRequired,
-		isOver: PropTypes.bool.isRequired,
-		canDrop: PropTypes.bool.isRequired,
-		accepts: PropTypes.arrayOf(PropTypes.string).isRequired,
-		onDrop: PropTypes.func,
-	}
-
 	public render() {
 		const { canDrop, isOver, connectDropTarget } = this.props
 		const isActive = canDrop && isOver

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -40,19 +40,17 @@
 		"@types/immutability-helper": "^2.6.3",
 		"@types/lodash": "^4.14.109",
 		"@types/node": "^10.3.0",
-		"@types/prop-types": "^15.5.3",
 		"@types/react": "^16.3.14",
 		"@types/react-dom": "^16.0.5",
 		"faker": "^3.1.0",
 		"immutability-helper": "^2.4.0",
 		"lodash": "^4.17.10",
-		"prop-types": "^15.6.1",
 		"react": "^16.4.0",
 		"react-dnd": "^4.0.4",
 		"react-dnd-html5-backend": "^4.0.4",
 		"react-dnd-test-backend": "^4.0.4",
 		"react-dom": "^16.4.0",
-		"react-frame-component": "^3.0.0",
+		"react-frame-component": "^4.0.0",
 		"shallowequal": "^1.0.2"
 	}
 }

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -50,7 +50,7 @@
 		"react-dnd-html5-backend": "^4.0.4",
 		"react-dnd-test-backend": "^4.0.4",
 		"react-dom": "^16.4.0",
-		"react-frame-component": "^4.0.0",
+		"react-frame-component": "git://github.com/ryanseddon/react-frame-component.git#bcc0af0a4fc43c8e50908f478133cf8ee528238c",
 		"shallowequal": "^1.0.2"
 	}
 }

--- a/packages/documentation/site/components/CodeBlock.tsx
+++ b/packages/documentation/site/components/CodeBlock.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import PropTypes from 'prop-types'
 import { findDOMNode } from 'react-dom'
 import StaticHTMLBlock from './StaticHTMLBlock'
 
@@ -40,12 +39,6 @@ export default class CodeBlock extends React.Component<
 	CodeBlockProps,
 	CodeBlockState
 > {
-	public static propTypes = {
-		es5: PropTypes.string,
-		es6: PropTypes.string,
-		es7: PropTypes.string,
-	}
-
 	public static defaultProps = {
 		es5: '',
 		es6: '',

--- a/packages/documentation/site/components/Header.tsx
+++ b/packages/documentation/site/components/Header.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import NavBar from './NavBar'
-import Cover from './Cover'
 import './Header.less'
 
 export default class Header extends React.Component {

--- a/packages/documentation/site/components/PageBody.tsx
+++ b/packages/documentation/site/components/PageBody.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import './PageBody.less'
 
 export interface PageBodyProps {
@@ -7,10 +6,6 @@ export interface PageBodyProps {
 	html?: any
 }
 export default class PageBody extends React.Component<PageBodyProps> {
-	public static propTypes = {
-		hasSidebar: PropTypes.bool,
-	}
-
 	public render() {
 		const { hasSidebar, html, ...props } = this.props
 		return (

--- a/packages/documentation/site/components/StaticHTMLBlock.tsx
+++ b/packages/documentation/site/components/StaticHTMLBlock.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import CodeBlock from './CodeBlock'
 
 export interface StaticHTMLBlockProps {
@@ -9,10 +8,6 @@ export interface StaticHTMLBlockProps {
 export default class StaticHTMLBlock extends React.Component<
 	StaticHTMLBlockProps
 > {
-	public static propTypes = {
-		html: PropTypes.string.isRequired,
-	}
-
 	public render() {
 		const { html } = this.props
 

--- a/packages/react-dnd/package.json
+++ b/packages/react-dnd/package.json
@@ -23,7 +23,6 @@
 		"@types/invariant": "^2.2.29",
 		"@types/lodash": "^4.14.109",
 		"@types/node": "^10.3.0",
-		"@types/prop-types": "^15.5.3",
 		"@types/react": "^16.3.14",
 		"@types/react-dom": "^16.0.5",
 		"@types/shallowequal": "^0.2.2",
@@ -31,7 +30,6 @@
 		"hoist-non-react-statics": "^2.5.0",
 		"invariant": "^2.1.0",
 		"lodash": "^4.17.10",
-		"prop-types": "^15.6.1",
 		"shallowequal": "^1.0.2"
 	},
 	"devDependencies": {

--- a/packages/react-dnd/src/DragDropContext.tsx
+++ b/packages/react-dnd/src/DragDropContext.tsx
@@ -1,8 +1,6 @@
 import React, { Component, ComponentClass, Context } from 'react'
-import PropTypes from 'prop-types'
 import {
 	DragDropManager,
-	Backend,
 	BackendFactory,
 	createDragDropManager,
 } from 'dnd-core'
@@ -10,7 +8,6 @@ import invariant from 'invariant'
 import hoistStatics from 'hoist-non-react-statics'
 import checkDecoratorArguments from './utils/checkDecoratorArguments'
 import { ContextComponent } from './interfaces'
-import { Target } from './createTargetFactory'
 
 /**
  * The React context type

--- a/packages/react-dnd/src/DragLayer.tsx
+++ b/packages/react-dnd/src/DragLayer.tsx
@@ -1,5 +1,4 @@
 import React, { Component, StatelessComponent, ComponentClass } from 'react'
-import PropTypes from 'prop-types'
 import hoistStatics from 'hoist-non-react-statics'
 import isPlainObject from 'lodash/isPlainObject'
 import invariant from 'invariant'

--- a/packages/react-dnd/src/decorateHandler.tsx
+++ b/packages/react-dnd/src/decorateHandler.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import PropTypes from 'prop-types'
 import isPlainObject from 'lodash/isPlainObject'
 import invariant from 'invariant'
 import hoistStatics from 'hoist-non-react-statics'

--- a/yarn.lock
+++ b/yarn.lock
@@ -6986,9 +6986,9 @@ react-dom@^16.4.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-frame-component@^4.0.0:
+"react-frame-component@git://github.com/ryanseddon/react-frame-component.git#bcc0af0a4fc43c8e50908f478133cf8ee528238c":
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/react-frame-component/-/react-frame-component-4.0.0.tgz#57d51cdb2da3b204cc34577349f9f5bb84a76aac"
+  resolved "git://github.com/ryanseddon/react-frame-component.git#bcc0af0a4fc43c8e50908f478133cf8ee528238c"
 
 react-hot-loader@^4.1.2:
   version "4.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,10 +57,6 @@
   version "10.3.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.0.tgz#078516315a84d56216b5d4fed8f75d59d3b16cac"
 
-"@types/prop-types@^15.5.3":
-  version "15.5.3"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.3.tgz#bef071852dca2a2dbb65fecdb7bfb30cedae2de2"
-
 "@types/react-dom@^16.0.5":
   version "16.0.5"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.5.tgz#a757457662e3819409229e8f86795ff37b371f96"
@@ -6990,9 +6986,9 @@ react-dom@^16.4.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-frame-component@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/react-frame-component/-/react-frame-component-3.0.0.tgz#8e01ada1e1aecd2962bea751087c0420bc52b0c3"
+react-frame-component@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/react-frame-component/-/react-frame-component-4.0.0.tgz#57d51cdb2da3b204cc34577349f9f5bb84a76aac"
 
 react-hot-loader@^4.1.2:
   version "4.1.2"


### PR DESCRIPTION
Remove dependency on `prop-types`, since it's doing the same job as Typescript in doing prop-validation in the examples. I'm leaving it in the example text, because raw JS users might find it valuable.