### PR TITLE
targetId undefined on initial render being passed to parseRoleFromHandlerId 

### DIFF
--- a/packages/dnd-core/src/DragDropMonitorImpl.ts
+++ b/packages/dnd-core/src/DragDropMonitorImpl.ts
@@ -125,7 +125,15 @@ export default class DragDropMonitorImpl implements DragDropMonitor {
 		return source.isDragging(this, sourceId)
 	}
 
-	public isOverTarget(targetId: string, options = { shallow: false }) {
+	public isOverTarget(
+		targetId: string | undefined,
+		options = { shallow: false },
+	) {
+		// undefined on initial render
+		if (!targetId) {
+			return false
+		}
+
 		const { shallow } = options
 		if (!this.isDragging()) {
 			return false


### PR DESCRIPTION
fixes: #1245 

In a previous change set targetId/sourceId was changed so that it could
be passed undefined to internal functions. Not all functions were
changed to check for this change causing parseRoleFromHandlerId to
reference an undefined variable.

Signed-off-by: Chris Frank <cfrank@redventures.com>