### PR TITLE
Remove duplicate content in tutorial example page

### DIFF
--- a/packages/documentation-examples/src/00 Chessboard/index.tsx
+++ b/packages/documentation-examples/src/00 Chessboard/index.tsx
@@ -29,36 +29,14 @@ export default class ChessboardTutorialApp extends React.Component<
 	public render() {
 		const { knightPosition } = this.state
 		return (
-			<div>
-				<p>
-					<b>
-						<a href="https://github.com/react-dnd/react-dnd/tree/master/packages/documentation-examples/src/00%20Chessboard/">
-							Browse the Source
-						</a>
-					</b>
-				</p>
-				<p>
-					This is a sample app you&apos;ll build as you work through the{' '}
-					<a href="/docs/tutorial">tutorial</a>.
-				</p>
-				<p>
-					It illustrates creating the drag sources and the drop targets, using
-					the monitors to query the current drag state, and customizing the drag
-					previews.
-				</p>
-				<div
-					style={{
-						width: 500,
-						height: 500,
-						border: '1px solid gray',
-					}}
-				>
-					<Board knightPosition={knightPosition} />
-				</div>
-				<p>
-					Make sure to check out the <a href="/docs/tutorial">tutorial</a> for
-					step-by-step instructions on building it!
-				</p>
+			<div
+				style={{
+					width: 500,
+					height: 500,
+					border: '1px solid gray',
+				}}
+			>
+				<Board knightPosition={knightPosition} />
 			</div>
 		)
 	}


### PR DESCRIPTION
Hey, 

I was reading the documentation this week and noticed some duplicate content on the tutorial example page : http://react-dnd.github.io/react-dnd/examples/tutorial (the links in the duplicate content are also broken)

![duplicate_tutorial_content](https://user-images.githubusercontent.com/3253522/48658900-9221c900-ea49-11e8-887a-6124400beb29.jpg)

I have in this commit removed the extra stuff from `documentation-examples\src\00 Chessboard\index.tsx` which seems to be the expected way to correct this.

Thanks for the cool lib!