### PR TITLE
Check for uninitialized source/target ID parameters in the DragDropMonitor

### DIFF
--- a/packages/dnd-core/src/DragDropMonitorImpl.ts
+++ b/packages/dnd-core/src/DragDropMonitorImpl.ts
@@ -125,7 +125,15 @@ export default class DragDropMonitorImpl implements DragDropMonitor {
 		return source.isDragging(this, sourceId)
 	}
 
-	public isOverTarget(targetId: string, options = { shallow: false }) {
+	public isOverTarget(
+		targetId: string | undefined,
+		options = { shallow: false },
+	) {
+		// undefined on initial render
+		if (!targetId) {
+			return false
+		}
+
 		const { shallow } = options
 		if (!this.isDragging()) {
 			return false

--- a/packages/dnd-core/src/DragDropMonitorImpl.ts
+++ b/packages/dnd-core/src/DragDropMonitorImpl.ts
@@ -70,7 +70,10 @@ export default class DragDropMonitorImpl implements DragDropMonitor {
 		return this.store.subscribe(handleChange)
 	}
 
-	public canDragSource(sourceId: string): boolean {
+	public canDragSource(sourceId: string | undefined): boolean {
+		if (!sourceId) {
+			return false
+		}
 		const source = this.registry.getSource(sourceId)
 		invariant(source, 'Expected to find a valid source.')
 

--- a/packages/dnd-core/src/interfaces.ts
+++ b/packages/dnd-core/src/interfaces.ts
@@ -32,8 +32,8 @@ export interface DragDropMonitor {
 		},
 	): Unsubscribe
 	subscribeToOffsetChange(listener: Listener): Unsubscribe
-	canDragSource(sourceId: string): boolean
-	canDropOnTarget(targetId: string): boolean
+	canDragSource(sourceId: string | undefined): boolean
+	canDropOnTarget(targetId: string | undefined): boolean
 
 	/**
 	 * Returns true if a drag operation is in progress, and either the owner initiated the drag, or its isDragging()


### PR DESCRIPTION
Modified #1248 

modifications:
* Update the interface to match the impl
* Update the canDragSource method to match