### PR TITLE
Enable syntheticDefaultImports in TypeScript examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,11 @@
 		"transform": {
 			"^.+\\.(ts|tsx)$": "ts-jest"
 		},
+		"globals": {
+			"ts-jest": {
+				"tsConfig": "tsconfig.jest.json"
+			}
+		},
 		"moduleNameMapper": {
 			"^react-dnd$": "<rootDir>/packages/react-dnd/src",
 			"react-dnd-html5-backend": "<rootDir>//packages/react-dnd-html5-backend/src",

--- a/packages/documentation-examples/src/00 Chessboard/Board.tsx
+++ b/packages/documentation-examples/src/00 Chessboard/Board.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { BoardSquare } from './BoardSquare'
 import { Knight } from './Knight'
 

--- a/packages/documentation-examples/src/00 Chessboard/BoardSquare.tsx
+++ b/packages/documentation-examples/src/00 Chessboard/BoardSquare.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React, { useRef } from 'react'
 import { useDropTarget } from 'react-dnd'
 import { Square } from './Square'
 import { canMoveKnight, moveKnight } from './Game'
@@ -14,7 +14,7 @@ export interface BoardSquareProps {
 export const BoardSquare: React.FC<BoardSquareProps> = (
 	props: BoardSquareProps,
 ) => {
-	const ref = React.useRef(null)
+	const ref = useRef(null)
 	const { isOver, canDrop } = useDropTarget(ref, ItemTypes.KNIGHT, {
 		canDrop: () => canMoveKnight(props.x, props.y),
 		drop: () => moveKnight(props.x, props.y),

--- a/packages/documentation-examples/src/00 Chessboard/Knight.tsx
+++ b/packages/documentation-examples/src/00 Chessboard/Knight.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React, { useRef, useMemo } from 'react'
 import { useDragSource } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 import knightImage from './knightImage'
@@ -19,8 +19,8 @@ function createKnightImage() {
 }
 
 export const Knight: React.FC = () => {
-	const ref = React.useRef(null)
-	const dragPreview = React.useMemo(createKnightImage, [])
+	const ref = useRef(null)
+	const dragPreview = useMemo(createKnightImage, [])
 	const { isDragging } = useDragSource(ref, ItemTypes.KNIGHT, {
 		beginDrag: () => ({}),
 		dragPreview,

--- a/packages/documentation-examples/src/00 Chessboard/Overlay.tsx
+++ b/packages/documentation-examples/src/00 Chessboard/Overlay.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 export interface OverlayProps {
 	color: string

--- a/packages/documentation-examples/src/00 Chessboard/Square.tsx
+++ b/packages/documentation-examples/src/00 Chessboard/Square.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 export interface SquareProps {
 	black: boolean

--- a/packages/documentation-examples/src/00 Chessboard/index.tsx
+++ b/packages/documentation-examples/src/00 Chessboard/index.tsx
@@ -1,5 +1,4 @@
-// tslint:disable member-ordering
-import * as React from 'react'
+import React, { useEffect, useState } from 'react'
 import Board from './Board'
 import { observe } from './Game'
 
@@ -7,23 +6,22 @@ export interface ChessboardTutorialAppState {
 	knightPosition: [number, number]
 }
 
+const containerStyle: React.CSSProperties = {
+	width: 500,
+	height: 500,
+	border: '1px solid gray',
+}
+
 /**
- * Unlike the tutorial, export a component so it can be used on the website.
+ * The Chessboard Tutorial Application
  */
 const ChessboardTutorialApp: React.FC = () => {
-	const [knightPos, setKnightPos] = React.useState<[number, number]>([1, 7])
+	const [knightPos, setKnightPos] = useState<[number, number]>([1, 7])
 
-	React.useEffect(() =>
-		observe((newPos: [number, number]) => setKnightPos(newPos)),
-	)
+	// the observe function will return an unsubscribe callback
+	useEffect(() => observe((newPos: [number, number]) => setKnightPos(newPos)))
 	return (
-		<div
-			style={{
-				width: 500,
-				height: 500,
-				border: '1px solid gray',
-			}}
-		>
+		<div style={containerStyle}>
 			<Board knightPosition={knightPos} />
 		</div>
 	)

--- a/packages/documentation-examples/src/01 Dustbin/Copy or Move/Box.tsx
+++ b/packages/documentation-examples/src/01 Dustbin/Copy or Move/Box.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import {
 	DragSource,
 	ConnectDragSource,

--- a/packages/documentation-examples/src/01 Dustbin/Copy or Move/Dustbin.tsx
+++ b/packages/documentation-examples/src/01 Dustbin/Copy or Move/Dustbin.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { DropTarget, ConnectDropTarget } from 'react-dnd'
 import ItemTypes from '../Single Target/ItemTypes'
 

--- a/packages/documentation-examples/src/01 Dustbin/Copy or Move/index.tsx
+++ b/packages/documentation-examples/src/01 Dustbin/Copy or Move/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import Dustbin from './Dustbin'
 import Box from './Box'
 

--- a/packages/documentation-examples/src/01 Dustbin/Multiple Targets/Box.tsx
+++ b/packages/documentation-examples/src/01 Dustbin/Multiple Targets/Box.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import {
 	DragSource,
 	ConnectDragSource,

--- a/packages/documentation-examples/src/01 Dustbin/Multiple Targets/Dustbin.tsx
+++ b/packages/documentation-examples/src/01 Dustbin/Multiple Targets/Dustbin.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { DropTarget, ConnectDropTarget, DropTargetMonitor } from 'react-dnd'
 
 const style: React.CSSProperties = {

--- a/packages/documentation-examples/src/01 Dustbin/Multiple Targets/index.tsx
+++ b/packages/documentation-examples/src/01 Dustbin/Multiple Targets/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { NativeTypes } from 'react-dnd-html5-backend'
 import Dustbin from './Dustbin'
 import Box from './Box'

--- a/packages/documentation-examples/src/01 Dustbin/Single Target in iframe/index.tsx
+++ b/packages/documentation-examples/src/01 Dustbin/Single Target in iframe/index.tsx
@@ -1,6 +1,6 @@
 declare var require: any
 
-import * as React from 'react'
+import React from 'react'
 import { DragDropContextProvider } from 'react-dnd'
 import HTML5Backend from 'react-dnd-html5-backend'
 import Dustbin from '../Single Target/Dustbin'

--- a/packages/documentation-examples/src/01 Dustbin/Single Target with FCs/Box.tsx
+++ b/packages/documentation-examples/src/01 Dustbin/Single Target with FCs/Box.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import {
 	ConnectDragSource,
 	DragSource,

--- a/packages/documentation-examples/src/01 Dustbin/Single Target with FCs/Dustbin.tsx
+++ b/packages/documentation-examples/src/01 Dustbin/Single Target with FCs/Dustbin.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import {
 	DropTarget,
 	DropTargetConnector,

--- a/packages/documentation-examples/src/01 Dustbin/Single Target with FCs/index.tsx
+++ b/packages/documentation-examples/src/01 Dustbin/Single Target with FCs/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import Dustbin from './Dustbin'
 import Box from './Box'
 

--- a/packages/documentation-examples/src/01 Dustbin/Single Target/Box.tsx
+++ b/packages/documentation-examples/src/01 Dustbin/Single Target/Box.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import {
 	ConnectDragSource,
 	DragSource,

--- a/packages/documentation-examples/src/01 Dustbin/Single Target/Dustbin.tsx
+++ b/packages/documentation-examples/src/01 Dustbin/Single Target/Dustbin.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import {
 	DropTarget,
 	DropTargetConnector,

--- a/packages/documentation-examples/src/01 Dustbin/Single Target/__tests__/Box.spec.tsx
+++ b/packages/documentation-examples/src/01 Dustbin/Single Target/__tests__/Box.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import * as TestUtils from 'react-dom/test-utils'
 import wrapInTestContext from '../../../shared/wrapInTestContext'
 import Box from '../Box'

--- a/packages/documentation-examples/src/01 Dustbin/Single Target/__tests__/Box.spec.tsx
+++ b/packages/documentation-examples/src/01 Dustbin/Single Target/__tests__/Box.spec.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import * as TestUtils from 'react-dom/test-utils'
 import wrapInTestContext from '../../../shared/wrapInTestContext'
 import Box from '../Box'

--- a/packages/documentation-examples/src/01 Dustbin/Single Target/__tests__/integration.spec.tsx
+++ b/packages/documentation-examples/src/01 Dustbin/Single Target/__tests__/integration.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import * as TestUtils from 'react-dom/test-utils'
 import wrapInTestContext from '../../../shared/wrapInTestContext'
 import Box from '../Box'

--- a/packages/documentation-examples/src/01 Dustbin/Single Target/__tests__/integration.spec.tsx
+++ b/packages/documentation-examples/src/01 Dustbin/Single Target/__tests__/integration.spec.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import * as TestUtils from 'react-dom/test-utils'
 import wrapInTestContext from '../../../shared/wrapInTestContext'
 import Box from '../Box'

--- a/packages/documentation-examples/src/01 Dustbin/Single Target/index.tsx
+++ b/packages/documentation-examples/src/01 Dustbin/Single Target/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import Dustbin from './Dustbin'
 import Box from './Box'
 

--- a/packages/documentation-examples/src/01 Dustbin/Stress Test/Box.tsx
+++ b/packages/documentation-examples/src/01 Dustbin/Stress Test/Box.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import {
 	DragSource,
 	DragSourceConnector,

--- a/packages/documentation-examples/src/01 Dustbin/Stress Test/Dustbin.tsx
+++ b/packages/documentation-examples/src/01 Dustbin/Stress Test/Dustbin.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import {
 	ConnectDropTarget,
 	DropTarget,

--- a/packages/documentation-examples/src/01 Dustbin/Stress Test/index.tsx
+++ b/packages/documentation-examples/src/01 Dustbin/Stress Test/index.tsx
@@ -1,6 +1,6 @@
 // tslint:disable jsx-no-lambda
 declare var require: any
-import * as React from 'react'
+import React from 'react'
 import { NativeTypes } from 'react-dnd-html5-backend'
 import Dustbin from './Dustbin'
 import Box from './Box'

--- a/packages/documentation-examples/src/02 Drag Around/Custom Drag Layer/Box.tsx
+++ b/packages/documentation-examples/src/02 Drag Around/Custom Drag Layer/Box.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 const styles: React.CSSProperties = {
 	border: '1px dashed gray',

--- a/packages/documentation-examples/src/02 Drag Around/Custom Drag Layer/BoxDragPreview.tsx
+++ b/packages/documentation-examples/src/02 Drag Around/Custom Drag Layer/BoxDragPreview.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React, { useState, useEffect } from 'react'
 import Box from './Box'
 
 const styles = {
@@ -16,9 +16,9 @@ export interface BoxDragPreviewState {
 }
 
 const BoxDragPreview: React.FC<BoxDragPreviewProps> = ({ title }) => {
-	const [tickTock, setTickTock] = React.useState(false)
+	const [tickTock, setTickTock] = useState(false)
 
-	React.useEffect(function subscribeToIntervalTick() {
+	useEffect(function subscribeToIntervalTick() {
 		const interval = setInterval(() => setTickTock(!tickTock), 500)
 		return () => clearInterval(interval)
 	})

--- a/packages/documentation-examples/src/02 Drag Around/Custom Drag Layer/Container.tsx
+++ b/packages/documentation-examples/src/02 Drag Around/Custom Drag Layer/Container.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React, { useState, useRef } from 'react'
 import { useDropTarget, DropTargetMonitor } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 import DraggableBox from './DraggableBox'
@@ -25,7 +25,7 @@ function renderBox(item: any, key: any) {
 }
 
 const Container: React.FC<ContainerProps> = props => {
-	const [boxes, setBoxes] = React.useState<BoxMap>({
+	const [boxes, setBoxes] = useState<BoxMap>({
 		a: { top: 20, left: 80, title: 'Drag me around' },
 		b: { top: 180, left: 20, title: 'Drag me too' },
 	})
@@ -40,7 +40,7 @@ const Container: React.FC<ContainerProps> = props => {
 		)
 	}
 
-	const ref = React.useRef(null)
+	const ref = useRef(null)
 	useDropTarget(ref, ItemTypes.BOX, {
 		drop(monitor: DropTargetMonitor) {
 			const delta = monitor.getDifferenceFromInitialOffset() as {

--- a/packages/documentation-examples/src/02 Drag Around/Custom Drag Layer/CustomDragLayer.tsx
+++ b/packages/documentation-examples/src/02 Drag Around/Custom Drag Layer/CustomDragLayer.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { XYCoord, useDragLayer } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 import BoxDragPreview from './BoxDragPreview'

--- a/packages/documentation-examples/src/02 Drag Around/Custom Drag Layer/DraggableBox.tsx
+++ b/packages/documentation-examples/src/02 Drag Around/Custom Drag Layer/DraggableBox.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { DragSource, ConnectDragSource, ConnectDragPreview } from 'react-dnd'
 import { getEmptyImage } from 'react-dnd-html5-backend'
 import ItemTypes from './ItemTypes'

--- a/packages/documentation-examples/src/02 Drag Around/Custom Drag Layer/index.tsx
+++ b/packages/documentation-examples/src/02 Drag Around/Custom Drag Layer/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import Container from './Container'
 import CustomDragLayer from './CustomDragLayer'
 

--- a/packages/documentation-examples/src/02 Drag Around/Naive/Box.tsx
+++ b/packages/documentation-examples/src/02 Drag Around/Naive/Box.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { DragSource, ConnectDragSource } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 

--- a/packages/documentation-examples/src/02 Drag Around/Naive/Container.tsx
+++ b/packages/documentation-examples/src/02 Drag Around/Naive/Container.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import {
 	DropTarget,
 	ConnectDropTarget,

--- a/packages/documentation-examples/src/02 Drag Around/Naive/index.tsx
+++ b/packages/documentation-examples/src/02 Drag Around/Naive/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import Container from './Container'
 
 export interface DragAroundNaiveState {

--- a/packages/documentation-examples/src/03 Nesting/Drag Sources/SourceBox.tsx
+++ b/packages/documentation-examples/src/03 Nesting/Drag Sources/SourceBox.tsx
@@ -1,5 +1,5 @@
 // tslint:disable max-classes-per-file jsx-no-lambda
-import * as React from 'react'
+import React from 'react'
 import {
 	DragSource,
 	ConnectDragSource,

--- a/packages/documentation-examples/src/03 Nesting/Drag Sources/TargetBox.tsx
+++ b/packages/documentation-examples/src/03 Nesting/Drag Sources/TargetBox.tsx
@@ -1,5 +1,5 @@
 // tslint:disable max-classes-per-file
-import * as React from 'react'
+import React from 'react'
 import { DropTarget, ConnectDropTarget, DropTargetMonitor } from 'react-dnd'
 import Colors from './Colors'
 
@@ -58,8 +58,9 @@ class TargetBoxRaw extends React.Component<
 			<div style={{ ...style, backgroundColor, opacity }}>
 				<p>Drop here.</p>
 
-				{!canDrop &&
-					lastDroppedColor && <p>Last dropped: {lastDroppedColor}</p>}
+				{!canDrop && lastDroppedColor && (
+					<p>Last dropped: {lastDroppedColor}</p>
+				)}
 			</div>,
 		)
 	}

--- a/packages/documentation-examples/src/03 Nesting/Drag Sources/index.tsx
+++ b/packages/documentation-examples/src/03 Nesting/Drag Sources/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import SourceBox from './SourceBox'
 import TargetBox from './TargetBox'
 import Colors from './Colors'

--- a/packages/documentation-examples/src/03 Nesting/Drop Targets/Box.tsx
+++ b/packages/documentation-examples/src/03 Nesting/Drop Targets/Box.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { DragSource, ConnectDragSource } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 

--- a/packages/documentation-examples/src/03 Nesting/Drop Targets/Dustbin.tsx
+++ b/packages/documentation-examples/src/03 Nesting/Drop Targets/Dustbin.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { DropTarget, ConnectDropTarget, DropTargetMonitor } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 

--- a/packages/documentation-examples/src/03 Nesting/Drop Targets/index.tsx
+++ b/packages/documentation-examples/src/03 Nesting/Drop Targets/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import Dustbin from './Dustbin'
 import Box from './Box'
 

--- a/packages/documentation-examples/src/04 Sortable/Cancel on Drop Outside/Card.tsx
+++ b/packages/documentation-examples/src/04 Sortable/Cancel on Drop Outside/Card.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import {
 	DragSource,
 	DropTarget,

--- a/packages/documentation-examples/src/04 Sortable/Cancel on Drop Outside/index.tsx
+++ b/packages/documentation-examples/src/04 Sortable/Cancel on Drop Outside/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { DropTarget, ConnectDropTarget } from 'react-dnd'
 import Card from './Card'
 import ItemTypes from './ItemTypes'

--- a/packages/documentation-examples/src/04 Sortable/Simple/Card.tsx
+++ b/packages/documentation-examples/src/04 Sortable/Simple/Card.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { findDOMNode } from 'react-dom'
 import {
 	DragSource,

--- a/packages/documentation-examples/src/04 Sortable/Simple/index.tsx
+++ b/packages/documentation-examples/src/04 Sortable/Simple/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import Card from './Card'
 import update from 'immutability-helper'
 

--- a/packages/documentation-examples/src/04 Sortable/Stress Test/Card.tsx
+++ b/packages/documentation-examples/src/04 Sortable/Stress Test/Card.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import {
 	DragSource,
 	DropTarget,

--- a/packages/documentation-examples/src/04 Sortable/Stress Test/Container.tsx
+++ b/packages/documentation-examples/src/04 Sortable/Stress Test/Container.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { name } from 'faker'
 import Card from './Card'
 import update from 'immutability-helper'

--- a/packages/documentation-examples/src/04 Sortable/Stress Test/index.tsx
+++ b/packages/documentation-examples/src/04 Sortable/Stress Test/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import Container from './Container'
 
 export interface SortableStressTestState {

--- a/packages/documentation-examples/src/05 Customize/Drop Effects/SourceBox.tsx
+++ b/packages/documentation-examples/src/05 Customize/Drop Effects/SourceBox.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { DragSource, ConnectDragSource } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 

--- a/packages/documentation-examples/src/05 Customize/Drop Effects/TargetBox.tsx
+++ b/packages/documentation-examples/src/05 Customize/Drop Effects/TargetBox.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { DropTarget, ConnectDropTarget } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 

--- a/packages/documentation-examples/src/05 Customize/Drop Effects/index.tsx
+++ b/packages/documentation-examples/src/05 Customize/Drop Effects/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import SourceBox from './SourceBox'
 import TargetBox from './TargetBox'
 

--- a/packages/documentation-examples/src/05 Customize/Handles and Previews/BoxWithHandle.tsx
+++ b/packages/documentation-examples/src/05 Customize/Handles and Previews/BoxWithHandle.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { DragSource, ConnectDragPreview, ConnectDragSource } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 

--- a/packages/documentation-examples/src/05 Customize/Handles and Previews/BoxWithImage.tsx
+++ b/packages/documentation-examples/src/05 Customize/Handles and Previews/BoxWithImage.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { DragSource, ConnectDragPreview, ConnectDragSource } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 import boxImage from './boxImage'

--- a/packages/documentation-examples/src/05 Customize/Handles and Previews/index.tsx
+++ b/packages/documentation-examples/src/05 Customize/Handles and Previews/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import BoxWithImage from './BoxWithImage'
 import BoxWithHandle from './BoxWithHandle'
 

--- a/packages/documentation-examples/src/06 Other/Native Files/FileList.tsx
+++ b/packages/documentation-examples/src/06 Other/Native Files/FileList.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 export interface FileListProps {
 	files: any[]

--- a/packages/documentation-examples/src/06 Other/Native Files/TargetBox.tsx
+++ b/packages/documentation-examples/src/06 Other/Native Files/TargetBox.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import {
 	DropTarget,
 	DropTargetConnector,

--- a/packages/documentation-examples/src/06 Other/Native Files/index.tsx
+++ b/packages/documentation-examples/src/06 Other/Native Files/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { DropTargetMonitor } from 'react-dnd'
 import { NativeTypes } from 'react-dnd-html5-backend'
 import TargetBox from './TargetBox'

--- a/packages/documentation-examples/src/index.ts
+++ b/packages/documentation-examples/src/index.ts
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import chessboard from './00 Chessboard'
 import dustbinCopyOrMove from './01 Dustbin/Copy or Move'
 import dustbinMultipleTargets from './01 Dustbin/Multiple Targets'

--- a/packages/documentation-examples/src/shared/wrapInTestContext.tsx
+++ b/packages/documentation-examples/src/shared/wrapInTestContext.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import TestBackend from 'react-dnd-test-backend'
 import { DragDropContext } from 'react-dnd'
 

--- a/packages/documentation-examples/tsconfig.cjs.json
+++ b/packages/documentation-examples/tsconfig.cjs.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.cjs.base.json",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
+		"esModuleInterop": true,
 		"outDir": "./lib/cjs",
 		"baseUrl": "./"
 	},

--- a/packages/documentation-examples/tsconfig.cjs.json
+++ b/packages/documentation-examples/tsconfig.cjs.json
@@ -1,6 +1,7 @@
 {
 	"extends": "../../tsconfig.cjs.base.json",
 	"compilerOptions": {
+		"allowSyntheticDefaultImports": true,
 		"outDir": "./lib/cjs",
 		"baseUrl": "./"
 	},

--- a/packages/documentation-examples/tsconfig.docs.json
+++ b/packages/documentation-examples/tsconfig.docs.json
@@ -1,6 +1,7 @@
 {
 	"extends": "./tsconfig.esm.json",
 	"compilerOptions": {
+		"allowSyntheticDefaultImports": true,
 		"jsx": "preserve",
 		"outDir": "./lib/docs",
 		"baseUrl": "./",

--- a/packages/documentation-examples/tsconfig.esm.json
+++ b/packages/documentation-examples/tsconfig.esm.json
@@ -1,6 +1,7 @@
 {
 	"extends": "../../tsconfig.esm.base.json",
 	"compilerOptions": {
+		"allowSyntheticDefaultImports": true,
 		"outDir": "./lib/esm",
 		"baseUrl": "./"
 	},

--- a/packages/documentation/src/components/layout.tsx
+++ b/packages/documentation/src/components/layout.tsx
@@ -5,7 +5,7 @@ import * as React from 'react'
 import Helmet from 'react-helmet'
 import styled from 'styled-components'
 import HTML5Backend from 'react-dnd-html5-backend'
-import { isDebugMode } from 'react-dnd-documentation-examples'
+import { isDebugMode } from 'react-dnd-documentation-examples/lib/esm/index'
 
 import { DragDropContextProvider } from 'react-dnd'
 import PageBody from './pagebody'

--- a/packages/documentation/src/util/renderHtmlAst.ts
+++ b/packages/documentation/src/util/renderHtmlAst.ts
@@ -1,6 +1,6 @@
 declare var require: any
 import { createElement } from 'react'
-import { componentIndex } from 'react-dnd-documentation-examples'
+import { componentIndex } from 'react-dnd-documentation-examples/lib/esm/index'
 import processImages from './processImagesInMarkdownAst'
 const log = require('debug')('site:renderHtmlAst')
 const rehypeReact = require('rehype-react')

--- a/packages/documentation/tsconfig.json
+++ b/packages/documentation/tsconfig.json
@@ -3,7 +3,8 @@
 	"compilerOptions": {
 		"outDir": "./lib",
 		"baseUrl": "./",
-		"allowSyntheticDefaultImports": true
+		"allowSyntheticDefaultImports": true,
+		"esModuleInterop": true
 	},
 	"include": ["./src/index.ts"]
 }

--- a/packages/documentation/tsconfig.json
+++ b/packages/documentation/tsconfig.json
@@ -3,6 +3,7 @@
 	"compilerOptions": {
 		"outDir": "./lib",
 		"baseUrl": "./",
+		"allowSyntheticDefaultImports": true
 	},
 	"include": ["./src/index.ts"]
 }

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"allowSyntheticDefaultImports": true,
+		"esModuleInterop": true,
+		"allowJs": true
+	}
+}


### PR DESCRIPTION
Turning this flag on will allow us to do a default import of react (e.g. `import React from 'react'`), this will allow us to create more idiomatic cross-language examples.