### PR TITLE
Fixed the typo in functional component example link

### DIFF
--- a/packages/documentation/markdown/examples/dustbin/using-fcs.md
+++ b/packages/documentation/markdown/examples/dustbin/using-fcs.md
@@ -3,7 +3,7 @@ path: "/examples/dustbin/using-fcs"
 title: "Using FCs"
 ---
 
-[Browse the Source](https://github.com/react-dnd/react-dnd/tree/master/packages/documentation-examples/src/01%20Dustbin/Single%20Target%20with%20SCs)
+[Browse the Source](https://github.com/react-dnd/react-dnd/tree/master/packages/documentation-examples/src/01%20Dustbin/Single%20Target%20with%20FCs)
 
 This is the same simple example, but written using React Function Components.
 


### PR DESCRIPTION
The functional component link was broken due to typo.