### PR TITLE
Remove the esModuleInterop setting in tsconfig.json

### DIFF
--- a/packages/dnd-core/package.json
+++ b/packages/dnd-core/package.json
@@ -17,14 +17,13 @@
 		"url": "https://github.com/react-dnd/react-dnd.git"
 	},
 	"dependencies": {
-		"@types/invariant": "^2.2.29",
-		"@types/lodash": "^4.14.109",
 		"asap": "^2.0.6",
 		"invariant": "^2.2.4",
 		"lodash": "^4.17.10",
 		"redux": "^4.0.0"
 	},
 	"devDependencies": {
+		"@types/node": "10.3.2",
 		"npm-run-all": "^4.1.2",
 		"rimraf": "^2.6.2",
 		"typescript": "^2.8.1"

--- a/packages/dnd-core/src/DragDropMonitorImpl.ts
+++ b/packages/dnd-core/src/DragDropMonitorImpl.ts
@@ -1,5 +1,4 @@
 import { Store } from 'redux'
-import invariant from 'invariant'
 import matchesType from './utils/matchesType'
 import {
 	getSourceClientOffset,
@@ -15,6 +14,7 @@ import {
 	HandlerRegistry,
 	Identifier,
 } from './interfaces'
+const invariant = require('invariant')
 
 export default class DragDropMonitorImpl implements DragDropMonitor {
 	constructor(private store: Store<State>, public registry: HandlerRegistry) {}

--- a/packages/dnd-core/src/HandlerRegistryImpl.ts
+++ b/packages/dnd-core/src/HandlerRegistryImpl.ts
@@ -1,5 +1,4 @@
 import { Store } from 'redux'
-import invariant from 'invariant'
 import {
 	addSource,
 	addTarget,
@@ -22,8 +21,8 @@ import {
 	validateTargetContract,
 	validateType,
 } from './contracts'
-// @ts-ignore
-import asap from 'asap'
+const invariant = require('invariant')
+const asap = require('asap')
 
 function getNextHandlerId(role: HandlerRole): string {
 	const id = getNextUniqueId().toString()
@@ -52,7 +51,7 @@ function mapContainsValue<T>(map: Map<string, T>, searchValue: T) {
 	const entries = map.entries()
 	let isDone = false
 	do {
-		const { done, value: [key, value] } = entries.next()
+		const { done, value: [, value] } = entries.next()
 		if (value === searchValue) {
 			return true
 		}

--- a/packages/dnd-core/src/__tests__/DragDropManager.spec.ts
+++ b/packages/dnd-core/src/__tests__/DragDropManager.spec.ts
@@ -1,5 +1,4 @@
 import createTestBackend, { TestBackend } from 'react-dnd-test-backend'
-import isString from 'lodash/isString'
 import * as Types from './types'
 import { NormalSource, NonDraggableSource, BadItemSource } from './sources'
 import {
@@ -11,6 +10,7 @@ import {
 } from './targets'
 import DragDropManagerImpl from '../DragDropManagerImpl'
 import { DragDropManager, Backend, HandlerRegistry } from '../interfaces'
+const isString = require('lodash/isString')
 
 describe('DragDropManager', () => {
 	let manager: DragDropManager<any>

--- a/packages/dnd-core/src/actions/dragDrop.ts
+++ b/packages/dnd-core/src/actions/dragDrop.ts
@@ -9,9 +9,9 @@ import {
 	HoverPayload,
 	HoverOptions,
 } from '../interfaces'
-import invariant from 'invariant'
-import isObject from 'lodash/isObject'
 import matchesType from '../utils/matchesType'
+const invariant = require('invariant')
+const isObject = require('lodash/isObject')
 
 export const BEGIN_DRAG = 'dnd-core/BEGIN_DRAG'
 export const PUBLISH_DRAG_SOURCE = 'dnd-core/PUBLISH_DRAG_SOURCE'

--- a/packages/dnd-core/src/contracts.ts
+++ b/packages/dnd-core/src/contracts.ts
@@ -1,5 +1,5 @@
-import invariant from 'invariant'
 import { DragSource, DropTarget, Identifier } from './interfaces'
+const invariant = require('invariant')
 
 export function validateSourceContract(source: DragSource) {
 	invariant(

--- a/packages/dnd-core/src/reducers/dirtyHandlerIds.ts
+++ b/packages/dnd-core/src/reducers/dirtyHandlerIds.ts
@@ -1,4 +1,3 @@
-import xor from 'lodash/xor'
 import {
 	BEGIN_DRAG,
 	PUBLISH_DRAG_SOURCE,
@@ -15,6 +14,7 @@ import {
 import { Action } from '../interfaces'
 import { areArraysEqual } from '../utils/equality'
 import { NONE, ALL } from '../utils/dirtiness'
+const xor = require('lodash/xor')
 
 export type State = string[]
 

--- a/packages/dnd-core/src/reducers/dragOperation.ts
+++ b/packages/dnd-core/src/reducers/dragOperation.ts
@@ -1,4 +1,3 @@
-import without from 'lodash/without'
 import {
 	BEGIN_DRAG,
 	PUBLISH_DRAG_SOURCE,
@@ -7,12 +6,8 @@ import {
 	DROP,
 } from '../actions/dragDrop'
 import { REMOVE_TARGET } from '../actions/registry'
-import {
-	Identifier,
-	Action,
-	BeginDragOptions,
-	SentinelAction,
-} from '../interfaces'
+import { Identifier, Action } from '../interfaces'
+const without = require('lodash/without')
 
 export interface State {
 	itemType: Identifier | Identifier[] | null

--- a/packages/dnd-core/src/reducers/index.ts
+++ b/packages/dnd-core/src/reducers/index.ts
@@ -1,4 +1,3 @@
-import get from 'lodash/get'
 import dragOffset, { State as DragOffsetState } from './dragOffset'
 import dragOperation, { State as DragOperationState } from './dragOperation'
 import refCount, { State as RefCountState } from './refCount'
@@ -6,6 +5,7 @@ import dirtyHandlerIds, {
 	State as DirtyHandlerIdsState,
 } from './dirtyHandlerIds'
 import stateId, { State as StateIdState } from './stateId'
+const get = require('lodash/get')
 
 export interface State {
 	dirtyHandlerIds: DirtyHandlerIdsState

--- a/packages/dnd-core/src/utils/dirtiness.ts
+++ b/packages/dnd-core/src/utils/dirtiness.ts
@@ -1,4 +1,4 @@
-import intersection from 'lodash/intersection'
+const intersection = require('lodash/intersection')
 
 export const NONE: string[] = []
 export const ALL: string[] = []

--- a/packages/documentation/examples/00 Chessboard/Tutorial App/Board.tsx
+++ b/packages/documentation/examples/00 Chessboard/Tutorial App/Board.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { DragDropContext } from 'react-dnd'
 import HTML5Backend, { HTML5BackendContext } from 'react-dnd-html5-backend'
 import BoardSquare from './BoardSquare'

--- a/packages/documentation/examples/00 Chessboard/Tutorial App/BoardSquare.tsx
+++ b/packages/documentation/examples/00 Chessboard/Tutorial App/BoardSquare.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {
 	DropTarget,
 	DropTargetMonitor,

--- a/packages/documentation/examples/00 Chessboard/Tutorial App/Knight.tsx
+++ b/packages/documentation/examples/00 Chessboard/Tutorial App/Knight.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {
 	DragSource,
 	ConnectDragSource,

--- a/packages/documentation/examples/00 Chessboard/Tutorial App/Square.tsx
+++ b/packages/documentation/examples/00 Chessboard/Tutorial App/Square.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 export interface SquareProps {
 	black: boolean

--- a/packages/documentation/examples/00 Chessboard/Tutorial App/index.tsx
+++ b/packages/documentation/examples/00 Chessboard/Tutorial App/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import Board from './Board'
 import { observe } from './Game'
 

--- a/packages/documentation/examples/01 Dustbin/Copy or Move/Box.tsx
+++ b/packages/documentation/examples/01 Dustbin/Copy or Move/Box.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {
 	DragSource,
 	ConnectDragSource,

--- a/packages/documentation/examples/01 Dustbin/Copy or Move/Container.tsx
+++ b/packages/documentation/examples/01 Dustbin/Copy or Move/Container.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { DragDropContextProvider } from 'react-dnd'
 import HTML5Backend from 'react-dnd-html5-backend'
 import Dustbin from './Dustbin'

--- a/packages/documentation/examples/01 Dustbin/Copy or Move/Dustbin.tsx
+++ b/packages/documentation/examples/01 Dustbin/Copy or Move/Dustbin.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { DropTarget, ConnectDropTarget } from 'react-dnd'
 import ItemTypes from '../Single Target/ItemTypes'
 

--- a/packages/documentation/examples/01 Dustbin/Copy or Move/index.tsx
+++ b/packages/documentation/examples/01 Dustbin/Copy or Move/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import Container from './Container'
 
 export default class DustbinCopyOrMove extends React.Component {

--- a/packages/documentation/examples/01 Dustbin/Multiple Targets/Box.tsx
+++ b/packages/documentation/examples/01 Dustbin/Multiple Targets/Box.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {
 	DragSource,
 	ConnectDragSource,

--- a/packages/documentation/examples/01 Dustbin/Multiple Targets/Container.tsx
+++ b/packages/documentation/examples/01 Dustbin/Multiple Targets/Container.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { DragDropContext } from 'react-dnd'
 import HTML5Backend, { NativeTypes } from 'react-dnd-html5-backend'
 import Dustbin from './Dustbin'

--- a/packages/documentation/examples/01 Dustbin/Multiple Targets/Dustbin.tsx
+++ b/packages/documentation/examples/01 Dustbin/Multiple Targets/Dustbin.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { DropTarget, ConnectDropTarget, DropTargetMonitor } from 'react-dnd'
 
 const style: React.CSSProperties = {

--- a/packages/documentation/examples/01 Dustbin/Multiple Targets/index.tsx
+++ b/packages/documentation/examples/01 Dustbin/Multiple Targets/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import Container from './Container'
 
 export default class DustbinMultipleTargets extends React.Component {

--- a/packages/documentation/examples/01 Dustbin/Single Target in iframe/Container.tsx
+++ b/packages/documentation/examples/01 Dustbin/Single Target in iframe/Container.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { DragDropContextProvider } from 'react-dnd'
 import HTML5Backend from 'react-dnd-html5-backend'
 import Dustbin from '../Single Target/Dustbin'

--- a/packages/documentation/examples/01 Dustbin/Single Target in iframe/index.tsx
+++ b/packages/documentation/examples/01 Dustbin/Single Target in iframe/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import Container from './Container'
 
 export default class DustbinSingleTargetIframe extends React.Component {

--- a/packages/documentation/examples/01 Dustbin/Single Target/Box.tsx
+++ b/packages/documentation/examples/01 Dustbin/Single Target/Box.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {
 	ConnectDragSource,
 	DragSource,

--- a/packages/documentation/examples/01 Dustbin/Single Target/Container.tsx
+++ b/packages/documentation/examples/01 Dustbin/Single Target/Container.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { DragDropContextProvider } from 'react-dnd'
 import HTML5Backend from 'react-dnd-html5-backend'
 import Dustbin from './Dustbin'

--- a/packages/documentation/examples/01 Dustbin/Single Target/Dustbin.tsx
+++ b/packages/documentation/examples/01 Dustbin/Single Target/Dustbin.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {
 	DropTarget,
 	DropTargetConnector,

--- a/packages/documentation/examples/01 Dustbin/Single Target/__tests__/Box.spec.tsx
+++ b/packages/documentation/examples/01 Dustbin/Single Target/__tests__/Box.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import TestUtils from 'react-dom/test-utils'
+import * as React from 'react'
+import * as TestUtils from 'react-dom/test-utils'
 import wrapInTestContext from '../../../shared/wrapInTestContext'
 import Box from '../Box'
 

--- a/packages/documentation/examples/01 Dustbin/Single Target/__tests__/integration.spec.tsx
+++ b/packages/documentation/examples/01 Dustbin/Single Target/__tests__/integration.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import TestUtils from 'react-dom/test-utils'
+import * as React from 'react'
+import * as TestUtils from 'react-dom/test-utils'
 import wrapInTestContext from '../../../shared/wrapInTestContext'
 import Box from '../Box'
 import Dustbin from '../Dustbin'

--- a/packages/documentation/examples/01 Dustbin/Single Target/index.tsx
+++ b/packages/documentation/examples/01 Dustbin/Single Target/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import Container from './Container'
 
 export default class DustbinSingleTarget extends React.PureComponent {

--- a/packages/documentation/examples/01 Dustbin/Stress Test/Box.tsx
+++ b/packages/documentation/examples/01 Dustbin/Stress Test/Box.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {
 	DragSource,
 	DragSourceConnector,

--- a/packages/documentation/examples/01 Dustbin/Stress Test/Container.tsx
+++ b/packages/documentation/examples/01 Dustbin/Stress Test/Container.tsx
@@ -1,5 +1,5 @@
 // tslint:disable jsx-no-lambda
-import React from 'react'
+import * as React from 'react'
 import { DragDropContext } from 'react-dnd'
 import HTML5Backend, { NativeTypes } from 'react-dnd-html5-backend'
 import shuffle from 'lodash/shuffle'

--- a/packages/documentation/examples/01 Dustbin/Stress Test/Dustbin.tsx
+++ b/packages/documentation/examples/01 Dustbin/Stress Test/Dustbin.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {
 	ConnectDropTarget,
 	DropTarget,

--- a/packages/documentation/examples/01 Dustbin/Stress Test/index.tsx
+++ b/packages/documentation/examples/01 Dustbin/Stress Test/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import Container from './Container'
 
 export default class DustbinStressTest extends React.Component {

--- a/packages/documentation/examples/02 Drag Around/Custom Drag Layer/Box.tsx
+++ b/packages/documentation/examples/02 Drag Around/Custom Drag Layer/Box.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 const styles: React.CSSProperties = {
 	border: '1px dashed gray',

--- a/packages/documentation/examples/02 Drag Around/Custom Drag Layer/BoxDragPreview.tsx
+++ b/packages/documentation/examples/02 Drag Around/Custom Drag Layer/BoxDragPreview.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import Box from './Box'
 
 const styles = {

--- a/packages/documentation/examples/02 Drag Around/Custom Drag Layer/Container.tsx
+++ b/packages/documentation/examples/02 Drag Around/Custom Drag Layer/Container.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {
 	DropTarget,
 	ConnectDropTarget,

--- a/packages/documentation/examples/02 Drag Around/Custom Drag Layer/CustomDragLayer.tsx
+++ b/packages/documentation/examples/02 Drag Around/Custom Drag Layer/CustomDragLayer.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { DragLayer, XYCoord } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 import BoxDragPreview from './BoxDragPreview'

--- a/packages/documentation/examples/02 Drag Around/Custom Drag Layer/DraggableBox.tsx
+++ b/packages/documentation/examples/02 Drag Around/Custom Drag Layer/DraggableBox.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { DragSource, ConnectDragSource, ConnectDragPreview } from 'react-dnd'
 import { getEmptyImage } from 'react-dnd-html5-backend'
 import ItemTypes from './ItemTypes'

--- a/packages/documentation/examples/02 Drag Around/Custom Drag Layer/index.tsx
+++ b/packages/documentation/examples/02 Drag Around/Custom Drag Layer/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { DragDropContext } from 'react-dnd'
 import HTML5Backend from 'react-dnd-html5-backend'
 import Container from './Container'

--- a/packages/documentation/examples/02 Drag Around/Naive/Box.tsx
+++ b/packages/documentation/examples/02 Drag Around/Naive/Box.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { DragSource, ConnectDragSource } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 

--- a/packages/documentation/examples/02 Drag Around/Naive/Container.tsx
+++ b/packages/documentation/examples/02 Drag Around/Naive/Container.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {
 	DropTarget,
 	DragDropContext,

--- a/packages/documentation/examples/02 Drag Around/Naive/index.tsx
+++ b/packages/documentation/examples/02 Drag Around/Naive/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import Container from './Container'
 
 export interface DragAroundNaiveState {

--- a/packages/documentation/examples/03 Nesting/Drag Sources/Container.tsx
+++ b/packages/documentation/examples/03 Nesting/Drag Sources/Container.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { DragDropContext } from 'react-dnd'
 import HTML5Backend from 'react-dnd-html5-backend'
 import SourceBox from './SourceBox'

--- a/packages/documentation/examples/03 Nesting/Drag Sources/SourceBox.tsx
+++ b/packages/documentation/examples/03 Nesting/Drag Sources/SourceBox.tsx
@@ -1,5 +1,5 @@
 // tslint:disable max-classes-per-file jsx-no-lambda
-import React from 'react'
+import * as React from 'react'
 import {
 	DragSource,
 	ConnectDragSource,

--- a/packages/documentation/examples/03 Nesting/Drag Sources/TargetBox.tsx
+++ b/packages/documentation/examples/03 Nesting/Drag Sources/TargetBox.tsx
@@ -1,5 +1,5 @@
 // tslint:disable max-classes-per-file
-import React from 'react'
+import * as React from 'react'
 import { DropTarget, ConnectDropTarget, DropTargetMonitor } from 'react-dnd'
 import Colors from './Colors'
 

--- a/packages/documentation/examples/03 Nesting/Drag Sources/index.tsx
+++ b/packages/documentation/examples/03 Nesting/Drag Sources/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import Container from './Container'
 
 export default class NestingDragSources extends React.Component {

--- a/packages/documentation/examples/03 Nesting/Drop Targets/Box.tsx
+++ b/packages/documentation/examples/03 Nesting/Drop Targets/Box.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { DragSource, ConnectDragSource } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 

--- a/packages/documentation/examples/03 Nesting/Drop Targets/Container.tsx
+++ b/packages/documentation/examples/03 Nesting/Drop Targets/Container.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { DragDropContext } from 'react-dnd'
 import HTML5Backend from 'react-dnd-html5-backend'
 import Dustbin from './Dustbin'

--- a/packages/documentation/examples/03 Nesting/Drop Targets/Dustbin.tsx
+++ b/packages/documentation/examples/03 Nesting/Drop Targets/Dustbin.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { DropTarget, ConnectDropTarget, DropTargetMonitor } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 

--- a/packages/documentation/examples/03 Nesting/Drop Targets/index.tsx
+++ b/packages/documentation/examples/03 Nesting/Drop Targets/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import Container from './Container'
 
 export default class NestingDropTargets extends React.Component {

--- a/packages/documentation/examples/04 Sortable/Cancel on Drop Outside/Card.tsx
+++ b/packages/documentation/examples/04 Sortable/Cancel on Drop Outside/Card.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {
 	DragSource,
 	DropTarget,

--- a/packages/documentation/examples/04 Sortable/Cancel on Drop Outside/Container.tsx
+++ b/packages/documentation/examples/04 Sortable/Cancel on Drop Outside/Container.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { DropTarget, DragDropContext, ConnectDropTarget } from 'react-dnd'
 import HTML5Backend from 'react-dnd-html5-backend'
 import Card from './Card'

--- a/packages/documentation/examples/04 Sortable/Cancel on Drop Outside/index.tsx
+++ b/packages/documentation/examples/04 Sortable/Cancel on Drop Outside/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import Container from './Container'
 
 export default class SortableCancelOnDropOutside extends React.Component {

--- a/packages/documentation/examples/04 Sortable/Simple/Card.tsx
+++ b/packages/documentation/examples/04 Sortable/Simple/Card.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { findDOMNode } from 'react-dom'
 import {
 	DragSource,

--- a/packages/documentation/examples/04 Sortable/Simple/Container.tsx
+++ b/packages/documentation/examples/04 Sortable/Simple/Container.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { DragDropContext } from 'react-dnd'
 import HTML5Backend from 'react-dnd-html5-backend'
 import Card from './Card'

--- a/packages/documentation/examples/04 Sortable/Simple/index.tsx
+++ b/packages/documentation/examples/04 Sortable/Simple/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import Container from './Container'
 
 export default class SortableSimple extends React.Component {

--- a/packages/documentation/examples/04 Sortable/Stress Test/Card.tsx
+++ b/packages/documentation/examples/04 Sortable/Stress Test/Card.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {
 	DragSource,
 	DropTarget,

--- a/packages/documentation/examples/04 Sortable/Stress Test/Container.tsx
+++ b/packages/documentation/examples/04 Sortable/Stress Test/Container.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { DragDropContext } from 'react-dnd'
 import HTML5Backend from 'react-dnd-html5-backend'
 import { name } from 'faker'

--- a/packages/documentation/examples/04 Sortable/Stress Test/index.tsx
+++ b/packages/documentation/examples/04 Sortable/Stress Test/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import Container from './Container'
 
 export interface SortableStressTestState {

--- a/packages/documentation/examples/05 Customize/Drop Effects/Container.tsx
+++ b/packages/documentation/examples/05 Customize/Drop Effects/Container.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { DragDropContext } from 'react-dnd'
 import HTML5Backend from 'react-dnd-html5-backend'
 import SourceBox from './SourceBox'

--- a/packages/documentation/examples/05 Customize/Drop Effects/SourceBox.tsx
+++ b/packages/documentation/examples/05 Customize/Drop Effects/SourceBox.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { DragSource, ConnectDragSource } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 

--- a/packages/documentation/examples/05 Customize/Drop Effects/TargetBox.tsx
+++ b/packages/documentation/examples/05 Customize/Drop Effects/TargetBox.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { DropTarget, ConnectDropTarget } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 

--- a/packages/documentation/examples/05 Customize/Drop Effects/index.tsx
+++ b/packages/documentation/examples/05 Customize/Drop Effects/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import Container from './Container'
 
 export default class CustomizeDropEffects extends React.Component {

--- a/packages/documentation/examples/05 Customize/Handles and Previews/BoxWithHandle.tsx
+++ b/packages/documentation/examples/05 Customize/Handles and Previews/BoxWithHandle.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { DragSource, ConnectDragPreview, ConnectDragSource } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 

--- a/packages/documentation/examples/05 Customize/Handles and Previews/BoxWithImage.tsx
+++ b/packages/documentation/examples/05 Customize/Handles and Previews/BoxWithImage.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { DragSource, ConnectDragPreview, ConnectDragSource } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 

--- a/packages/documentation/examples/05 Customize/Handles and Previews/Container.tsx
+++ b/packages/documentation/examples/05 Customize/Handles and Previews/Container.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { DragDropContext } from 'react-dnd'
 import HTML5Backend from 'react-dnd-html5-backend'
 import BoxWithImage from './BoxWithImage'

--- a/packages/documentation/examples/05 Customize/Handles and Previews/index.tsx
+++ b/packages/documentation/examples/05 Customize/Handles and Previews/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import Container from './Container'
 
 export default class CustomizeHandlesAndPreviews extends React.Component {

--- a/packages/documentation/examples/06 Other/Native Files/Container.tsx
+++ b/packages/documentation/examples/06 Other/Native Files/Container.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {
 	DragDropContext,
 	DragDropContextProvider,

--- a/packages/documentation/examples/06 Other/Native Files/FileList.tsx
+++ b/packages/documentation/examples/06 Other/Native Files/FileList.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 export interface FileListProps {
 	files: any[]

--- a/packages/documentation/examples/06 Other/Native Files/TargetBox.tsx
+++ b/packages/documentation/examples/06 Other/Native Files/TargetBox.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {
 	DropTarget,
 	DropTargetConnector,

--- a/packages/documentation/examples/06 Other/Native Files/index.tsx
+++ b/packages/documentation/examples/06 Other/Native Files/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import Container from './Container'
 
 export default class NativeFiles extends React.Component {

--- a/packages/documentation/examples/shared/wrapInTestContext.tsx
+++ b/packages/documentation/examples/shared/wrapInTestContext.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import TestBackend from 'react-dnd-test-backend'
 import { DragDropContext } from 'react-dnd'
 

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -38,8 +38,7 @@
 	"dependencies": {
 		"@types/faker": "^4.1.2",
 		"@types/immutability-helper": "^2.6.3",
-		"@types/lodash": "^4.14.109",
-		"@types/node": "^10.3.0",
+		"@types/node": "10.3.2",
 		"@types/react": "^16.3.14",
 		"@types/react-dom": "^16.0.5",
 		"faker": "^3.1.0",

--- a/packages/documentation/scripts/buildSiteIndexPages.ts
+++ b/packages/documentation/scripts/buildSiteIndexPages.ts
@@ -1,7 +1,7 @@
-import fs from 'fs'
-import path from 'path'
 import * as Constants from '../site/Constants'
-import flatten from 'lodash/flatten'
+const fs = require('fs')
+const path = require('path')
+const flatten = require('lodash/flatten')
 
 const glob = require('glob')
 const renderPath = require('../__site_prerender__/renderPath').default

--- a/packages/documentation/site/IndexPage.tsx
+++ b/packages/documentation/site/IndexPage.tsx
@@ -4,7 +4,7 @@ import HomePage from './pages/HomePage'
 import APIPage from './pages/APIPage'
 import ExamplePage from './pages/ExamplePage'
 import * as React from 'react'
-import ReactDOMServer from 'react-dom/server'
+import * as ReactDOMServer from 'react-dom/server'
 
 const APIDocs: { [key: string]: any } = {
 	OVERVIEW: require('../docs/00 Quick Start/Overview.md'),

--- a/packages/documentation/site/client.tsx
+++ b/packages/documentation/site/client.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import IndexPage from './IndexPage'
 

--- a/packages/documentation/site/components/Cover.tsx
+++ b/packages/documentation/site/components/Cover.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import './Cover.less'
 
 export default class Cover extends React.Component {

--- a/packages/documentation/site/components/Header.tsx
+++ b/packages/documentation/site/components/Header.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import NavBar from './NavBar'
 import './Header.less'
 

--- a/packages/documentation/site/components/NavBar.tsx
+++ b/packages/documentation/site/components/NavBar.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import './NavBar.less'
 const { DOCS_DEFAULT, EXAMPLES_DEFAULT } = require('../Constants')
 

--- a/packages/documentation/site/components/PageBody.tsx
+++ b/packages/documentation/site/components/PageBody.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import './PageBody.less'
 
 export interface PageBodyProps {

--- a/packages/documentation/site/components/SideBar.tsx
+++ b/packages/documentation/site/components/SideBar.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import './SideBar.less'
 import { Page, PageGroup } from '../Constants'
 

--- a/packages/documentation/site/components/StaticHTMLBlock.tsx
+++ b/packages/documentation/site/components/StaticHTMLBlock.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import CodeBlock from './CodeBlock'
 
 export interface StaticHTMLBlockProps {

--- a/packages/documentation/site/pages/APIPage.tsx
+++ b/packages/documentation/site/pages/APIPage.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import * as React from 'react'
 import Header from '../components/Header'
 import PageBody from '../components/PageBody'
 import SideBar from '../components/SideBar'

--- a/packages/documentation/site/pages/ExamplePage.tsx
+++ b/packages/documentation/site/pages/ExamplePage.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import Header from '../components/Header'
 import PageBody from '../components/PageBody'
 import SideBar from '../components/SideBar'

--- a/packages/documentation/site/renderPath.ts
+++ b/packages/documentation/site/renderPath.ts
@@ -1,4 +1,3 @@
-import React from 'react'
 import IndexPage from './IndexPage'
 
 export default function renderPath(path: string, props: any, onRender: any) {

--- a/packages/react-dnd-html5-backend/package.json
+++ b/packages/react-dnd-html5-backend/package.json
@@ -20,16 +20,15 @@
 		"start": "npm run watch"
 	},
 	"dependencies": {
-		"@types/lodash": "^4.14.109",
-		"@types/react": "^16.3.16",
-		"@types/shallowequal": "^0.2.2",
 		"autobind-decorator": "^2.1.0",
 		"dnd-core": "^4.0.4",
 		"lodash": "^4.17.10",
 		"shallowequal": "^1.0.2"
 	},
 	"devDependencies": {
-		"@types/node": "^10.3.0",
+		"@types/react": "^16.3.16",
+		"@types/shallowequal": "^0.2.2",
+		"@types/node": "10.3.2",
 		"npm-run-all": "^4.1.2",
 		"react": "^16.4.0",
 		"react-dnd": "^4.0.4",

--- a/packages/react-dnd-html5-backend/src/BrowserDetector.ts
+++ b/packages/react-dnd-html5-backend/src/BrowserDetector.ts
@@ -1,4 +1,4 @@
-import memoize from 'lodash/memoize'
+const memoize = require('lodash/memoize')
 
 declare global {
 	// tslint:disable-next-line interface-name

--- a/packages/react-dnd-html5-backend/src/EnterLeaveCounter.ts
+++ b/packages/react-dnd-html5-backend/src/EnterLeaveCounter.ts
@@ -1,5 +1,5 @@
-import union from 'lodash/union'
-import without from 'lodash/without'
+const union = require('lodash/union')
+const without = require('lodash/without')
 
 export default class EnterLeaveCounter {
 	private entered: any[] = []

--- a/packages/react-dnd-html5-backend/src/HTML5Backend.ts
+++ b/packages/react-dnd-html5-backend/src/HTML5Backend.ts
@@ -1,4 +1,3 @@
-import defaults from 'lodash/defaults'
 import {
 	Backend,
 	DragDropManager,
@@ -21,7 +20,8 @@ import {
 import * as NativeTypes from './NativeTypes'
 import autobind from 'autobind-decorator'
 import { HTML5BackendContext } from './interfaces'
-import shallowEqual from 'shallowequal'
+const defaults = require('lodash/defaults')
+const shallowEqual = require('shallowequal')
 
 declare global {
 	// tslint:disable-next-line interface-name
@@ -55,7 +55,6 @@ export default class HTML5Backend implements Backend {
 	private mouseMoveTimeoutTimer: any = null
 	private asyncEndDragFrameId: any = null
 	private dragOverTargetIds: string[] | null = null
-	private mouseMoveTimeoutId: any
 
 	constructor(manager: DragDropManager<any>) {
 		this.actions = manager.getActions()
@@ -246,15 +245,6 @@ export default class HTML5Backend implements Backend {
 	}
 
 	@autobind
-	private asyncEndDragNativeItem() {
-		if (this.window) {
-			this.asyncEndDragFrameId = this.window.requestAnimationFrame(
-				this.endDragNativeItem,
-			)
-		}
-	}
-
-	@autobind
 	private endDragNativeItem() {
 		if (!this.isDraggingNativeItem()) {
 			return
@@ -312,7 +302,6 @@ export default class HTML5Backend implements Backend {
 		//   * https://github.com/react-dnd/react-dnd/issues/869
 		//
 		this.mouseMoveTimeoutTimer = setTimeout(() => {
-			this.mouseMoveTimeoutId = null
 			return (
 				this.window &&
 				this.window.addEventListener(

--- a/packages/react-dnd-html5-backend/src/NativeDragSources.ts
+++ b/packages/react-dnd-html5-backend/src/NativeDragSources.ts
@@ -1,5 +1,4 @@
 import * as NativeTypes from './NativeTypes'
-import matchesType from './matchesType'
 import { DragDropMonitor } from 'dnd-core'
 
 function getDataFromDataTransfer(

--- a/packages/react-dnd-html5-backend/src/OffsetUtils.ts
+++ b/packages/react-dnd-html5-backend/src/OffsetUtils.ts
@@ -1,6 +1,5 @@
 import { isSafari, isFirefox } from './BrowserDetector'
 import MonotonicInterpolant from './MonotonicInterpolant'
-import { DOMElement, ReactNode } from 'react'
 import { XYCoord } from 'dnd-core'
 
 const ELEMENT_NODE = 1

--- a/packages/react-dnd-html5-backend/src/index.ts
+++ b/packages/react-dnd-html5-backend/src/index.ts
@@ -4,6 +4,7 @@ import HTML5Backend from './HTML5Backend'
 import getEmptyImage from './getEmptyImage'
 import * as NativeTypes from './NativeTypes'
 import { DragDropManager } from 'dnd-core'
+
 export { NativeTypes, getEmptyImage }
 
 export default function createHTML5Backend(manager: DragDropManager<any>) {

--- a/packages/react-dnd-test-backend/package.json
+++ b/packages/react-dnd-test-backend/package.json
@@ -15,7 +15,6 @@
 		"prepublish": "npm run test"
 	},
 	"dependencies": {
-		"@types/lodash": "^4.14.109",
 		"dnd-core": "^4.0.4",
 		"lodash": "^4.17.10"
 	},
@@ -23,6 +22,7 @@
 		"react": ">= 16.3"
 	},
 	"devDependencies": {
+		"@types/node": "10.3.2",
 		"npm-run-all": "^4.1.2",
 		"rimraf": "^2.6.2",
 		"typescript": "^2.9.1"

--- a/packages/react-dnd-test-backend/src/TestBackend.ts
+++ b/packages/react-dnd-test-backend/src/TestBackend.ts
@@ -1,4 +1,3 @@
-import noop from 'lodash/noop'
 import {
 	DragDropManager,
 	DragDropActions,
@@ -6,6 +5,7 @@ import {
 	BeginDragOptions,
 	HoverOptions,
 } from 'dnd-core'
+const noop = require('lodash/noop')
 
 export interface TestBackend {
 	didCallSetup: boolean

--- a/packages/react-dnd-test-backend/src/index.ts
+++ b/packages/react-dnd-test-backend/src/index.ts
@@ -1,5 +1,5 @@
 import TestBackend from './TestBackend'
-import { DragDropManager, DragDropActions } from 'dnd-core'
+import { DragDropManager } from 'dnd-core'
 export { TestBackend } from './TestBackend'
 
 export default function createBackend(manager: DragDropManager<any>) {

--- a/packages/react-dnd/package.json
+++ b/packages/react-dnd/package.json
@@ -20,12 +20,6 @@
 		"start": "npm run watch"
 	},
 	"dependencies": {
-		"@types/invariant": "^2.2.29",
-		"@types/lodash": "^4.14.109",
-		"@types/node": "^10.3.0",
-		"@types/react": "^16.3.14",
-		"@types/react-dom": "^16.0.5",
-		"@types/shallowequal": "^0.2.2",
 		"dnd-core": "^4.0.4",
 		"hoist-non-react-statics": "^2.5.0",
 		"invariant": "^2.1.0",
@@ -33,6 +27,10 @@
 		"shallowequal": "^1.0.2"
 	},
 	"devDependencies": {
+		"@types/node": "10.3.2",
+		"@types/react": "^16.3.14",
+		"@types/react-dom": "^16.0.5",
+		"@types/shallowequal": "^0.2.2",
 		"babel-cli": "^6.26.0",
 		"babel-loader": "^7.1.1",
 		"npm-run-all": "^4.1.2",

--- a/packages/react-dnd/src/DragDropContext.tsx
+++ b/packages/react-dnd/src/DragDropContext.tsx
@@ -1,13 +1,13 @@
-import React, { Component, ComponentClass, Context } from 'react'
+import * as React from 'react'
 import {
 	DragDropManager,
 	BackendFactory,
 	createDragDropManager,
 } from 'dnd-core'
-import invariant from 'invariant'
-import hoistStatics from 'hoist-non-react-statics'
 import checkDecoratorArguments from './utils/checkDecoratorArguments'
 import { ContextComponent } from './interfaces'
+const invariant = require('invariant')
+const hoistStatics = require('hoist-non-react-statics')
 
 /**
  * The React context type

--- a/packages/react-dnd/src/DragLayer.tsx
+++ b/packages/react-dnd/src/DragLayer.tsx
@@ -1,12 +1,12 @@
-import React, { Component, StatelessComponent, ComponentClass } from 'react'
-import hoistStatics from 'hoist-non-react-statics'
-import isPlainObject from 'lodash/isPlainObject'
-import invariant from 'invariant'
+import * as React from 'react'
 import checkDecoratorArguments from './utils/checkDecoratorArguments'
 import { DragDropManager, Unsubscribe } from 'dnd-core'
 import { DragLayerCollector, DndOptions, DndComponentClass } from './interfaces'
 import { Consumer } from './DragDropContext'
-import shallowEqual from 'shallowequal'
+const hoistStatics = require('hoist-non-react-statics')
+const isPlainObject = require('lodash/isPlainObject')
+const invariant = require('invariant')
+const shallowEqual = require('shallowequal')
 
 export default function DragLayer<
 	P,

--- a/packages/react-dnd/src/DragSource.ts
+++ b/packages/react-dnd/src/DragSource.ts
@@ -1,13 +1,10 @@
-import React, { Component, ComponentClass, StatelessComponent } from 'react'
-import invariant from 'invariant'
-import isPlainObject from 'lodash/isPlainObject'
-import { Backend, SourceType } from 'dnd-core'
+import * as React from 'react'
+import { SourceType } from 'dnd-core'
 import {
 	DragSourceSpec,
 	DragSourceCollector,
 	DndOptions,
 	DndComponentClass,
-	DragSourceMonitor,
 } from './interfaces'
 import checkDecoratorArguments from './utils/checkDecoratorArguments'
 import decorateHandler from './decorateHandler'
@@ -16,6 +13,8 @@ import createSourceFactory from './createSourceFactory'
 import createSourceMonitor from './createSourceMonitor'
 import createSourceConnector from './createSourceConnector'
 import isValidType from './utils/isValidType'
+const invariant = require('invariant')
+const isPlainObject = require('lodash/isPlainObject')
 
 /**
  * Decorates a component as a dragsource

--- a/packages/react-dnd/src/DropTarget.ts
+++ b/packages/react-dnd/src/DropTarget.ts
@@ -1,13 +1,10 @@
-import React, { StatelessComponent, Component, ComponentClass } from 'react'
-import invariant from 'invariant'
-import isPlainObject from 'lodash/isPlainObject'
-import { Backend, Identifier, DragDropMonitor, TargetType } from 'dnd-core'
+import * as React from 'react'
+import { TargetType } from 'dnd-core'
 import {
 	DropTargetSpec,
 	DndOptions,
 	DropTargetCollector,
 	DndComponentClass,
-	DropTargetMonitor,
 } from './interfaces'
 import checkDecoratorArguments from './utils/checkDecoratorArguments'
 import decorateHandler from './decorateHandler'
@@ -16,6 +13,8 @@ import createTargetFactory from './createTargetFactory'
 import createTargetMonitor from './createTargetMonitor'
 import createTargetConnector from './createTargetConnector'
 import isValidType from './utils/isValidType'
+const invariant = require('invariant')
+const isPlainObject = require('lodash/isPlainObject')
 
 export default function DropTarget<
 	P,

--- a/packages/react-dnd/src/createSourceConnector.ts
+++ b/packages/react-dnd/src/createSourceConnector.ts
@@ -1,6 +1,6 @@
 import wrapConnectorHooks from './wrapConnectorHooks'
 import { Backend, Unsubscribe } from 'dnd-core'
-import shallowEqual from 'shallowequal'
+const shallowEqual = require('shallowequal')
 
 export default function createSourceConnector(backend: Backend) {
 	let currentHandlerId: string

--- a/packages/react-dnd/src/createSourceFactory.ts
+++ b/packages/react-dnd/src/createSourceFactory.ts
@@ -1,8 +1,7 @@
-import invariant from 'invariant'
-import isPlainObject from 'lodash/isPlainObject'
 import { DragSource, DragDropMonitor } from 'dnd-core'
 import { DragSourceSpec, DragSourceMonitor } from './interfaces'
-import { ComponentClass } from 'react'
+const invariant = require('invariant')
+const isPlainObject = require('lodash/isPlainObject')
 
 const ALLOWED_SPEC_METHODS = ['canDrag', 'beginDrag', 'isDragging', 'endDrag']
 const REQUIRED_SPEC_METHODS = ['beginDrag']

--- a/packages/react-dnd/src/createSourceMonitor.ts
+++ b/packages/react-dnd/src/createSourceMonitor.ts
@@ -1,14 +1,11 @@
-import invariant from 'invariant'
 import {
 	DragDropManager,
 	DragDropMonitor,
 	Unsubscribe,
 	Listener,
-	XYCoord,
-	Identifier,
-	DragSource,
 } from 'dnd-core'
 import { DragSourceMonitor } from './interfaces'
+const invariant = require('invariant')
 
 let isCallingCanDrag = false
 let isCallingIsDragging = false

--- a/packages/react-dnd/src/createTargetConnector.ts
+++ b/packages/react-dnd/src/createTargetConnector.ts
@@ -1,6 +1,6 @@
 import wrapConnectorHooks from './wrapConnectorHooks'
 import { Backend, Unsubscribe } from 'dnd-core'
-import shallowEqual from 'shallowequal'
+const shallowEqual = require('shallowequal')
 
 export default function createTargetConnector(backend: Backend) {
 	let currentHandlerId: string

--- a/packages/react-dnd/src/createTargetFactory.ts
+++ b/packages/react-dnd/src/createTargetFactory.ts
@@ -1,8 +1,7 @@
-import invariant from 'invariant'
-import isPlainObject from 'lodash/isPlainObject'
-import { DragDropMonitor, DropTarget } from 'dnd-core'
-import { MemoVoidArrayIterator } from 'lodash'
+import { DropTarget } from 'dnd-core'
 import { DropTargetSpec, DropTargetMonitor } from './interfaces'
+const invariant = require('invariant')
+const isPlainObject = require('lodash/isPlainObject')
 
 const ALLOWED_SPEC_METHODS = ['canDrop', 'hover', 'drop']
 

--- a/packages/react-dnd/src/createTargetMonitor.ts
+++ b/packages/react-dnd/src/createTargetMonitor.ts
@@ -1,12 +1,6 @@
-import invariant from 'invariant'
-import {
-	Identifier,
-	DragDropManager,
-	DragDropMonitor,
-	XYCoord,
-	DropTarget,
-} from 'dnd-core'
+import { DragDropManager, DragDropMonitor } from 'dnd-core'
 import { DropTargetMonitor } from './interfaces'
+const invariant = require('invariant')
 
 let isCallingCanDrop = false
 

--- a/packages/react-dnd/src/decorateHandler.tsx
+++ b/packages/react-dnd/src/decorateHandler.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react'
-import isPlainObject from 'lodash/isPlainObject'
-import invariant from 'invariant'
-import hoistStatics from 'hoist-non-react-statics'
 import { DragDropManager, Identifier } from 'dnd-core'
 import { DndComponentClass, DndComponent } from './interfaces'
 import { Consumer } from './DragDropContext'
-import shallowEqual from 'shallowequal'
 import {
 	Disposable,
 	CompositeDisposable,
 	SerialDisposable,
 } from './utils/disposables'
+const isPlainObject = require('lodash/isPlainObject')
+const invariant = require('invariant')
+const hoistStatics = require('hoist-non-react-statics')
+const shallowEqual = require('shallowequal')
 
 export interface DecorateHandlerArgs<
 	P,

--- a/packages/react-dnd/src/interfaces.ts
+++ b/packages/react-dnd/src/interfaces.ts
@@ -1,4 +1,4 @@
-import React, { StatelessComponent } from 'react'
+import * as React from 'react'
 import { XYCoord, DragDropMonitor, Identifier, DragDropManager } from 'dnd-core'
 
 export { XYCoord }

--- a/packages/react-dnd/src/utils/cloneWithRef.ts
+++ b/packages/react-dnd/src/utils/cloneWithRef.ts
@@ -1,5 +1,5 @@
-import invariant from 'invariant'
 import { cloneElement } from 'react'
+const invariant = require('invariant')
 
 export default function cloneWithRef(
 	element: any,

--- a/packages/react-dnd/src/utils/disposables/Disposable.ts
+++ b/packages/react-dnd/src/utils/disposables/Disposable.ts
@@ -1,6 +1,5 @@
-// tslint:disable max-classes-per-file
-import isFunction from 'lodash/isFunction'
-import noop from 'lodash/noop'
+const isFunction = require('lodash/isFunction')
+const noop = require('lodash/noop')
 
 /**
  * Provides a set of static methods for creating Disposables.

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,8 +4,8 @@
 		"module": "commonjs",
 		"lib": ["esnext", "dom"],
 		"strict": true,
-		"esModuleInterop": true,
 		"experimentalDecorators": true,
+		"noUnusedLocals": true ,
 		"jsx": "react"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,25 +37,17 @@
   dependencies:
     immutability-helper "*"
 
-"@types/invariant@^2.2.29":
-  version "2.2.29"
-  resolved "https://registry.yarnpkg.com/@types/invariant/-/invariant-2.2.29.tgz#aa845204cd0a289f65d47e0de63a6a815e30cc66"
-
 "@types/jest@^22.2.3":
   version "22.2.3"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-22.2.3.tgz#0157c0316dc3722c43a7b71de3fdf3acbccef10d"
-
-"@types/lodash@^4.14.109":
-  version "4.14.109"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.109.tgz#b1c4442239730bf35cabaf493c772b18c045886d"
 
 "@types/node@*":
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.1.2.tgz#1b928a0baa408fc8ae3ac012cc81375addc147c6"
 
-"@types/node@^10.3.0":
-  version "10.3.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.0.tgz#078516315a84d56216b5d4fed8f75d59d3b16cac"
+"@types/node@10.3.2":
+  version "10.3.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.2.tgz#3840ec6c12556fdda6e0e6d036df853101d732a4"
 
 "@types/react-dom@^16.0.5":
   version "16.0.5"


### PR DESCRIPTION
* The esModuleInterop flag is more appropriate for client applications than libraries. Since the target module system is `commonjs`, the transplied code will all just thunk to require() anyway. This should reduce bundle sizes quite a bit by removing unnecessary boilerplate that was generated per module.

* Turn on "noUnusedLocals" to check for unused imports and functions.

* Remove `@types/lodash` and `@types/invariant`, which were kind of useless.

* Moving `@types/*` dependencies on into devDependencies.

Fixes #1075, #1070 