### PR TITLE
fix: #980 added MIT license to inner packages

### DIFF
--- a/packages/dnd-core/package.json
+++ b/packages/dnd-core/package.json
@@ -2,7 +2,7 @@
 	"name": "dnd-core",
 	"version": "7.0.1",
 	"description": "Drag and drop sans the GUI",
-	"license": "BSD-3-Clause",
+	"license": "MIT",
 	"main": "./lib/index.js",
 	"types": "./lib/index.d.ts",
 	"scripts": {

--- a/packages/documentation-examples/package.json
+++ b/packages/documentation-examples/package.json
@@ -9,7 +9,7 @@
 		"type": "git",
 		"url": "https://github.com/react-dnd/react-dnd.git"
 	},
-	"license": "BSD-3-Clause",
+	"license": "MIT",
 	"scripts": {
 		"clean": "rimraf lib",
 		"build": "tsc",

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -3,6 +3,7 @@
   "description": "React DnD Docsite",
   "version": "7.0.1",
   "private": true,
+  "license": "MIT",
   "dependencies": {
     "@types/query-string": "^6.1.1",
     "@types/react": "^16.4.18",

--- a/packages/react-dnd-html5-backend/package.json
+++ b/packages/react-dnd-html5-backend/package.json
@@ -4,7 +4,7 @@
 	"description": "HTML5 backend for React DnD",
 	"main": "lib/index.js",
 	"types": "lib/index.d.ts",
-	"license": "BSD-3-Clause",
+	"license": "MIT",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/react-dnd/react-dnd.git"

--- a/packages/react-dnd-test-backend/package.json
+++ b/packages/react-dnd-test-backend/package.json
@@ -4,6 +4,7 @@
 	"description": "A mock backend for testing React DnD apps",
 	"main": "lib/index.js",
 	"types": "lib/index.d.ts",
+	"license": "MIT",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/react-dnd/react-dnd.git"

--- a/packages/react-dnd/package.json
+++ b/packages/react-dnd/package.json
@@ -8,7 +8,7 @@
 		"type": "git",
 		"url": "https://github.com/react-dnd/react-dnd.git"
 	},
-	"license": "BSD-3-Clause",
+	"license": "MIT",
 	"scripts": {
 		"clean": "rimraf lib dist",
 		"bundle:unmin": "webpack --mode development --output-filename=ReactDnD.js",


### PR DESCRIPTION
We have license files inside packages which are MIT license. But the license inside package.json was `BSD-3`. So changed the `BSD-3` to `MIT` where applicable to remove confusion, and added `MIT` license to packages without any license. @darthtrevino please let me know if the package.json had `BSD-3` for some particular reason.