### PR TITLE
HTML5Backend: support passing data to dataTransfer.setData via DragSource beginDrag

### DIFF
--- a/packages/react-dnd-html5-backend/src/HTML5Backend.ts
+++ b/packages/react-dnd-html5-backend/src/HTML5Backend.ts
@@ -431,8 +431,15 @@ export default class HTML5Backend implements Backend {
 			}
 
 			try {
-				// Firefox won't drag without setting data
-				dataTransfer.setData('application/json', {})
+				const { dataItems } = this.monitor.getItem()
+				if (dataItems && typeof dataItems === 'object') {
+					Object.keys(dataItems).forEach(k =>
+						dataTransfer.setData(k, dataItems[k]),
+					)
+				} else {
+					// Firefox won't drag without setting data
+					dataTransfer.setData('application/json', {})
+				}
 			} catch (err) {
 				// IE doesn't support MIME types in setData
 			}


### PR DESCRIPTION
I guess this one is very similar to #681 in a sense that it enables a DragSource spec to pass additional Data to the backend that will be assigned to the underlying dataTransfer using `setData`. This PR is a somewhat initial, naive approach I guess but I'd be more than happy to start a discussion and do further work/refinements if this is a desired feature that could be useful for others.

The use-cases that I'm facing is that this way a browser hosted UI/App can interact with other applications and share data that goes beyond the borders of the current Document. In order to set the data one would include a `dataItems` props with `[mimeType]: "value"` pairs from within beginDrag of a DragSource spec.

As mentioned earlier the main difference is that this uses beginDrag instead of supplying the additional data as an option to connectDragSource as done in #681.