### PR TITLE
Remove react-dnd dependency from the backends

### DIFF
--- a/packages/react-dnd-html5-backend/package.json
+++ b/packages/react-dnd-html5-backend/package.json
@@ -31,7 +31,6 @@
 		"@types/shallowequal": "^0.2.2",
 		"npm-run-all": "^4.1.2",
 		"react": "^16.4.0",
-		"react-dnd": "^5.0.0",
 		"react-dnd-test-backend": "^4.0.5",
 		"rimraf": "^2.6.2",
 		"ts-loader": "^4.2.0",

--- a/packages/react-dnd-test-backend/package.json
+++ b/packages/react-dnd-test-backend/package.json
@@ -18,9 +18,6 @@
 		"dnd-core": "^4.0.5",
 		"lodash": "^4.17.10"
 	},
-	"peerDependencies": {
-		"react": ">= 16.3"
-	},
 	"devDependencies": {
 		"@types/node": "10.3.2",
 		"npm-run-all": "^4.1.2",


### PR DESCRIPTION
By removing it as a devDependency, the html5backend won't churn on releases as often as react-dnd. Also removing it as a peer from testbackend.