### PR TITLE
Hooks API Refactorings

### DIFF
--- a/packages/documentation/markdown/docs/05 Hooks-Based API/useDrag.md
+++ b/packages/documentation/markdown/docs/05 Hooks-Based API/useDrag.md
@@ -22,6 +22,14 @@ function myDraggable(props) {
 }
 ```
 
+### useDrag Parameters
+
+- **`spec`** Specification object, see below for details on how to construct this
+
+### Return Value
+
+useDrag returns an object of collected properties from the collect function. If this is not set, an empty object is returned.
+
 ### Specification Object Members
 
 - **`ref`**: Required. A ref object to use to attach to the draggable element.

--- a/packages/documentation/markdown/docs/05 Hooks-Based API/useDrag.md
+++ b/packages/documentation/markdown/docs/05 Hooks-Based API/useDrag.md
@@ -30,8 +30,8 @@ function myDraggable(props) {
 
 useDrag returns an array:
 
-0. An object containing collected properties from the collect function. If this is not set, an empty object is returned.
-1. The React ref to use. This is automatically created if no `ref` field is passed into the specification object.
+0. An object containing collected properties from the collect function. If no `collect` function is defined, an empty object is returned.
+1. The React ref to use. This is automatically created if no `ref` field is defined on the specification object.
 
 ### Specification Object Members
 

--- a/packages/documentation/markdown/docs/05 Hooks-Based API/useDrag.md
+++ b/packages/documentation/markdown/docs/05 Hooks-Based API/useDrag.md
@@ -26,7 +26,7 @@ function myDraggable(props) {
 
 - **`ref`**: Required. A ref object to use to attach to the draggable element.
 
-- **`preview`**: Optional. A ref object to use to attach to the dragPreview element.
+- **`preview`**: Optional. An HTML Element or a ref object attached to the dragPreview element.
 
 - **`previewOptions`**: Optional. A plain JavaScript object describing drag preview options.
 

--- a/packages/documentation/markdown/docs/05 Hooks-Based API/useDrag.md
+++ b/packages/documentation/markdown/docs/05 Hooks-Based API/useDrag.md
@@ -28,7 +28,10 @@ function myDraggable(props) {
 
 ### Return Value
 
-useDrag returns an object of collected properties from the collect function. If this is not set, an empty object is returned.
+useDrag returns an array:
+
+0. An object containing collected properties from the collect function. If this is not set, an empty object is returned.
+1. The React ref to use. This is automatically created if no `ref` field is passed into the specification object.
 
 ### Specification Object Members
 

--- a/packages/documentation/markdown/docs/05 Hooks-Based API/useDrag.md
+++ b/packages/documentation/markdown/docs/05 Hooks-Based API/useDrag.md
@@ -1,0 +1,47 @@
+---
+path: '/docs/api/use-drag'
+title: 'useDrag'
+---
+
+## EXPERIMENTAL API - UNSTABLE
+
+_New to React DnD? [Read the overview](/docs/overview) before jumping into the docs._
+
+# useDrag
+
+A hook to use the current component as a drag-source.
+
+```js
+import { __EXPERIMENTAL_DND_HOOKS_THAT_MAY_CHANGE_AND_BREAK_MY_BUILD__ } from 'react-dnd'
+const {
+	useDrag,
+} = __EXPERIMENTAL_DND_HOOKS_THAT_MAY_CHANGE_AND_BREAK_MY_BUILD__
+
+function myDraggable(props) {
+	const collectedProps = useDrag(spec)
+}
+```
+
+### Specification Object Members
+
+- **`ref`**: Required. A ref object to use to attach to the draggable element.
+
+- **`preview`**: Optional. A ref object to use to attach to the dragPreview element.
+
+- **`previewOptions`**: Optional. A plain JavaScript object describing drag preview options.
+
+- **`item`**: Required. A plain JavaScript object describing the data being dragged. This is the _only_ information available to the drop targets about the drag source so it's important to pick the _minimal_ data they need to know. You may be tempted to put a complex reference here, but you should try very hard to avoid doing this because it couples the drag sources and drop targets. It's a good idea to return something like `{ type, id }` from this method.
+
+- **`item.type`**: Required. Either a string, an ES6 symbol`. Only the [drop targets](/docs/api/drop-target) registered for the same type will react to the items produced by this drag source. Read the [overview](/docs/overview) to learn more about the items and types.
+
+- **`options`**: Optional. A plain object. If some of the props to your component are not scalar (that is, are not primitive values or functions), specifying a custom`arePropsEqual(props, otherProps)`function inside the`options` object can improve the performance. Unless you have performance problems, don't worry about it.
+
+- **`begin(monitor)`**: Optionaln. Fired when a drag operation begins.
+
+- **`end(monitor)`**: Optional. When the dragging stops, `end` is called. For every `begin` call, a corresponding `end` call is guaranteed. You may call `monitor.didDrop()` to check whether or not the drop was handled by a compatible drop target. If it was handled, and the drop target specified a _drop result_ by returning a plain object from its `drop()` method, it will be available as `monitor.getDropResult()`. This method is a good place to fire a Flux action. _Note: If the component is unmounted while dragging, `component` parameter is set to be `null`._
+
+- **`canDrag(monitor)`**: Optional. Use it to specify whether the dragging is currently allowed. If you want to always allow it, just omit this method. Specifying it is handy if you'd like to disable dragging based on some predicate over `props`. _Note: You may not call `monitor.canDrag()` inside this method._
+
+- **`isDragging(monitor)`**: Optional. By default, only the drag source that initiated the drag operation is considered to be dragging. You can override this behavior by defining a custom `isDragging` method. It might return something like `props.id === monitor.getItem().id`. Do this if the original component may be unmounted during the dragging and later “resurrected” with a different parent. For example, when moving a card across the lists in a Kanban board, you want it to retain the dragged appearance—even though technically, the component gets unmounted and a different one gets mounted every time you move it to another list. _Note: You may not call `monitor.isDragging()` inside this method._
+
+* **`collect`**: Optional. The collecting function. It should return a plain object of the props to return for injection into your component. It receives two parameters, `monitor` and `props`. Read the [overview](/docs/overview) for an introduction to the monitors and the collecting function. See the collecting function described in detail in the next section.

--- a/packages/documentation/markdown/docs/05 Hooks-Based API/useDragLayer.md
+++ b/packages/documentation/markdown/docs/05 Hooks-Based API/useDragLayer.md
@@ -23,6 +23,10 @@ function myDragLayer(props) {
 }
 ```
 
-### Specification Object Members
+### useDragLayer Parameters
 
 - **`collect`**: Required. The collecting function. It should return a plain object of the props to return for injection into your component. It receives two parameters, `monitor` and `props`. Read the [overview](/docs/overview) for an introduction to the monitors and the collecting function. See the collecting function described in detail in the next section.
+
+### Return Value
+
+useDragLayer returns an object of collected properties from the collect function.

--- a/packages/documentation/markdown/docs/05 Hooks-Based API/useDragLayer.md
+++ b/packages/documentation/markdown/docs/05 Hooks-Based API/useDragLayer.md
@@ -1,0 +1,28 @@
+---
+path: '/docs/api/use-drag-layer'
+title: 'useDrag'
+---
+
+## EXPERIMENTAL API - UNSTABLE
+
+_New to React DnD? [Read the overview](/docs/overview) before jumping into the docs._
+
+# useDragLayer
+
+A hook to use the current component as a drag-layer.
+
+```js
+import { __EXPERIMENTAL_DND_HOOKS_THAT_MAY_CHANGE_AND_BREAK_MY_BUILD__ } from 'react-dnd'
+const {
+	useDragLayer,
+} = __EXPERIMENTAL_DND_HOOKS_THAT_MAY_CHANGE_AND_BREAK_MY_BUILD__
+
+function myDragLayer(props) {
+  const collectedProps = useDragLayer(spec)
+  ...
+}
+```
+
+### Specification Object Members
+
+- **`collect`**: Required. The collecting function. It should return a plain object of the props to return for injection into your component. It receives two parameters, `monitor` and `props`. Read the [overview](/docs/overview) for an introduction to the monitors and the collecting function. See the collecting function described in detail in the next section.

--- a/packages/documentation/markdown/docs/05 Hooks-Based API/useDragPreview.md
+++ b/packages/documentation/markdown/docs/05 Hooks-Based API/useDragPreview.md
@@ -1,0 +1,45 @@
+---
+path: '/docs/api/use-drag-preview'
+title: 'useDragPreview'
+---
+
+## EXPERIMENTAL API - UNSTABLE
+
+_New to React DnD? [Read the overview](/docs/overview) before jumping into the docs._
+
+# useDragPreview
+
+A hook to use the current component as a drag-layer.
+
+```js
+import { __EXPERIMENTAL_DND_HOOKS_THAT_MAY_CHANGE_AND_BREAK_MY_BUILD__ } from 'react-dnd'
+const {
+	useDragPreview,
+} = __EXPERIMENTAL_DND_HOOKS_THAT_MAY_CHANGE_AND_BREAK_MY_BUILD__
+
+function myDragLayer(props) {
+  const [preview, DragPreview] = useDragPreview(spec)
+  const collectedProps = useDrag({
+    ...
+    preview
+  })
+
+  return (
+    <>
+      <DragPreview/>
+      <... rest of item... />
+    </>
+  )
+}
+```
+
+### useDragPreview Parameters
+
+- **`dragPreview`** A refForwarding component that will render the drag preview.
+
+### Return Value
+
+useDragPreview returns an array of two items:
+
+0. The drag preview ref object. This should be passed into useDrag's specification
+1. A component to render the dragPreview in your render method.

--- a/packages/documentation/markdown/docs/05 Hooks-Based API/useDrop.md
+++ b/packages/documentation/markdown/docs/05 Hooks-Based API/useDrop.md
@@ -1,0 +1,39 @@
+---
+path: '/docs/api/use-drop'
+title: 'useDrop'
+---
+
+## EXPERIMENTAL API - UNSTABLE
+
+_New to React DnD? [Read the overview](/docs/overview) before jumping into the docs._
+
+# useDrop
+
+A hook to use the current component as a drop target.
+
+```js
+import { __EXPERIMENTAL_DND_HOOKS_THAT_MAY_CHANGE_AND_BREAK_MY_BUILD__ } from 'react-dnd'
+const {
+	useDrop,
+} = __EXPERIMENTAL_DND_HOOKS_THAT_MAY_CHANGE_AND_BREAK_MY_BUILD__
+
+function myDropTarget(props) {
+	const collectedProps = useDrop(spec)
+}
+```
+
+### Specification Object Members
+
+- **`ref`**: Required. A ref object to use to attach to the draggable element.
+
+* **`accept`**: Required. A string, an ES6 symbol, an array of either, or a function that returns either of those, given component's `props`. This drop target will only react to the items produced by the [drag sources](/docs/api/drag-source) of the specified type or types. Read the [overview](/docs/overview) to learn more about the items and types.
+
+- **`options`**: Optional. A plain object. If some of the props to your component are not scalar (that is, are not primitive values or functions), specifying a custom `arePropsEqual(props, otherProps)` function inside the `options` object can improve the performance. Unless you have performance problems, don't worry about it.
+
+- **`drop(item, monitor)`**: Optional. Called when a compatible item is dropped on the target. You may either return undefined, or a plain object. If you return an object, it is going to become _the drop result_ and will be available to the drag source in its `endDrag` method as `monitor.getDropResult()`. This is useful in case you want to perform different actions depending on which target received the drop. If you have nested drop targets, you can test whether a nested target has already handled `drop` by checking `monitor.didDrop()` and `monitor.getDropResult()`. Both this method and the source's `endDrag` method are good places to fire Flux actions. This method will not be called if `canDrop()` is defined and returns `false`.
+
+- **`hover(item, monitor)`**: Optional. Called when an item is hovered over the component. You can check `monitor.isOver({ shallow: true })` to test whether the hover happens over _just_ the current target, or over a nested one. Unlike `drop()`, this method will be called even if `canDrop()` is defined and returns `false`. You can check `monitor.canDrop()` to test whether this is the case.
+
+- **`canDrop(item, monitor)`**: Optional. Use it to specify whether the drop target is able to accept the item. If you want to always allow it, just omit this method. Specifying it is handy if you'd like to disable dropping based on some predicate over `props` or `monitor.getItem()`. _Note: You may not call `monitor.canDrop()` inside this method._
+
+* **`collect`**: Optional. The collecting function. It should return a plain object of the props to return for injection into your component. It receives two parameters, `monitor` and `props`. Read the [overview](/docs/overview) for an introduction to the monitors and the collecting function. See the collecting function described in detail in the next section.

--- a/packages/documentation/markdown/docs/05 Hooks-Based API/useDrop.md
+++ b/packages/documentation/markdown/docs/05 Hooks-Based API/useDrop.md
@@ -30,8 +30,8 @@ function myDropTarget(props) {
 
 useDrop returns an array:
 
-0. An object containing collected properties from the collect function. If this is not set, an empty object is returned.
-1. The React ref to use. This is automatically created if no `ref` field is passed into the specification object.
+0. An object containing collected properties from the collect function. If no `collect` function is defined, an empty object is returned.
+1. The React ref to use. This is automatically created if no `ref` field is defined on the specification object.
 
 ### Specification Object Members
 

--- a/packages/documentation/markdown/docs/05 Hooks-Based API/useDrop.md
+++ b/packages/documentation/markdown/docs/05 Hooks-Based API/useDrop.md
@@ -28,7 +28,10 @@ function myDropTarget(props) {
 
 ### Return Value
 
-useDrop returns an object of collected properties from the collect function. If this is not set, an empty object is returned.
+useDrop returns an array:
+
+0. An object containing collected properties from the collect function. If this is not set, an empty object is returned.
+1. The React ref to use. This is automatically created if no `ref` field is passed into the specification object.
 
 ### Specification Object Members
 

--- a/packages/documentation/markdown/docs/05 Hooks-Based API/useDrop.md
+++ b/packages/documentation/markdown/docs/05 Hooks-Based API/useDrop.md
@@ -22,6 +22,14 @@ function myDropTarget(props) {
 }
 ```
 
+### useDrop Parameters
+
+- **`spec`** Specification object, see below for details on how to construct this
+
+### Return Value
+
+useDrop returns an object of collected properties from the collect function. If this is not set, an empty object is returned.
+
 ### Specification Object Members
 
 - **`ref`**: Required. A ref object to use to attach to the draggable element.

--- a/packages/documentation/src/constants.ts
+++ b/packages/documentation/src/constants.ts
@@ -71,6 +71,23 @@ export const APIPages: PageGroup[] = [
 		},
 	},
 	{
+		title: 'Hooks-Based API',
+		pages: {
+			USE_DRAG: {
+				location: '/docs/api/use-drag',
+				title: 'useDrag',
+			},
+			USE_DRAG_LAYER: {
+				location: '/docs/api/use-drag-layer',
+				title: 'useDragLayer',
+			},
+			USE_DROP: {
+				location: '/docs/api/use-drop',
+				title: 'useDrop',
+			},
+		},
+	},
+	{
 		title: 'Connecting to DOM',
 		pages: {
 			DRAG_SOURCE_CONNECTOR: {

--- a/packages/documentation/src/constants.ts
+++ b/packages/documentation/src/constants.ts
@@ -81,6 +81,10 @@ export const APIPages: PageGroup[] = [
 				location: '/docs/api/use-drag-layer',
 				title: 'useDragLayer',
 			},
+			USE_DRAG_PREVIEW: {
+				location: '/docs/api/use-drag-preview',
+				title: 'useDragPreview',
+			},
 			USE_DROP: {
 				location: '/docs/api/use-drop',
 				title: 'useDrop',

--- a/packages/examples-hooks/src/00 Chessboard/BoardSquare.tsx
+++ b/packages/examples-hooks/src/00 Chessboard/BoardSquare.tsx
@@ -20,7 +20,7 @@ export const BoardSquare: React.FC<BoardSquareProps> = (
 	const ref = React.useRef(null)
 	const { isOver, canDrop } = useDrop({
 		ref,
-		type: ItemTypes.KNIGHT,
+		accept: ItemTypes.KNIGHT,
 		canDrop: () => canMoveKnight(props.x, props.y),
 		drop: () => moveKnight(props.x, props.y),
 		collect: mon => ({

--- a/packages/examples-hooks/src/00 Chessboard/BoardSquare.tsx
+++ b/packages/examples-hooks/src/00 Chessboard/BoardSquare.tsx
@@ -17,7 +17,7 @@ export interface BoardSquareProps {
 export const BoardSquare: React.FC<BoardSquareProps> = (
 	props: BoardSquareProps,
 ) => {
-	const { ref, isOver, canDrop } = useDrop({
+	const [{ isOver, canDrop }, ref] = useDrop({
 		accept: ItemTypes.KNIGHT,
 		canDrop: () => canMoveKnight(props.x, props.y),
 		drop: () => moveKnight(props.x, props.y),

--- a/packages/examples-hooks/src/00 Chessboard/BoardSquare.tsx
+++ b/packages/examples-hooks/src/00 Chessboard/BoardSquare.tsx
@@ -17,9 +17,7 @@ export interface BoardSquareProps {
 export const BoardSquare: React.FC<BoardSquareProps> = (
 	props: BoardSquareProps,
 ) => {
-	const ref = React.useRef(null)
-	const { isOver, canDrop } = useDrop({
-		ref,
+	const { ref, isOver, canDrop } = useDrop({
 		accept: ItemTypes.KNIGHT,
 		canDrop: () => canMoveKnight(props.x, props.y),
 		drop: () => moveKnight(props.x, props.y),

--- a/packages/examples-hooks/src/00 Chessboard/Knight.tsx
+++ b/packages/examples-hooks/src/00 Chessboard/Knight.tsx
@@ -27,7 +27,7 @@ export const Knight: React.FC = () => {
 	const dragPreview = React.useMemo(createKnightImage, [])
 	const { isDragging } = useDrag({
 		ref,
-		type: ItemTypes.KNIGHT,
+		item: { type: ItemTypes.KNIGHT },
 		preview: dragPreview,
 		collect: mon => ({
 			isDragging: !!mon.isDragging(),

--- a/packages/examples-hooks/src/00 Chessboard/Knight.tsx
+++ b/packages/examples-hooks/src/00 Chessboard/Knight.tsx
@@ -33,6 +33,7 @@ export const Knight: React.FC = () => {
 	const ref = React.useRef(null)
 	const preview = React.useRef(null)
 	const dragPreviewRoot = document.createElement('div')
+
 	const { isDragging } = useDrag({
 		ref,
 		item: { type: ItemTypes.KNIGHT },

--- a/packages/examples-hooks/src/00 Chessboard/Knight.tsx
+++ b/packages/examples-hooks/src/00 Chessboard/Knight.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
-import { createPortal } from 'react-dom'
 import { __EXPERIMENTAL_DND_HOOKS_THAT_MAY_CHANGE_AND_BREAK_MY_BUILD__ } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 import knightImage from './knightImage'
 
 const {
 	useDrag,
+	useDragPreview,
 } = __EXPERIMENTAL_DND_HOOKS_THAT_MAY_CHANGE_AND_BREAK_MY_BUILD__
 
 const knightStyle: React.CSSProperties = {
@@ -23,20 +23,13 @@ const KnightDragPreview = React.forwardRef(
 	},
 )
 
-const KnightDragPreviewWrapper: React.FC<any> = React.forwardRef(
-	({ root }, ref: React.Ref<HTMLImageElement>) => {
-		return createPortal(<KnightDragPreview ref={ref} />, root)
-	},
-)
-
 export const Knight: React.FC = () => {
 	const ref = React.useRef(null)
-	const preview = React.useRef(null)
-	const dragPreviewRoot = document.createElement('div')
-
+	const item = { type: ItemTypes.KNIGHT }
+	const [preview, DragPreview] = useDragPreview(KnightDragPreview)
 	const { isDragging } = useDrag({
 		ref,
-		item: { type: ItemTypes.KNIGHT },
+		item,
 		preview,
 		collect: mon => ({
 			isDragging: !!mon.isDragging(),
@@ -45,7 +38,7 @@ export const Knight: React.FC = () => {
 
 	return (
 		<>
-			<KnightDragPreviewWrapper ref={preview} root={dragPreviewRoot} />
+			<DragPreview />
 			<div
 				ref={ref}
 				style={{

--- a/packages/examples-hooks/src/00 Chessboard/Knight.tsx
+++ b/packages/examples-hooks/src/00 Chessboard/Knight.tsx
@@ -25,8 +25,8 @@ const KnightDragPreview = React.forwardRef(
 
 export const Knight: React.FC = () => {
 	const item = { type: ItemTypes.KNIGHT }
-	const [preview, DragPreview] = useDragPreview(KnightDragPreview)
-	const { isDragging, ref } = useDrag({
+	const [DragPreview, preview] = useDragPreview(KnightDragPreview)
+	const [{ isDragging }, ref] = useDrag({
 		item,
 		preview,
 		collect: mon => ({

--- a/packages/examples-hooks/src/00 Chessboard/Knight.tsx
+++ b/packages/examples-hooks/src/00 Chessboard/Knight.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { createPortal } from 'react-dom'
 import { __EXPERIMENTAL_DND_HOOKS_THAT_MAY_CHANGE_AND_BREAK_MY_BUILD__ } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 import knightImage from './knightImage'
@@ -13,36 +14,46 @@ const knightStyle: React.CSSProperties = {
 	cursor: 'move',
 }
 
-function createKnightImage() {
-	if (typeof Image === 'undefined') {
-		return undefined
-	}
-	const img = new Image()
-	img.src = knightImage
-	return img
-}
+const KnightDragPreview = React.forwardRef(
+	(props, ref: React.Ref<HTMLImageElement>) => {
+		if (typeof Image === 'undefined') {
+			return null
+		}
+		return <img ref={ref} src={knightImage} />
+	},
+)
+
+const KnightDragPreviewWrapper: React.FC<any> = React.forwardRef(
+	({ root }, ref: React.Ref<HTMLImageElement>) => {
+		return createPortal(<KnightDragPreview ref={ref} />, root)
+	},
+)
 
 export const Knight: React.FC = () => {
 	const ref = React.useRef(null)
-	const dragPreview = React.useMemo(createKnightImage, [])
+	const preview = React.useRef(null)
+	const dragPreviewRoot = document.createElement('div')
 	const { isDragging } = useDrag({
 		ref,
 		item: { type: ItemTypes.KNIGHT },
-		preview: dragPreview,
+		preview,
 		collect: mon => ({
 			isDragging: !!mon.isDragging(),
 		}),
 	})
 
 	return (
-		<div
-			ref={ref}
-			style={{
-				...knightStyle,
-				opacity: isDragging ? 0.5 : 1,
-			}}
-		>
-			♘
-		</div>
+		<>
+			<KnightDragPreviewWrapper ref={preview} root={dragPreviewRoot} />
+			<div
+				ref={ref}
+				style={{
+					...knightStyle,
+					opacity: isDragging ? 0.5 : 1,
+				}}
+			>
+				♘
+			</div>
+		</>
 	)
 }

--- a/packages/examples-hooks/src/00 Chessboard/Knight.tsx
+++ b/packages/examples-hooks/src/00 Chessboard/Knight.tsx
@@ -24,11 +24,9 @@ const KnightDragPreview = React.forwardRef(
 )
 
 export const Knight: React.FC = () => {
-	const ref = React.useRef(null)
 	const item = { type: ItemTypes.KNIGHT }
 	const [preview, DragPreview] = useDragPreview(KnightDragPreview)
-	const { isDragging } = useDrag({
-		ref,
+	const { isDragging, ref } = useDrag({
 		item,
 		preview,
 		collect: mon => ({

--- a/packages/examples-hooks/src/01 Dustbin/Copy or Move/Box.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Copy or Move/Box.tsx
@@ -27,7 +27,7 @@ interface DropResult {
 
 const Box: React.FC<BoxProps> = ({ name }) => {
 	const item = { name, type: ItemTypes.BOX }
-	const { ref, opacity } = useDrag({
+	const [{ opacity }, ref] = useDrag({
 		item,
 		end(dropResult?: DropResult) {
 			if (dropResult) {

--- a/packages/examples-hooks/src/01 Dustbin/Copy or Move/Box.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Copy or Move/Box.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import ItemTypes from '../Single Target/ItemTypes'
-import { DragItem, DropResult } from './interfaces'
 
 import { __EXPERIMENTAL_DND_HOOKS_THAT_MAY_CHANGE_AND_BREAK_MY_BUILD__ } from 'react-dnd'
 const {
@@ -20,13 +19,17 @@ export interface BoxProps {
 	name: string
 }
 
+interface DropResult {
+	allowedDropEffect: string
+	dropEffect: string
+	name: string
+}
+
 const Box: React.FC<BoxProps> = ({ name }) => {
-	const ref = React.useRef(null)
 	const item = { name, type: ItemTypes.BOX }
-	const { opacity } = useDrag<DragItem, DropResult, { opacity: number }>({
-		ref,
+	const { ref, opacity } = useDrag({
 		item,
-		end(dropResult, monitor) {
+		end(dropResult?: DropResult) {
 			if (dropResult) {
 				let alertMessage = ''
 				const isDropAllowed =

--- a/packages/examples-hooks/src/01 Dustbin/Copy or Move/Box.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Copy or Move/Box.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react'
 import ItemTypes from '../Single Target/ItemTypes'
+import { DragItem, DropResult } from './interfaces'
+
 import { __EXPERIMENTAL_DND_HOOKS_THAT_MAY_CHANGE_AND_BREAK_MY_BUILD__ } from 'react-dnd'
 const {
 	useDrag,
@@ -20,13 +22,11 @@ export interface BoxProps {
 
 const Box: React.FC<BoxProps> = ({ name }) => {
 	const ref = React.useRef(null)
-	const { opacity } = useDrag({
+	const item = { name, type: ItemTypes.BOX }
+	const { opacity } = useDrag<DragItem, DropResult, { opacity: number }>({
 		ref,
-		item: { name, type: ItemTypes.BOX },
-		end(monitor) {
-			const item = monitor.getItem()
-			const dropResult = monitor.getDropResult()
-
+		item,
+		end(dropResult, monitor) {
 			if (dropResult) {
 				let alertMessage = ''
 				const isDropAllowed =

--- a/packages/examples-hooks/src/01 Dustbin/Copy or Move/Box.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Copy or Move/Box.tsx
@@ -22,8 +22,7 @@ const Box: React.FC<BoxProps> = ({ name }) => {
 	const ref = React.useRef(null)
 	const { opacity } = useDrag({
 		ref,
-		type: ItemTypes.BOX,
-		begin: () => ({ name }),
+		item: { name, type: ItemTypes.BOX },
 		end(monitor) {
 			const item = monitor.getItem()
 			const dropResult = monitor.getDropResult()

--- a/packages/examples-hooks/src/01 Dustbin/Copy or Move/Dustbin.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Copy or Move/Dustbin.tsx
@@ -33,9 +33,7 @@ function selectBackgroundColor(isActive: boolean, canDrop: boolean) {
 }
 
 const Dustbin: React.FC<DustbinProps> = ({ allowedDropEffect }) => {
-	const ref = React.useRef(null)
-	const { canDrop, isOver } = useDrop({
-		ref,
+	const { ref, canDrop, isOver } = useDrop({
 		accept: ItemTypes.BOX,
 		drop: () => ({
 			name: `${allowedDropEffect} Dustbin`,

--- a/packages/examples-hooks/src/01 Dustbin/Copy or Move/Dustbin.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Copy or Move/Dustbin.tsx
@@ -33,7 +33,7 @@ function selectBackgroundColor(isActive: boolean, canDrop: boolean) {
 }
 
 const Dustbin: React.FC<DustbinProps> = ({ allowedDropEffect }) => {
-	const { ref, canDrop, isOver } = useDrop({
+	const [{ canDrop, isOver }, ref] = useDrop({
 		accept: ItemTypes.BOX,
 		drop: () => ({
 			name: `${allowedDropEffect} Dustbin`,

--- a/packages/examples-hooks/src/01 Dustbin/Copy or Move/Dustbin.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Copy or Move/Dustbin.tsx
@@ -36,7 +36,7 @@ const Dustbin: React.FC<DustbinProps> = ({ allowedDropEffect }) => {
 	const ref = React.useRef(null)
 	const { canDrop, isOver } = useDrop({
 		ref,
-		type: ItemTypes.BOX,
+		accept: ItemTypes.BOX,
 		drop: () => ({
 			name: `${allowedDropEffect} Dustbin`,
 			allowedDropEffect,

--- a/packages/examples-hooks/src/01 Dustbin/Copy or Move/interfaces.ts
+++ b/packages/examples-hooks/src/01 Dustbin/Copy or Move/interfaces.ts
@@ -1,0 +1,10 @@
+export interface DragItem {
+	type: string
+	name: string
+}
+
+export interface DropResult {
+	name: string
+	dropEffect: string
+	allowedDropEffect: string
+}

--- a/packages/examples-hooks/src/01 Dustbin/Multiple Targets/Box.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Multiple Targets/Box.tsx
@@ -22,10 +22,8 @@ export interface BoxProps {
 }
 
 const Box: React.FC<BoxProps> = ({ name, type, isDropped }) => {
-	const ref = React.useRef(null)
 	const item = { name, type }
-	const { opacity } = useDrag({
-		ref,
+	const { ref, opacity } = useDrag({
 		item,
 		collect: monitor => ({
 			opacity: monitor.isDragging() ? 0.4 : 1,

--- a/packages/examples-hooks/src/01 Dustbin/Multiple Targets/Box.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Multiple Targets/Box.tsx
@@ -23,10 +23,10 @@ export interface BoxProps {
 
 const Box: React.FC<BoxProps> = ({ name, type, isDropped }) => {
 	const ref = React.useRef(null)
+	const item = { name, type }
 	const { opacity } = useDrag({
 		ref,
-
-		item: { name, type },
+		item,
 		collect: monitor => ({
 			opacity: monitor.isDragging() ? 0.4 : 1,
 		}),

--- a/packages/examples-hooks/src/01 Dustbin/Multiple Targets/Box.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Multiple Targets/Box.tsx
@@ -23,7 +23,7 @@ export interface BoxProps {
 
 const Box: React.FC<BoxProps> = ({ name, type, isDropped }) => {
 	const item = { name, type }
-	const { ref, opacity } = useDrag({
+	const [{ opacity }, ref] = useDrag({
 		item,
 		collect: monitor => ({
 			opacity: monitor.isDragging() ? 0.4 : 1,

--- a/packages/examples-hooks/src/01 Dustbin/Multiple Targets/Box.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Multiple Targets/Box.tsx
@@ -25,8 +25,8 @@ const Box: React.FC<BoxProps> = ({ name, type, isDropped }) => {
 	const ref = React.useRef(null)
 	const { opacity } = useDrag({
 		ref,
-		type,
-		begin: () => ({ name }),
+
+		item: { name, type },
 		collect: monitor => ({
 			opacity: monitor.isDragging() ? 0.4 : 1,
 		}),

--- a/packages/examples-hooks/src/01 Dustbin/Multiple Targets/Dustbin.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Multiple Targets/Dustbin.tsx
@@ -18,20 +18,20 @@ const style: React.CSSProperties = {
 }
 
 export interface DustbinProps {
-	accepts: string[]
+	accept: string[]
 	lastDroppedItem?: any
 	onDrop: (item: any) => void
 }
 
 const Dustbin: React.FC<DustbinProps> = ({
-	accepts,
+	accept,
 	lastDroppedItem,
 	onDrop,
 }) => {
 	const ref = React.useRef(null)
 	const { isOver, canDrop } = useDrop({
 		ref,
-		type: accepts,
+		accept,
 		drop: item => onDrop(item),
 		collect: monitor => ({
 			isOver: monitor.isOver(),
@@ -51,7 +51,7 @@ const Dustbin: React.FC<DustbinProps> = ({
 		<div ref={ref} style={{ ...style, backgroundColor }}>
 			{isActive
 				? 'Release to drop'
-				: `This dustbin accepts: ${accepts.join(', ')}`}
+				: `This dustbin accepts: ${accept.join(', ')}`}
 
 			{lastDroppedItem && (
 				<p>Last dropped: {JSON.stringify(lastDroppedItem)}</p>

--- a/packages/examples-hooks/src/01 Dustbin/Multiple Targets/Dustbin.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Multiple Targets/Dustbin.tsx
@@ -28,9 +28,7 @@ const Dustbin: React.FC<DustbinProps> = ({
 	lastDroppedItem,
 	onDrop,
 }) => {
-	const ref = React.useRef(null)
-	const { isOver, canDrop } = useDrop({
-		ref,
+	const { ref, isOver, canDrop } = useDrop({
 		accept,
 		drop: item => onDrop(item),
 		collect: monitor => ({

--- a/packages/examples-hooks/src/01 Dustbin/Multiple Targets/Dustbin.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Multiple Targets/Dustbin.tsx
@@ -32,7 +32,7 @@ const Dustbin: React.FC<DustbinProps> = ({
 	const { isOver, canDrop } = useDrop({
 		ref,
 		type: accepts,
-		drop: monitor => onDrop(monitor.getItem()),
+		drop: item => onDrop(item),
 		collect: monitor => ({
 			isOver: monitor.isOver(),
 			canDrop: monitor.canDrop(),

--- a/packages/examples-hooks/src/01 Dustbin/Multiple Targets/Dustbin.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Multiple Targets/Dustbin.tsx
@@ -28,7 +28,7 @@ const Dustbin: React.FC<DustbinProps> = ({
 	lastDroppedItem,
 	onDrop,
 }) => {
-	const { ref, isOver, canDrop } = useDrop({
+	const [{ isOver, canDrop }, ref] = useDrop({
 		accept,
 		drop: item => onDrop(item),
 		collect: monitor => ({

--- a/packages/examples-hooks/src/01 Dustbin/Multiple Targets/index.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Multiple Targets/index.tsx
@@ -51,7 +51,7 @@ export default class Container extends React.Component<{}, ContainerState> {
 				<div style={{ overflow: 'hidden', clear: 'both' }}>
 					{dustbins.map(({ accepts, lastDroppedItem }, index) => (
 						<Dustbin
-							accepts={accepts}
+							accept={accepts}
 							lastDroppedItem={lastDroppedItem}
 							// tslint:disable-next-line jsx-no-lambda
 							onDrop={item => this.handleDrop(index, item)}

--- a/packages/examples-hooks/src/01 Dustbin/Single Target with FCs/Box.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Single Target with FCs/Box.tsx
@@ -23,10 +23,8 @@ export interface BoxProps {
 }
 
 const Box: React.FC<BoxProps> = ({ name }) => {
-	const ref = React.createRef()
 	const item = { name, type: ItemTypes.BOX }
-	const { isDragging } = useDrag({
-		ref,
+	const [{ opacity }, ref] = useDrag({
 		item,
 		end: (dropResult?: { name: string }) => {
 			if (dropResult) {
@@ -34,10 +32,9 @@ const Box: React.FC<BoxProps> = ({ name }) => {
 			}
 		},
 		collect: (monitor: DragSourceMonitor) => ({
-			isDragging: monitor.isDragging(),
+			opacity: monitor.isDragging() ? 0.4 : 1,
 		}),
 	})
-	const opacity = isDragging ? 0.4 : 1
 
 	return (
 		<div ref={ref as any} style={{ ...style, opacity }}>

--- a/packages/examples-hooks/src/01 Dustbin/Single Target with FCs/Box.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Single Target with FCs/Box.tsx
@@ -24,12 +24,11 @@ export interface BoxProps {
 
 const Box: React.FC<BoxProps> = ({ name }) => {
 	const ref = React.createRef()
+	const item = { name, type: ItemTypes.BOX }
 	const { isDragging } = useDrag({
 		ref,
-		item: { name, type: ItemTypes.BOX },
-		end: (monitor: DragSourceMonitor) => {
-			const item = monitor.getItem()
-			const dropResult = monitor.getDropResult()
+		item,
+		end: (dropResult?: { name: string }) => {
 			if (dropResult) {
 				alert(`You dropped ${item.name} into ${dropResult.name}!`)
 			}

--- a/packages/examples-hooks/src/01 Dustbin/Single Target with FCs/Box.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Single Target with FCs/Box.tsx
@@ -26,8 +26,7 @@ const Box: React.FC<BoxProps> = ({ name }) => {
 	const ref = React.createRef()
 	const { isDragging } = useDrag({
 		ref,
-		type: ItemTypes.BOX,
-		begin: () => ({ name }),
+		item: { name, type: ItemTypes.BOX },
 		end: (monitor: DragSourceMonitor) => {
 			const item = monitor.getItem()
 			const dropResult = monitor.getDropResult()

--- a/packages/examples-hooks/src/01 Dustbin/Single Target with FCs/Dustbin.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Single Target with FCs/Dustbin.tsx
@@ -19,9 +19,7 @@ const style: React.CSSProperties = {
 }
 
 const Dustbin: React.FC = () => {
-	const ref = React.useRef(null)
-	const { isOver, canDrop } = useDrop({
-		ref,
+	const { ref, isOver, canDrop } = useDrop({
 		accept: ItemTypes.BOX,
 		drop: () => ({ name: 'Dustbin' }),
 		collect: monitor => ({

--- a/packages/examples-hooks/src/01 Dustbin/Single Target with FCs/Dustbin.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Single Target with FCs/Dustbin.tsx
@@ -22,7 +22,7 @@ const Dustbin: React.FC = () => {
 	const ref = React.useRef(null)
 	const { isOver, canDrop } = useDrop({
 		ref,
-		type: ItemTypes.BOX,
+		accept: ItemTypes.BOX,
 		drop: () => ({ name: 'Dustbin' }),
 		collect: monitor => ({
 			isOver: monitor.isOver(),

--- a/packages/examples-hooks/src/01 Dustbin/Single Target with FCs/Dustbin.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Single Target with FCs/Dustbin.tsx
@@ -19,7 +19,7 @@ const style: React.CSSProperties = {
 }
 
 const Dustbin: React.FC = () => {
-	const { ref, isOver, canDrop } = useDrop({
+	const [{ isOver, canDrop }, ref] = useDrop({
 		accept: ItemTypes.BOX,
 		drop: () => ({ name: 'Dustbin' }),
 		collect: monitor => ({

--- a/packages/examples-hooks/src/01 Dustbin/Single Target/Box.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Single Target/Box.tsx
@@ -23,8 +23,8 @@ const Box: React.FC<BoxProps> = ({ name }) => {
 	const ref = React.useRef(null)
 	const { isDragging } = useDrag({
 		ref,
-		type: ItemTypes.BOX,
-		begin: () => ({ name }),
+
+		item: { name, type: ItemTypes.BOX },
 		end: monitor => {
 			const item = monitor.getItem()
 			const dropResult = monitor.getDropResult()

--- a/packages/examples-hooks/src/01 Dustbin/Single Target/Box.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Single Target/Box.tsx
@@ -22,7 +22,7 @@ interface BoxProps {
 const Box: React.FC<BoxProps> = ({ name }) => {
 	const item = { name, type: ItemTypes.BOX }
 
-	const { ref, isDragging } = useDrag({
+	const [{ isDragging }, ref] = useDrag({
 		item,
 		end: (dropResult?: { name: string }) => {
 			if (dropResult) {

--- a/packages/examples-hooks/src/01 Dustbin/Single Target/Box.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Single Target/Box.tsx
@@ -21,13 +21,12 @@ interface BoxProps {
 
 const Box: React.FC<BoxProps> = ({ name }) => {
 	const ref = React.useRef(null)
+	const item = { name, type: ItemTypes.BOX }
+
 	const { isDragging } = useDrag({
 		ref,
-
-		item: { name, type: ItemTypes.BOX },
-		end: monitor => {
-			const item = monitor.getItem()
-			const dropResult = monitor.getDropResult()
+		item,
+		end: (dropResult?: { name: string }) => {
 			if (dropResult) {
 				alert(`You dropped ${item.name} into ${dropResult.name}!`)
 			}

--- a/packages/examples-hooks/src/01 Dustbin/Single Target/Box.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Single Target/Box.tsx
@@ -20,11 +20,9 @@ interface BoxProps {
 }
 
 const Box: React.FC<BoxProps> = ({ name }) => {
-	const ref = React.useRef(null)
 	const item = { name, type: ItemTypes.BOX }
 
-	const { isDragging } = useDrag({
-		ref,
+	const { ref, isDragging } = useDrag({
 		item,
 		end: (dropResult?: { name: string }) => {
 			if (dropResult) {

--- a/packages/examples-hooks/src/01 Dustbin/Single Target/Dustbin.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Single Target/Dustbin.tsx
@@ -23,7 +23,7 @@ const Dustbin: React.FC = () => {
 	const ref = React.useRef(null)
 	const { canDrop, isOver } = useDrop({
 		ref,
-		type: ItemTypes.BOX,
+		accept: ItemTypes.BOX,
 		drop: () => ({ name: 'Dustbin' }),
 		collect: monitor => ({
 			isOver: monitor.isOver(),

--- a/packages/examples-hooks/src/01 Dustbin/Single Target/Dustbin.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Single Target/Dustbin.tsx
@@ -20,9 +20,7 @@ const style: React.CSSProperties = {
 }
 
 const Dustbin: React.FC = () => {
-	const ref = React.useRef(null)
-	const { canDrop, isOver } = useDrop({
-		ref,
+	const { ref, canDrop, isOver } = useDrop({
 		accept: ItemTypes.BOX,
 		drop: () => ({ name: 'Dustbin' }),
 		collect: monitor => ({

--- a/packages/examples-hooks/src/01 Dustbin/Single Target/Dustbin.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Single Target/Dustbin.tsx
@@ -20,7 +20,7 @@ const style: React.CSSProperties = {
 }
 
 const Dustbin: React.FC = () => {
-	const { ref, canDrop, isOver } = useDrop({
+	const [{ canDrop, isOver }, ref] = useDrop({
 		accept: ItemTypes.BOX,
 		drop: () => ({ name: 'Dustbin' }),
 		collect: monitor => ({

--- a/packages/examples-hooks/src/01 Dustbin/Stress Test/Box.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Stress Test/Box.tsx
@@ -25,8 +25,7 @@ const Box: React.FC<BoxProps> = ({ name, type, isDropped }) => {
 	const ref = React.useRef(null)
 	const { isDragging } = useDrag({
 		ref,
-		type,
-		begin: () => ({ name }),
+		item: { name, type },
 		isDragging(monitor) {
 			const item = monitor.getItem()
 			return name === item.name

--- a/packages/examples-hooks/src/01 Dustbin/Stress Test/Box.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Stress Test/Box.tsx
@@ -22,7 +22,7 @@ export interface BoxProps {
 }
 
 const Box: React.FC<BoxProps> = ({ name, type, isDropped }) => {
-	const { ref, isDragging } = useDrag({
+	const [{ isDragging }, ref] = useDrag({
 		item: { name, type },
 		isDragging(monitor) {
 			const item = monitor.getItem()

--- a/packages/examples-hooks/src/01 Dustbin/Stress Test/Box.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Stress Test/Box.tsx
@@ -22,9 +22,7 @@ export interface BoxProps {
 }
 
 const Box: React.FC<BoxProps> = ({ name, type, isDropped }) => {
-	const ref = React.useRef(null)
-	const { isDragging } = useDrag({
-		ref,
+	const { ref, isDragging } = useDrag({
 		item: { name, type },
 		isDragging(monitor) {
 			const item = monitor.getItem()

--- a/packages/examples-hooks/src/01 Dustbin/Stress Test/Dustbin.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Stress Test/Dustbin.tsx
@@ -26,13 +26,13 @@ export interface DustbinProps {
 
 const Dustbin: React.FC<DustbinProps> = ({
 	lastDroppedItem,
-	accepts,
+	accepts: accept,
 	onDrop,
 }) => {
 	const ref = React.useRef(null)
 	const { isOver, canDrop } = useDrop({
 		ref,
-		type: accepts,
+		accept,
 		collect: monitor => ({
 			isOver: monitor.isOver(),
 			canDrop: monitor.canDrop(),
@@ -52,7 +52,7 @@ const Dustbin: React.FC<DustbinProps> = ({
 		<div ref={ref} style={{ ...style, backgroundColor }}>
 			{isActive
 				? 'Release to drop'
-				: `This dustbin accepts: ${accepts.join(', ')}`}
+				: `This dustbin accepts: ${accept.join(', ')}`}
 
 			{lastDroppedItem && (
 				<p>Last dropped: {JSON.stringify(lastDroppedItem)}</p>

--- a/packages/examples-hooks/src/01 Dustbin/Stress Test/Dustbin.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Stress Test/Dustbin.tsx
@@ -29,7 +29,7 @@ const Dustbin: React.FC<DustbinProps> = ({
 	accepts: accept,
 	onDrop,
 }) => {
-	const { ref, isOver, canDrop } = useDrop({
+	const [{ isOver, canDrop }, ref] = useDrop({
 		accept,
 		collect: monitor => ({
 			isOver: monitor.isOver(),

--- a/packages/examples-hooks/src/01 Dustbin/Stress Test/Dustbin.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Stress Test/Dustbin.tsx
@@ -29,9 +29,7 @@ const Dustbin: React.FC<DustbinProps> = ({
 	accepts: accept,
 	onDrop,
 }) => {
-	const ref = React.useRef(null)
-	const { isOver, canDrop } = useDrop({
-		ref,
+	const { ref, isOver, canDrop } = useDrop({
 		accept,
 		collect: monitor => ({
 			isOver: monitor.isOver(),

--- a/packages/examples-hooks/src/01 Dustbin/Stress Test/Dustbin.tsx
+++ b/packages/examples-hooks/src/01 Dustbin/Stress Test/Dustbin.tsx
@@ -37,7 +37,7 @@ const Dustbin: React.FC<DustbinProps> = ({
 			isOver: monitor.isOver(),
 			canDrop: monitor.canDrop(),
 		}),
-		drop: monitor => onDrop(monitor.getItem()),
+		drop: item => onDrop(item),
 	})
 
 	const isActive = isOver && canDrop

--- a/packages/examples-hooks/src/02 Drag Around/Custom Drag Layer/Container.tsx
+++ b/packages/examples-hooks/src/02 Drag Around/Custom Drag Layer/Container.tsx
@@ -44,11 +44,9 @@ const Container: React.FC<ContainerProps> = props => {
 		)
 	}
 
-	const ref = React.useRef(null)
-	useDrop<DragItem, {}, {}>({
-		ref,
+	const { ref } = useDrop({
 		accept: ItemTypes.BOX,
-		drop(item, monitor) {
+		drop(item: DragItem, monitor) {
 			const delta = monitor.getDifferenceFromInitialOffset() as {
 				x: number
 				y: number

--- a/packages/examples-hooks/src/02 Drag Around/Custom Drag Layer/Container.tsx
+++ b/packages/examples-hooks/src/02 Drag Around/Custom Drag Layer/Container.tsx
@@ -4,6 +4,7 @@ import ItemTypes from './ItemTypes'
 import DraggableBox from './DraggableBox'
 import snapToGrid from './snapToGrid'
 import update from 'immutability-helper'
+import { DragItem } from './interfaces'
 const {
 	useDrop,
 } = __EXPERIMENTAL_DND_HOOKS_THAT_MAY_CHANGE_AND_BREAK_MY_BUILD__
@@ -44,15 +45,14 @@ const Container: React.FC<ContainerProps> = props => {
 	}
 
 	const ref = React.useRef(null)
-	useDrop({
+	useDrop<DragItem, {}, {}>({
 		ref,
 		type: ItemTypes.BOX,
-		drop(monitor) {
+		drop(item, monitor) {
 			const delta = monitor.getDifferenceFromInitialOffset() as {
 				x: number
 				y: number
 			}
-			const item = monitor.getItem()
 
 			let left = Math.round(item.left + delta.x)
 			let top = Math.round(item.top + delta.y)
@@ -61,6 +61,7 @@ const Container: React.FC<ContainerProps> = props => {
 			}
 
 			moveBox(item.id, left, top)
+			return undefined
 		},
 	})
 

--- a/packages/examples-hooks/src/02 Drag Around/Custom Drag Layer/Container.tsx
+++ b/packages/examples-hooks/src/02 Drag Around/Custom Drag Layer/Container.tsx
@@ -44,7 +44,9 @@ const Container: React.FC<ContainerProps> = props => {
 		)
 	}
 
-	const { ref } = useDrop({
+	const ref = React.useRef(null)
+	useDrop({
+		ref,
 		accept: ItemTypes.BOX,
 		drop(item: DragItem, monitor) {
 			const delta = monitor.getDifferenceFromInitialOffset() as {

--- a/packages/examples-hooks/src/02 Drag Around/Custom Drag Layer/Container.tsx
+++ b/packages/examples-hooks/src/02 Drag Around/Custom Drag Layer/Container.tsx
@@ -47,7 +47,7 @@ const Container: React.FC<ContainerProps> = props => {
 	const ref = React.useRef(null)
 	useDrop<DragItem, {}, {}>({
 		ref,
-		type: ItemTypes.BOX,
+		accept: ItemTypes.BOX,
 		drop(item, monitor) {
 			const delta = monitor.getDifferenceFromInitialOffset() as {
 				x: number

--- a/packages/examples-hooks/src/02 Drag Around/Custom Drag Layer/DraggableBox.tsx
+++ b/packages/examples-hooks/src/02 Drag Around/Custom Drag Layer/DraggableBox.tsx
@@ -35,10 +35,8 @@ export interface DraggableBoxProps {
 
 const DraggableBox: React.FC<DraggableBoxProps> = props => {
 	const { id, title, left, top } = props
-	const ref = React.useRef(null)
 	const item = { type: ItemTypes.BOX, id, title, left, top }
-	const { isDragging } = useDrag({
-		ref,
+	const { ref, isDragging } = useDrag({
 		item,
 		// Use empty image as a drag preview so browsers don't draw it
 		// and we can draw whatever we want on the custom drag layer instead.

--- a/packages/examples-hooks/src/02 Drag Around/Custom Drag Layer/DraggableBox.tsx
+++ b/packages/examples-hooks/src/02 Drag Around/Custom Drag Layer/DraggableBox.tsx
@@ -36,7 +36,7 @@ export interface DraggableBoxProps {
 const DraggableBox: React.FC<DraggableBoxProps> = props => {
 	const { id, title, left, top } = props
 	const item = { type: ItemTypes.BOX, id, title, left, top }
-	const { ref, isDragging } = useDrag({
+	const [{ isDragging }, ref] = useDrag({
 		item,
 		// Use empty image as a drag preview so browsers don't draw it
 		// and we can draw whatever we want on the custom drag layer instead.

--- a/packages/examples-hooks/src/02 Drag Around/Custom Drag Layer/DraggableBox.tsx
+++ b/packages/examples-hooks/src/02 Drag Around/Custom Drag Layer/DraggableBox.tsx
@@ -36,10 +36,10 @@ export interface DraggableBoxProps {
 const DraggableBox: React.FC<DraggableBoxProps> = props => {
 	const { id, title, left, top } = props
 	const ref = React.useRef(null)
-
+	const item = { type: ItemTypes.BOX, id, title, left, top }
 	const { isDragging } = useDrag({
 		ref,
-		item: { type: ItemTypes.BOX },
+		item,
 		// Use empty image as a drag preview so browsers don't draw it
 		// and we can draw whatever we want on the custom drag layer instead.
 		preview: getEmptyImage(),
@@ -48,7 +48,6 @@ const DraggableBox: React.FC<DraggableBoxProps> = props => {
 			// when it already knows it's being dragged so we can hide it with CSS.
 			captureDraggingState: true,
 		},
-		begin: () => ({ id, title, left, top }),
 		collect: (monitor: DragSourceMonitor) => ({
 			isDragging: monitor.isDragging(),
 		}),

--- a/packages/examples-hooks/src/02 Drag Around/Custom Drag Layer/DraggableBox.tsx
+++ b/packages/examples-hooks/src/02 Drag Around/Custom Drag Layer/DraggableBox.tsx
@@ -39,7 +39,7 @@ const DraggableBox: React.FC<DraggableBoxProps> = props => {
 
 	const { isDragging } = useDrag({
 		ref,
-		type: ItemTypes.BOX,
+		item: { type: ItemTypes.BOX },
 		// Use empty image as a drag preview so browsers don't draw it
 		// and we can draw whatever we want on the custom drag layer instead.
 		preview: getEmptyImage(),

--- a/packages/examples-hooks/src/02 Drag Around/Custom Drag Layer/interfaces.ts
+++ b/packages/examples-hooks/src/02 Drag Around/Custom Drag Layer/interfaces.ts
@@ -1,0 +1,6 @@
+export interface DragItem {
+	id: string
+	type: string
+	left: number
+	top: number
+}

--- a/packages/examples-hooks/src/02 Drag Around/Naive/Box.tsx
+++ b/packages/examples-hooks/src/02 Drag Around/Naive/Box.tsx
@@ -31,8 +31,7 @@ const Box: React.FC<BoxProps> = ({
 	const ref = React.useRef(null)
 	const { isDragging } = useDrag({
 		ref,
-		type: ItemTypes.BOX,
-		begin: () => ({ id, left, top }),
+		item: { id, left, top, type: ItemTypes.BOX },
 		collect: monitor => ({
 			isDragging: monitor.isDragging(),
 		}),

--- a/packages/examples-hooks/src/02 Drag Around/Naive/Box.tsx
+++ b/packages/examples-hooks/src/02 Drag Around/Naive/Box.tsx
@@ -28,9 +28,7 @@ const Box: React.FC<BoxProps> = ({
 	hideSourceOnDrag,
 	children,
 }) => {
-	const ref = React.useRef(null)
-	const { isDragging } = useDrag({
-		ref,
+	const { ref, isDragging } = useDrag({
 		item: { id, left, top, type: ItemTypes.BOX },
 		collect: monitor => ({
 			isDragging: monitor.isDragging(),

--- a/packages/examples-hooks/src/02 Drag Around/Naive/Box.tsx
+++ b/packages/examples-hooks/src/02 Drag Around/Naive/Box.tsx
@@ -28,7 +28,7 @@ const Box: React.FC<BoxProps> = ({
 	hideSourceOnDrag,
 	children,
 }) => {
-	const { ref, isDragging } = useDrag({
+	const [{ isDragging }, ref] = useDrag({
 		item: { id, left, top, type: ItemTypes.BOX },
 		collect: monitor => ({
 			isDragging: monitor.isDragging(),

--- a/packages/examples-hooks/src/02 Drag Around/Naive/Container.tsx
+++ b/packages/examples-hooks/src/02 Drag Around/Naive/Container.tsx
@@ -39,7 +39,9 @@ const Container: React.FC<ContainerProps> = ({ hideSourceOnDrag }) => {
 		b: { top: 180, left: 20, title: 'Drag me too' },
 	})
 
-	const { ref } = useDrop({
+	const ref = React.useRef(null)
+	useDrop({
+		ref,
 		accept: ItemTypes.BOX,
 		drop(item: DragItem, monitor) {
 			const delta = monitor.getDifferenceFromInitialOffset() as XYCoord

--- a/packages/examples-hooks/src/02 Drag Around/Naive/Container.tsx
+++ b/packages/examples-hooks/src/02 Drag Around/Naive/Container.tsx
@@ -39,11 +39,9 @@ const Container: React.FC<ContainerProps> = ({ hideSourceOnDrag }) => {
 		b: { top: 180, left: 20, title: 'Drag me too' },
 	})
 
-	const ref = React.useRef(null)
-	useDrop<DragItem, {}, {}>({
-		ref,
+	const { ref } = useDrop({
 		accept: ItemTypes.BOX,
-		drop(item, monitor) {
+		drop(item: DragItem, monitor) {
 			const delta = monitor.getDifferenceFromInitialOffset() as XYCoord
 			const left = Math.round(item.left + delta.x)
 			const top = Math.round(item.top + delta.y)

--- a/packages/examples-hooks/src/02 Drag Around/Naive/Container.tsx
+++ b/packages/examples-hooks/src/02 Drag Around/Naive/Container.tsx
@@ -6,6 +6,7 @@ import {
 import ItemTypes from './ItemTypes'
 import Box from './Box'
 import update from 'immutability-helper'
+import { DragItem } from './interfaces'
 
 const {
 	useDrop,
@@ -39,15 +40,15 @@ const Container: React.FC<ContainerProps> = ({ hideSourceOnDrag }) => {
 	})
 
 	const ref = React.useRef(null)
-	useDrop({
+	useDrop<DragItem, {}, {}>({
 		ref,
 		type: ItemTypes.BOX,
-		drop(monitor) {
-			const item = monitor.getItem()
+		drop(item, monitor) {
 			const delta = monitor.getDifferenceFromInitialOffset() as XYCoord
 			const left = Math.round(item.left + delta.x)
 			const top = Math.round(item.top + delta.y)
 			moveBox(item.id, left, top)
+			return undefined
 		},
 	})
 

--- a/packages/examples-hooks/src/02 Drag Around/Naive/Container.tsx
+++ b/packages/examples-hooks/src/02 Drag Around/Naive/Container.tsx
@@ -42,7 +42,7 @@ const Container: React.FC<ContainerProps> = ({ hideSourceOnDrag }) => {
 	const ref = React.useRef(null)
 	useDrop<DragItem, {}, {}>({
 		ref,
-		type: ItemTypes.BOX,
+		accept: ItemTypes.BOX,
 		drop(item, monitor) {
 			const delta = monitor.getDifferenceFromInitialOffset() as XYCoord
 			const left = Math.round(item.left + delta.x)

--- a/packages/examples-hooks/src/02 Drag Around/Naive/interfaces.ts
+++ b/packages/examples-hooks/src/02 Drag Around/Naive/interfaces.ts
@@ -1,0 +1,6 @@
+export interface DragItem {
+	type: string
+	id: string
+	top: number
+	left: number
+}

--- a/packages/examples-hooks/src/03 Nesting/Drag Sources/SourceBox.tsx
+++ b/packages/examples-hooks/src/03 Nesting/Drag Sources/SourceBox.tsx
@@ -24,7 +24,7 @@ const SourceBox: React.FC<SourceBoxProps> = ({
 	onToggleForbidDrag,
 	children,
 }) => {
-	const { ref, isDragging } = useDrag({
+	const [{ isDragging }, ref] = useDrag({
 		item: { type: `${color}` },
 		canDrag: () => !forbidDrag,
 		collect: monitor => ({

--- a/packages/examples-hooks/src/03 Nesting/Drag Sources/SourceBox.tsx
+++ b/packages/examples-hooks/src/03 Nesting/Drag Sources/SourceBox.tsx
@@ -27,7 +27,7 @@ const SourceBox: React.FC<SourceBoxProps> = ({
 	const ref = React.useRef(null)
 	const { isDragging } = useDrag({
 		ref,
-		type: `${color}`,
+		item: { type: `${color}` },
 		canDrag: () => !forbidDrag,
 		collect: monitor => ({
 			isDragging: monitor.isDragging(),

--- a/packages/examples-hooks/src/03 Nesting/Drag Sources/SourceBox.tsx
+++ b/packages/examples-hooks/src/03 Nesting/Drag Sources/SourceBox.tsx
@@ -24,9 +24,7 @@ const SourceBox: React.FC<SourceBoxProps> = ({
 	onToggleForbidDrag,
 	children,
 }) => {
-	const ref = React.useRef(null)
-	const { isDragging } = useDrag({
-		ref,
+	const { ref, isDragging } = useDrag({
 		item: { type: `${color}` },
 		canDrag: () => !forbidDrag,
 		collect: monitor => ({

--- a/packages/examples-hooks/src/03 Nesting/Drag Sources/TargetBox.tsx
+++ b/packages/examples-hooks/src/03 Nesting/Drag Sources/TargetBox.tsx
@@ -22,7 +22,7 @@ export interface TargetBoxProps {
 }
 
 const TargetBox: React.FC<TargetBoxProps> = ({ onDrop, lastDroppedColor }) => {
-	const { ref, isOver, draggingColor, canDrop } = useDrop({
+	const [{ isOver, draggingColor, canDrop }, ref] = useDrop({
 		accept: [Colors.YELLOW, Colors.BLUE],
 		drop(item: DragItem) {
 			onDrop(item.type)

--- a/packages/examples-hooks/src/03 Nesting/Drag Sources/TargetBox.tsx
+++ b/packages/examples-hooks/src/03 Nesting/Drag Sources/TargetBox.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import { __EXPERIMENTAL_DND_HOOKS_THAT_MAY_CHANGE_AND_BREAK_MY_BUILD__ } from 'react-dnd'
 import Colors from './Colors'
+import { DragItem } from './interfaces'
 
 const {
 	useDrop,
@@ -22,11 +23,16 @@ export interface TargetBoxProps {
 
 const TargetBox: React.FC<TargetBoxProps> = ({ onDrop, lastDroppedColor }) => {
 	const ref = React.useRef(null)
-	const { isOver, draggingColor, canDrop } = useDrop({
+	const { isOver, draggingColor, canDrop } = useDrop<
+		DragItem,
+		void,
+		{ isOver: boolean; draggingColor: string; canDrop: boolean }
+	>({
 		ref,
 		type: [Colors.YELLOW, Colors.BLUE],
-		drop(monitor) {
-			onDrop(monitor.getItemType())
+		drop(item) {
+			onDrop(item.type)
+			return undefined
 		},
 		collect: monitor => ({
 			isOver: monitor.isOver(),

--- a/packages/examples-hooks/src/03 Nesting/Drag Sources/TargetBox.tsx
+++ b/packages/examples-hooks/src/03 Nesting/Drag Sources/TargetBox.tsx
@@ -29,7 +29,7 @@ const TargetBox: React.FC<TargetBoxProps> = ({ onDrop, lastDroppedColor }) => {
 		{ isOver: boolean; draggingColor: string; canDrop: boolean }
 	>({
 		ref,
-		type: [Colors.YELLOW, Colors.BLUE],
+		accept: [Colors.YELLOW, Colors.BLUE],
 		drop(item) {
 			onDrop(item.type)
 			return undefined

--- a/packages/examples-hooks/src/03 Nesting/Drag Sources/TargetBox.tsx
+++ b/packages/examples-hooks/src/03 Nesting/Drag Sources/TargetBox.tsx
@@ -22,15 +22,9 @@ export interface TargetBoxProps {
 }
 
 const TargetBox: React.FC<TargetBoxProps> = ({ onDrop, lastDroppedColor }) => {
-	const ref = React.useRef(null)
-	const { isOver, draggingColor, canDrop } = useDrop<
-		DragItem,
-		void,
-		{ isOver: boolean; draggingColor: string; canDrop: boolean }
-	>({
-		ref,
+	const { ref, isOver, draggingColor, canDrop } = useDrop({
 		accept: [Colors.YELLOW, Colors.BLUE],
-		drop(item) {
+		drop(item: DragItem) {
 			onDrop(item.type)
 			return undefined
 		},

--- a/packages/examples-hooks/src/03 Nesting/Drag Sources/interfaces.ts
+++ b/packages/examples-hooks/src/03 Nesting/Drag Sources/interfaces.ts
@@ -1,0 +1,3 @@
+export interface DragItem {
+	type: string
+}

--- a/packages/examples-hooks/src/03 Nesting/Drop Targets/Box.tsx
+++ b/packages/examples-hooks/src/03 Nesting/Drop Targets/Box.tsx
@@ -14,7 +14,8 @@ const style = {
 }
 
 const Box: React.FC = () => {
-	const { ref } = useDrag({ item: { type: ItemTypes.BOX } })
+	const ref = React.useRef(null)
+	useDrag({ ref, item: { type: ItemTypes.BOX } })
 	return (
 		<div ref={ref} style={style}>
 			Drag me

--- a/packages/examples-hooks/src/03 Nesting/Drop Targets/Box.tsx
+++ b/packages/examples-hooks/src/03 Nesting/Drop Targets/Box.tsx
@@ -14,8 +14,7 @@ const style = {
 }
 
 const Box: React.FC = () => {
-	const ref = React.useRef(null)
-	useDrag({ ref, item: { type: ItemTypes.BOX } })
+	const { ref } = useDrag({ item: { type: ItemTypes.BOX } })
 	return (
 		<div ref={ref} style={style}>
 			Drag me

--- a/packages/examples-hooks/src/03 Nesting/Drop Targets/Box.tsx
+++ b/packages/examples-hooks/src/03 Nesting/Drop Targets/Box.tsx
@@ -15,7 +15,7 @@ const style = {
 
 const Box: React.FC = () => {
 	const ref = React.useRef(null)
-	useDrag({ ref, type: ItemTypes.BOX })
+	useDrag({ ref, item: { type: ItemTypes.BOX } })
 	return (
 		<div ref={ref} style={style}>
 			Drag me

--- a/packages/examples-hooks/src/03 Nesting/Drop Targets/Dustbin.tsx
+++ b/packages/examples-hooks/src/03 Nesting/Drop Targets/Dustbin.tsx
@@ -37,7 +37,7 @@ const Dustbin: React.FC<DustbinProps> = ({ greedy, children }) => {
 	const ref = React.useRef(null)
 	const { isOver, isOverCurrent } = useDrop({
 		ref,
-		type: ItemTypes.BOX,
+		accept: ItemTypes.BOX,
 		drop(item, monitor) {
 			const didDrop = monitor.didDrop()
 			if (didDrop && !greedy) {

--- a/packages/examples-hooks/src/03 Nesting/Drop Targets/Dustbin.tsx
+++ b/packages/examples-hooks/src/03 Nesting/Drop Targets/Dustbin.tsx
@@ -34,9 +34,7 @@ const Dustbin: React.FC<DustbinProps> = ({ greedy, children }) => {
 	const [hasDropped, setHasDropped] = React.useState(false)
 	const [hasDroppedOnChild, setHasDroppedOnChild] = React.useState(false)
 
-	const ref = React.useRef(null)
-	const { isOver, isOverCurrent } = useDrop({
-		ref,
+	const { ref, isOver, isOverCurrent } = useDrop({
 		accept: ItemTypes.BOX,
 		drop(item, monitor) {
 			const didDrop = monitor.didDrop()

--- a/packages/examples-hooks/src/03 Nesting/Drop Targets/Dustbin.tsx
+++ b/packages/examples-hooks/src/03 Nesting/Drop Targets/Dustbin.tsx
@@ -38,7 +38,7 @@ const Dustbin: React.FC<DustbinProps> = ({ greedy, children }) => {
 	const { isOver, isOverCurrent } = useDrop({
 		ref,
 		type: ItemTypes.BOX,
-		drop(monitor) {
+		drop(item, monitor) {
 			const didDrop = monitor.didDrop()
 			if (didDrop && !greedy) {
 				return

--- a/packages/examples-hooks/src/03 Nesting/Drop Targets/Dustbin.tsx
+++ b/packages/examples-hooks/src/03 Nesting/Drop Targets/Dustbin.tsx
@@ -34,7 +34,7 @@ const Dustbin: React.FC<DustbinProps> = ({ greedy, children }) => {
 	const [hasDropped, setHasDropped] = React.useState(false)
 	const [hasDroppedOnChild, setHasDroppedOnChild] = React.useState(false)
 
-	const { ref, isOver, isOverCurrent } = useDrop({
+	const [{ isOver, isOverCurrent }, ref] = useDrop({
 		accept: ItemTypes.BOX,
 		drop(item, monitor) {
 			const didDrop = monitor.didDrop()

--- a/packages/examples-hooks/src/04 Sortable/Cancel on Drop Outside/Card.tsx
+++ b/packages/examples-hooks/src/04 Sortable/Cancel on Drop Outside/Card.tsx
@@ -34,7 +34,7 @@ const Card: React.FC<CardProps> = ({ id, text, moveCard, findCard }) => {
 
 	useDrop({
 		ref,
-		type: ItemTypes.CARD,
+		accept: ItemTypes.CARD,
 		canDrop: () => false,
 		hover({ id: draggedId }: { id: string }) {
 			if (draggedId !== id) {

--- a/packages/examples-hooks/src/04 Sortable/Cancel on Drop Outside/Card.tsx
+++ b/packages/examples-hooks/src/04 Sortable/Cancel on Drop Outside/Card.tsx
@@ -26,8 +26,7 @@ const Card: React.FC<CardProps> = ({ id, text, moveCard, findCard }) => {
 
 	const { isDragging } = useDrag({
 		ref,
-		type: ItemTypes.CARD,
-		begin: () => ({ id, originalIndex: findCard(id).index }),
+		item: { type: ItemTypes.CARD, id, originalIndex: findCard(id).index },
 		collect: monitor => ({
 			isDragging: monitor.isDragging(),
 		}),

--- a/packages/examples-hooks/src/04 Sortable/Cancel on Drop Outside/Card.tsx
+++ b/packages/examples-hooks/src/04 Sortable/Cancel on Drop Outside/Card.tsx
@@ -22,7 +22,7 @@ export interface CardProps {
 }
 
 const Card: React.FC<CardProps> = ({ id, text, moveCard, findCard }) => {
-	const { ref, isDragging } = useDrag({
+	const [{ isDragging }, ref] = useDrag({
 		item: { type: ItemTypes.CARD, id, originalIndex: findCard(id).index },
 		collect: monitor => ({
 			isDragging: monitor.isDragging(),

--- a/packages/examples-hooks/src/04 Sortable/Cancel on Drop Outside/Card.tsx
+++ b/packages/examples-hooks/src/04 Sortable/Cancel on Drop Outside/Card.tsx
@@ -22,10 +22,7 @@ export interface CardProps {
 }
 
 const Card: React.FC<CardProps> = ({ id, text, moveCard, findCard }) => {
-	const ref = React.useRef(null)
-
-	const { isDragging } = useDrag({
-		ref,
+	const { ref, isDragging } = useDrag({
 		item: { type: ItemTypes.CARD, id, originalIndex: findCard(id).index },
 		collect: monitor => ({
 			isDragging: monitor.isDragging(),

--- a/packages/examples-hooks/src/04 Sortable/Cancel on Drop Outside/Card.tsx
+++ b/packages/examples-hooks/src/04 Sortable/Cancel on Drop Outside/Card.tsx
@@ -36,8 +36,7 @@ const Card: React.FC<CardProps> = ({ id, text, moveCard, findCard }) => {
 		ref,
 		type: ItemTypes.CARD,
 		canDrop: () => false,
-		hover(monitor) {
-			const { id: draggedId } = monitor.getItem()
+		hover({ id: draggedId }: { id: string }) {
 			if (draggedId !== id) {
 				const { index: overIndex } = findCard(id)
 				moveCard(draggedId, overIndex)

--- a/packages/examples-hooks/src/04 Sortable/Cancel on Drop Outside/index.tsx
+++ b/packages/examples-hooks/src/04 Sortable/Cancel on Drop Outside/index.tsx
@@ -49,8 +49,6 @@ const ITEMS = [
 
 const Container: React.FC = () => {
 	const [cards, setCards] = React.useState(ITEMS)
-	const ref = React.useRef(null)
-
 	const moveCard = (id: string, atIndex: number) => {
 		const { card, index } = findCard(id)
 		setCards(
@@ -68,7 +66,7 @@ const Container: React.FC = () => {
 		}
 	}
 
-	useDrop({ ref, accept: ItemTypes.CARD })
+	const { ref } = useDrop({ accept: ItemTypes.CARD })
 	return (
 		<>
 			<h1>EXPERIMENTAL API</h1>

--- a/packages/examples-hooks/src/04 Sortable/Cancel on Drop Outside/index.tsx
+++ b/packages/examples-hooks/src/04 Sortable/Cancel on Drop Outside/index.tsx
@@ -66,7 +66,8 @@ const Container: React.FC = () => {
 		}
 	}
 
-	const { ref } = useDrop({ accept: ItemTypes.CARD })
+	const ref = React.useRef(null)
+	useDrop({ ref, accept: ItemTypes.CARD })
 	return (
 		<>
 			<h1>EXPERIMENTAL API</h1>

--- a/packages/examples-hooks/src/04 Sortable/Cancel on Drop Outside/index.tsx
+++ b/packages/examples-hooks/src/04 Sortable/Cancel on Drop Outside/index.tsx
@@ -68,7 +68,7 @@ const Container: React.FC = () => {
 		}
 	}
 
-	useDrop({ ref, type: ItemTypes.CARD })
+	useDrop({ ref, accept: ItemTypes.CARD })
 	return (
 		<>
 			<h1>EXPERIMENTAL API</h1>

--- a/packages/examples-hooks/src/04 Sortable/Simple/Card.tsx
+++ b/packages/examples-hooks/src/04 Sortable/Simple/Card.tsx
@@ -81,7 +81,7 @@ const Card: React.FC<CardProps> = ({ id, text, index, moveCard }) => {
 
 	const { isDragging } = useDrag({
 		ref,
-		type: ItemTypes.CARD,
+		item: { type: ItemTypes.CARD },
 		begin: () => ({ id, index }),
 		collect: monitor => ({
 			isDragging: monitor.isDragging(),

--- a/packages/examples-hooks/src/04 Sortable/Simple/Card.tsx
+++ b/packages/examples-hooks/src/04 Sortable/Simple/Card.tsx
@@ -24,7 +24,9 @@ export interface CardProps {
 }
 
 const Card: React.FC<CardProps> = ({ id, text, index, moveCard }) => {
-	const { ref } = useDrop({
+	const ref = React.useRef<HTMLDivElement>(null)
+	useDrop({
+		ref,
 		accept: ItemTypes.CARD,
 		hover(item: { index: number }, monitor) {
 			if (!ref.current) {
@@ -76,7 +78,7 @@ const Card: React.FC<CardProps> = ({ id, text, index, moveCard }) => {
 		},
 	})
 
-	const { isDragging } = useDrag({
+	const [{ isDragging }] = useDrag({
 		ref,
 		item: { type: ItemTypes.CARD, id, index },
 		collect: monitor => ({

--- a/packages/examples-hooks/src/04 Sortable/Simple/Card.tsx
+++ b/packages/examples-hooks/src/04 Sortable/Simple/Card.tsx
@@ -29,10 +29,11 @@ const Card: React.FC<CardProps> = ({ id, text, index, moveCard }) => {
 	useDrop({
 		ref,
 		accept: ItemTypes.CARD,
-		hover({ index: dragIndex }: { index: number }, monitor) {
+		hover(item: { index: number }, monitor) {
 			if (!ref.current) {
 				return
 			}
+			const dragIndex = item.index
 			const hoverIndex = index
 
 			// Don't replace items with themselves
@@ -74,14 +75,13 @@ const Card: React.FC<CardProps> = ({ id, text, index, moveCard }) => {
 			// Generally it's better to avoid mutations,
 			// but it's good here for the sake of performance
 			// to avoid expensive index searches.
-			monitor.getItem().index = hoverIndex
+			item.index = hoverIndex
 		},
 	})
 
 	const { isDragging } = useDrag({
 		ref,
-		item: { type: ItemTypes.CARD },
-		begin: () => ({ id, index }),
+		item: { type: ItemTypes.CARD, id, index },
 		collect: monitor => ({
 			isDragging: monitor.isDragging(),
 		}),

--- a/packages/examples-hooks/src/04 Sortable/Simple/Card.tsx
+++ b/packages/examples-hooks/src/04 Sortable/Simple/Card.tsx
@@ -29,11 +29,10 @@ const Card: React.FC<CardProps> = ({ id, text, index, moveCard }) => {
 	useDrop({
 		ref,
 		type: ItemTypes.CARD,
-		hover(monitor) {
+		hover({ index: dragIndex }: { index: number }, monitor) {
 			if (!ref.current) {
 				return
 			}
-			const dragIndex = monitor.getItem().index
 			const hoverIndex = index
 
 			// Don't replace items with themselves

--- a/packages/examples-hooks/src/04 Sortable/Simple/Card.tsx
+++ b/packages/examples-hooks/src/04 Sortable/Simple/Card.tsx
@@ -28,7 +28,7 @@ const Card: React.FC<CardProps> = ({ id, text, index, moveCard }) => {
 
 	useDrop({
 		ref,
-		type: ItemTypes.CARD,
+		accept: ItemTypes.CARD,
 		hover({ index: dragIndex }: { index: number }, monitor) {
 			if (!ref.current) {
 				return

--- a/packages/examples-hooks/src/04 Sortable/Simple/Card.tsx
+++ b/packages/examples-hooks/src/04 Sortable/Simple/Card.tsx
@@ -24,10 +24,7 @@ export interface CardProps {
 }
 
 const Card: React.FC<CardProps> = ({ id, text, index, moveCard }) => {
-	const ref = React.useRef<HTMLDivElement>(null)
-
-	useDrop({
-		ref,
+	const { ref } = useDrop({
 		accept: ItemTypes.CARD,
 		hover(item: { index: number }, monitor) {
 			if (!ref.current) {

--- a/packages/examples-hooks/src/04 Sortable/Simple/index.tsx
+++ b/packages/examples-hooks/src/04 Sortable/Simple/index.tsx
@@ -57,20 +57,22 @@ const Container: React.FC<ContainerProps> = ({}) => {
 			)
 		}
 
+		const renderCard = (card: { id: number; text: string }, index: number) => {
+			return (
+				<Card
+					key={card.id}
+					index={index}
+					id={card.id}
+					text={card.text}
+					moveCard={moveCard}
+				/>
+			)
+		}
+
 		return (
 			<>
 				<h1>EXPERIMENTAL API</h1>
-				<div style={style}>
-					{cards.map((card, i) => (
-						<Card
-							key={card.id}
-							index={i}
-							id={card.id}
-							text={card.text}
-							moveCard={moveCard}
-						/>
-					))}
-				</div>
+				<div style={style}>{cards.map((card, i) => renderCard(card, i))}</div>
 			</>
 		)
 	}

--- a/packages/examples-hooks/src/04 Sortable/Stress Test/Card.tsx
+++ b/packages/examples-hooks/src/04 Sortable/Stress Test/Card.tsx
@@ -21,7 +21,7 @@ export interface CardProps {
 }
 
 const Card: React.FC<CardProps> = ({ id, text, moveCard }) => {
-	const { ref, isDragging } = useDrag({
+	const [{ isDragging }, ref] = useDrag({
 		item: { id, type: ItemTypes.CARD },
 		collect: monitor => ({
 			isDragging: monitor.isDragging(),

--- a/packages/examples-hooks/src/04 Sortable/Stress Test/Card.tsx
+++ b/packages/examples-hooks/src/04 Sortable/Stress Test/Card.tsx
@@ -33,8 +33,7 @@ const Card: React.FC<CardProps> = ({ id, text, moveCard }) => {
 	useDrop({
 		ref,
 		type: ItemTypes.CARD,
-		hover(monitor) {
-			const draggedId = monitor.getItem().id
+		hover({ id: draggedId }: { id: string }) {
 			if (draggedId !== id) {
 				moveCard(draggedId, id)
 			}

--- a/packages/examples-hooks/src/04 Sortable/Stress Test/Card.tsx
+++ b/packages/examples-hooks/src/04 Sortable/Stress Test/Card.tsx
@@ -21,9 +21,7 @@ export interface CardProps {
 }
 
 const Card: React.FC<CardProps> = ({ id, text, moveCard }) => {
-	const ref = React.useRef(null)
-	const { isDragging } = useDrag({
-		ref,
+	const { ref, isDragging } = useDrag({
 		item: { id, type: ItemTypes.CARD },
 		collect: monitor => ({
 			isDragging: monitor.isDragging(),

--- a/packages/examples-hooks/src/04 Sortable/Stress Test/Card.tsx
+++ b/packages/examples-hooks/src/04 Sortable/Stress Test/Card.tsx
@@ -24,8 +24,7 @@ const Card: React.FC<CardProps> = ({ id, text, moveCard }) => {
 	const ref = React.useRef(null)
 	const { isDragging } = useDrag({
 		ref,
-		type: ItemTypes.CARD,
-		begin: () => ({ id }),
+		item: { id, type: ItemTypes.CARD },
 		collect: monitor => ({
 			isDragging: monitor.isDragging(),
 		}),

--- a/packages/examples-hooks/src/04 Sortable/Stress Test/Card.tsx
+++ b/packages/examples-hooks/src/04 Sortable/Stress Test/Card.tsx
@@ -32,7 +32,7 @@ const Card: React.FC<CardProps> = ({ id, text, moveCard }) => {
 
 	useDrop({
 		ref,
-		type: ItemTypes.CARD,
+		accept: ItemTypes.CARD,
 		hover({ id: draggedId }: { id: string }) {
 			if (draggedId !== id) {
 				moveCard(draggedId, id)

--- a/packages/examples-hooks/src/05 Customize/Drop Effects/SourceBox.tsx
+++ b/packages/examples-hooks/src/05 Customize/Drop Effects/SourceBox.tsx
@@ -20,7 +20,7 @@ export interface SourceBoxProps {
 }
 
 const SourceBox: React.FC<SourceBoxProps> = ({ showCopyIcon }) => {
-	const { ref, opacity } = useDrag({
+	const [{ opacity }, ref] = useDrag({
 		item: { type: ItemTypes.BOX },
 		options: {
 			dropEffect: showCopyIcon ? 'copy' : 'move',

--- a/packages/examples-hooks/src/05 Customize/Drop Effects/SourceBox.tsx
+++ b/packages/examples-hooks/src/05 Customize/Drop Effects/SourceBox.tsx
@@ -20,9 +20,7 @@ export interface SourceBoxProps {
 }
 
 const SourceBox: React.FC<SourceBoxProps> = ({ showCopyIcon }) => {
-	const ref = React.useRef(null)
-	const { opacity } = useDrag({
-		ref,
+	const { ref, opacity } = useDrag({
 		item: { type: ItemTypes.BOX },
 		options: {
 			dropEffect: showCopyIcon ? 'copy' : 'move',

--- a/packages/examples-hooks/src/05 Customize/Drop Effects/SourceBox.tsx
+++ b/packages/examples-hooks/src/05 Customize/Drop Effects/SourceBox.tsx
@@ -23,7 +23,7 @@ const SourceBox: React.FC<SourceBoxProps> = ({ showCopyIcon }) => {
 	const ref = React.useRef(null)
 	const { opacity } = useDrag({
 		ref,
-		type: ItemTypes.BOX,
+		item: { type: ItemTypes.BOX },
 		options: {
 			dropEffect: showCopyIcon ? 'copy' : 'move',
 		},

--- a/packages/examples-hooks/src/05 Customize/Drop Effects/TargetBox.tsx
+++ b/packages/examples-hooks/src/05 Customize/Drop Effects/TargetBox.tsx
@@ -18,7 +18,7 @@ const TargetBox: React.FC = () => {
 	const ref = React.useRef(null)
 	const { canDrop, isOver } = useDrop({
 		ref,
-		type: ItemTypes.BOX,
+		accept: ItemTypes.BOX,
 		collect: monitor => ({
 			canDrop: monitor.canDrop(),
 			isOver: monitor.isOver(),

--- a/packages/examples-hooks/src/05 Customize/Drop Effects/TargetBox.tsx
+++ b/packages/examples-hooks/src/05 Customize/Drop Effects/TargetBox.tsx
@@ -15,7 +15,7 @@ const style: React.CSSProperties = {
 }
 
 const TargetBox: React.FC = () => {
-	const { ref, canDrop, isOver } = useDrop({
+	const [{ canDrop, isOver }, ref] = useDrop({
 		accept: ItemTypes.BOX,
 		collect: monitor => ({
 			canDrop: monitor.canDrop(),

--- a/packages/examples-hooks/src/05 Customize/Drop Effects/TargetBox.tsx
+++ b/packages/examples-hooks/src/05 Customize/Drop Effects/TargetBox.tsx
@@ -15,9 +15,7 @@ const style: React.CSSProperties = {
 }
 
 const TargetBox: React.FC = () => {
-	const ref = React.useRef(null)
-	const { canDrop, isOver } = useDrop({
-		ref,
+	const { ref, canDrop, isOver } = useDrop({
 		accept: ItemTypes.BOX,
 		collect: monitor => ({
 			canDrop: monitor.canDrop(),

--- a/packages/examples-hooks/src/05 Customize/Handles and Previews/BoxWithHandle.tsx
+++ b/packages/examples-hooks/src/05 Customize/Handles and Previews/BoxWithHandle.tsx
@@ -24,7 +24,7 @@ const handleStyle: React.CSSProperties = {
 
 const BoxWithHandle: React.FC = () => {
 	const preview = React.useRef(null)
-	const { ref, opacity } = useDrag({
+	const [{ opacity }, ref] = useDrag({
 		item: { type: ItemTypes.BOX },
 		preview,
 		collect: monitor => ({

--- a/packages/examples-hooks/src/05 Customize/Handles and Previews/BoxWithHandle.tsx
+++ b/packages/examples-hooks/src/05 Customize/Handles and Previews/BoxWithHandle.tsx
@@ -27,7 +27,7 @@ const BoxWithHandle: React.FC = () => {
 	const preview = React.useRef(null)
 	const { opacity } = useDrag({
 		ref,
-		type: ItemTypes.BOX,
+		item: { type: ItemTypes.BOX },
 		preview,
 		collect: monitor => ({
 			opacity: monitor.isDragging() ? 0.4 : 1,

--- a/packages/examples-hooks/src/05 Customize/Handles and Previews/BoxWithHandle.tsx
+++ b/packages/examples-hooks/src/05 Customize/Handles and Previews/BoxWithHandle.tsx
@@ -23,10 +23,8 @@ const handleStyle: React.CSSProperties = {
 }
 
 const BoxWithHandle: React.FC = () => {
-	const ref = React.useRef(null)
 	const preview = React.useRef(null)
-	const { opacity } = useDrag({
-		ref,
+	const { ref, opacity } = useDrag({
 		item: { type: ItemTypes.BOX },
 		preview,
 		collect: monitor => ({

--- a/packages/examples-hooks/src/05 Customize/Handles and Previews/BoxWithImage.tsx
+++ b/packages/examples-hooks/src/05 Customize/Handles and Previews/BoxWithImage.tsx
@@ -25,10 +25,8 @@ const BoxImage = React.forwardRef((props, ref: React.Ref<HTMLImageElement>) => {
 })
 
 const BoxWithImage: React.FC = () => {
-	const ref = React.useRef(null)
 	const [preview, DragPreview] = useDragPreview(BoxImage)
-	const { opacity } = useDrag({
-		ref,
+	const { ref, opacity } = useDrag({
 		item: { type: ItemTypes.BOX },
 		preview,
 		collect: monitor => ({

--- a/packages/examples-hooks/src/05 Customize/Handles and Previews/BoxWithImage.tsx
+++ b/packages/examples-hooks/src/05 Customize/Handles and Previews/BoxWithImage.tsx
@@ -25,8 +25,8 @@ const BoxImage = React.forwardRef((props, ref: React.Ref<HTMLImageElement>) => {
 })
 
 const BoxWithImage: React.FC = () => {
-	const [preview, DragPreview] = useDragPreview(BoxImage)
-	const { ref, opacity } = useDrag({
+	const [DragPreview, preview] = useDragPreview(BoxImage)
+	const [{ opacity }, ref] = useDrag({
 		item: { type: ItemTypes.BOX },
 		preview,
 		collect: monitor => ({

--- a/packages/examples-hooks/src/05 Customize/Handles and Previews/BoxWithImage.tsx
+++ b/packages/examples-hooks/src/05 Customize/Handles and Previews/BoxWithImage.tsx
@@ -26,7 +26,7 @@ const BoxWithImage: React.FC = () => {
 
 	const { opacity } = useDrag({
 		ref,
-		type: ItemTypes.BOX,
+		item: { type: ItemTypes.BOX },
 		preview: preview as any,
 		collect: monitor => ({
 			opacity: monitor.isDragging() ? 0.4 : 1,

--- a/packages/examples-hooks/src/05 Customize/Handles and Previews/BoxWithImage.tsx
+++ b/packages/examples-hooks/src/05 Customize/Handles and Previews/BoxWithImage.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
-import { createPortal } from 'react-dom'
 import { __EXPERIMENTAL_DND_HOOKS_THAT_MAY_CHANGE_AND_BREAK_MY_BUILD__ } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 import boxImage from './boxImage'
 
 const {
 	useDrag,
+	useDragPreview,
 } = __EXPERIMENTAL_DND_HOOKS_THAT_MAY_CHANGE_AND_BREAK_MY_BUILD__
 
 const style = {
@@ -24,21 +24,13 @@ const BoxImage = React.forwardRef((props, ref: React.Ref<HTMLImageElement>) => {
 	return <img ref={ref} src={boxImage} />
 })
 
-const BoxImageWrapper: React.FC<any> = React.forwardRef(
-	({ root }, ref: React.Ref<HTMLImageElement>) => {
-		return createPortal(<BoxImage ref={ref} />, root)
-	},
-)
-
 const BoxWithImage: React.FC = () => {
 	const ref = React.useRef(null)
-	const preview = React.useRef(null)
-	const dragPreviewRoot = document.createElement('div')
-
+	const [preview, DragPreview] = useDragPreview(BoxImage)
 	const { opacity } = useDrag({
 		ref,
 		item: { type: ItemTypes.BOX },
-		preview: preview as any,
+		preview,
 		collect: monitor => ({
 			opacity: monitor.isDragging() ? 0.4 : 1,
 		}),
@@ -46,7 +38,7 @@ const BoxWithImage: React.FC = () => {
 
 	return (
 		<>
-			<BoxImageWrapper ref={preview} root={dragPreviewRoot} />
+			<DragPreview />
 			<div ref={ref} style={{ ...style, opacity }}>
 				Drag me to see an image
 			</div>

--- a/packages/examples-hooks/src/05 Customize/Handles and Previews/BoxWithImage.tsx
+++ b/packages/examples-hooks/src/05 Customize/Handles and Previews/BoxWithImage.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { createPortal } from 'react-dom'
 import { __EXPERIMENTAL_DND_HOOKS_THAT_MAY_CHANGE_AND_BREAK_MY_BUILD__ } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 import boxImage from './boxImage'
@@ -16,13 +17,23 @@ const style = {
 	width: '20rem',
 }
 
+const BoxImage = React.forwardRef((props, ref: React.Ref<HTMLImageElement>) => {
+	if (typeof Image === 'undefined') {
+		return null
+	}
+	return <img ref={ref} src={boxImage} />
+})
+
+const BoxImageWrapper: React.FC<any> = React.forwardRef(
+	({ root }, ref: React.Ref<HTMLImageElement>) => {
+		return createPortal(<BoxImage ref={ref} />, root)
+	},
+)
+
 const BoxWithImage: React.FC = () => {
 	const ref = React.useRef(null)
-	const preview = new Promise(resolve => {
-		const img = new Image()
-		img.onload = () => resolve(img)
-		img.src = boxImage
-	})
+	const preview = React.useRef(null)
+	const dragPreviewRoot = document.createElement('div')
 
 	const { opacity } = useDrag({
 		ref,
@@ -34,9 +45,12 @@ const BoxWithImage: React.FC = () => {
 	})
 
 	return (
-		<div ref={ref} style={{ ...style, opacity }}>
-			Drag me to see an image
-		</div>
+		<>
+			<BoxImageWrapper ref={preview} root={dragPreviewRoot} />
+			<div ref={ref} style={{ ...style, opacity }}>
+				Drag me to see an image
+			</div>
+		</>
 	)
 }
 export default BoxWithImage

--- a/packages/examples-hooks/src/06 Other/Native Files/TargetBox.tsx
+++ b/packages/examples-hooks/src/06 Other/Native Files/TargetBox.tsx
@@ -22,8 +22,7 @@ export interface TargetBoxProps {
 
 const TargetBox: React.FC<TargetBoxProps> = props => {
 	const { accepts: accept, onDrop } = props
-	const ref = React.useRef(null)
-	const { canDrop, isOver } = useDrop({
+	const { ref, canDrop, isOver } = useDrop({
 		ref,
 		accept,
 		drop(item, monitor) {

--- a/packages/examples-hooks/src/06 Other/Native Files/TargetBox.tsx
+++ b/packages/examples-hooks/src/06 Other/Native Files/TargetBox.tsx
@@ -22,8 +22,7 @@ export interface TargetBoxProps {
 
 const TargetBox: React.FC<TargetBoxProps> = props => {
 	const { accepts: accept, onDrop } = props
-	const { ref, canDrop, isOver } = useDrop({
-		ref,
+	const [{ canDrop, isOver }, ref] = useDrop({
 		accept,
 		drop(item, monitor) {
 			if (onDrop) {

--- a/packages/examples-hooks/src/06 Other/Native Files/TargetBox.tsx
+++ b/packages/examples-hooks/src/06 Other/Native Files/TargetBox.tsx
@@ -21,11 +21,11 @@ export interface TargetBoxProps {
 }
 
 const TargetBox: React.FC<TargetBoxProps> = props => {
-	const { accepts, onDrop } = props
+	const { accepts: accept, onDrop } = props
 	const ref = React.useRef(null)
 	const { canDrop, isOver } = useDrop({
 		ref,
-		type: accepts,
+		accept,
 		drop(item, monitor) {
 			if (onDrop) {
 				onDrop(props, monitor)

--- a/packages/examples-hooks/src/06 Other/Native Files/TargetBox.tsx
+++ b/packages/examples-hooks/src/06 Other/Native Files/TargetBox.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import * as React from 'react'
 import {
 	__EXPERIMENTAL_DND_HOOKS_THAT_MAY_CHANGE_AND_BREAK_MY_BUILD__,
 	DropTargetMonitor,
@@ -22,11 +22,11 @@ export interface TargetBoxProps {
 
 const TargetBox: React.FC<TargetBoxProps> = props => {
 	const { accepts, onDrop } = props
-	const ref = useRef(null)
+	const ref = React.useRef(null)
 	const { canDrop, isOver } = useDrop({
 		ref,
 		type: accepts,
-		drop(monitor) {
+		drop(item, monitor) {
 			if (onDrop) {
 				onDrop(props, monitor)
 			}

--- a/packages/react-dnd/src/hooks/index.ts
+++ b/packages/react-dnd/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useDrag'
 export * from './useDrop'
 export * from './useDragLayer'
+export * from './useDragPreview'

--- a/packages/react-dnd/src/hooks/internal/useDragSourceMonitor.ts
+++ b/packages/react-dnd/src/hooks/internal/useDragSourceMonitor.ts
@@ -10,10 +10,11 @@ import registerSource from '../../registerSource'
 
 export function useDragSourceMonitor<
 	DragObject extends DragObjectWithType,
+	DropResult,
 	CustomProps
 >(
 	manager: DragDropManager<any>,
-	sourceSpec: DragSourceHookSpec<DragObject, CustomProps>,
+	sourceSpec: DragSourceHookSpec<DragObject, DropResult, CustomProps>,
 ): DragSourceMonitor {
 	const sourceSpecRef = useRef(sourceSpec)
 
@@ -59,7 +60,7 @@ export function useDragSourceMonitor<
 				endDrag() {
 					const { end } = sourceSpecRef.current
 					if (end) {
-						end(monitor)
+						end(monitor.getItem(), monitor)
 					}
 				},
 			} as DragSource),

--- a/packages/react-dnd/src/hooks/internal/useDragSourceMonitor.ts
+++ b/packages/react-dnd/src/hooks/internal/useDragSourceMonitor.ts
@@ -1,10 +1,17 @@
 import { useMemo, useEffect, useRef } from 'react'
 import { DragSource, DragDropManager } from 'dnd-core'
-import { DragSourceHookSpec, DragSourceMonitor } from '../../interfaces'
+import {
+	DragSourceHookSpec,
+	DragSourceMonitor,
+	DragObjectWithType,
+} from '../../interfaces'
 import DragSourceMonitorImpl from '../../DragSourceMonitorImpl'
 import registerSource from '../../registerSource'
 
-export function useDragSourceMonitor<DragObject, CustomProps>(
+export function useDragSourceMonitor<
+	DragObject extends DragObjectWithType,
+	CustomProps
+>(
 	manager: DragDropManager<any>,
 	sourceSpec: DragSourceHookSpec<DragObject, CustomProps>,
 ): DragSourceMonitor {
@@ -18,7 +25,7 @@ export function useDragSourceMonitor<DragObject, CustomProps>(
 	useEffect(
 		function registerSourceWithMonitor() {
 			const { handlerId, unregister } = registerSource(
-				sourceSpec.type,
+				sourceSpec.item.type,
 				handler,
 				manager,
 			)
@@ -33,12 +40,11 @@ export function useDragSourceMonitor<DragObject, CustomProps>(
 		() =>
 			({
 				beginDrag() {
-					const { begin } = sourceSpecRef.current
+					const { begin, item } = sourceSpecRef.current
 					if (begin) {
-						return begin(monitor)
-					} else {
-						return {}
+						begin(monitor)
 					}
+					return item || {}
 				},
 				canDrag() {
 					const { canDrag } = sourceSpecRef.current

--- a/packages/react-dnd/src/hooks/internal/useDropTargetMonitor.ts
+++ b/packages/react-dnd/src/hooks/internal/useDropTargetMonitor.ts
@@ -20,7 +20,7 @@ export function useDropTargetMonitor<CustomProps, DragItem, DropResult>(
 	React.useEffect(
 		function registerTargetWithMonitor() {
 			const { handlerId, unregister } = registerTarget(
-				targetSpec.type,
+				targetSpec.accept,
 				handler,
 				manager,
 			)

--- a/packages/react-dnd/src/hooks/internal/useDropTargetMonitor.ts
+++ b/packages/react-dnd/src/hooks/internal/useDropTargetMonitor.ts
@@ -4,9 +4,9 @@ import { DropTarget, DragDropManager } from 'dnd-core'
 import DropTargetMonitorImpl from '../../DropTargetMonitorImpl'
 import registerTarget from '../../registerTarget'
 
-export function useDropTargetMonitor<CustomProps>(
+export function useDropTargetMonitor<CustomProps, DragItem, DropResult>(
 	manager: DragDropManager<any>,
-	targetSpec: DropTargetHookSpec<CustomProps>,
+	targetSpec: DropTargetHookSpec<CustomProps, DragItem, DropResult>,
 ): DropTargetMonitor {
 	const targetSpecRef = React.useRef(targetSpec)
 
@@ -36,18 +36,18 @@ export function useDropTargetMonitor<CustomProps>(
 			({
 				canDrop() {
 					const { canDrop } = targetSpecRef.current
-					return canDrop ? canDrop(monitor) : true
+					return canDrop ? canDrop(monitor.getItem(), monitor) : true
 				},
 				hover() {
 					const { hover } = targetSpecRef.current
 					if (hover) {
-						hover(monitor)
+						hover(monitor.getItem(), monitor)
 					}
 				},
 				drop() {
 					const { drop } = targetSpecRef.current
 					if (drop) {
-						return drop(monitor)
+						return drop(monitor.getItem(), monitor)
 					}
 				},
 			} as DropTarget),

--- a/packages/react-dnd/src/hooks/useDrag.ts
+++ b/packages/react-dnd/src/hooks/useDrag.ts
@@ -1,6 +1,6 @@
 declare var require: any
 import { useEffect } from 'react'
-import { DragSourceHookSpec } from '../interfaces'
+import { DragSourceHookSpec, DragObjectWithType } from '../interfaces'
 import { useDragSourceMonitor } from './internal/useDragSourceMonitor'
 import { useDragDropManager } from './internal/useDragDropManager'
 import { Ref, isRef } from './util'
@@ -11,13 +11,14 @@ const invariant = require('invariant')
  * useDragSource hook (This API is experimental and subject to breaking changes in non-major versions)
  * @param sourceSpec The drag source specification *
  */
-export function useDrag<DragObject, CustomProps>(
+export function useDrag<DragObject extends DragObjectWithType, CustomProps>(
 	spec: DragSourceHookSpec<DragObject, CustomProps>,
 ): CustomProps {
-	const { ref, type, options, preview, previewOptions, collect } = spec
+	const { ref, item, options, preview, previewOptions, collect } = spec
 	invariant(ref != null, 'ref instance must be defined')
 	invariant(typeof ref === 'object', 'ref must be a ref object')
-	invariant(type != null, 'type must be defined')
+	invariant(item != null, 'item must be defined')
+	invariant(item.type != null, 'item type must be defined')
 	const manager = useDragDropManager()
 	const backend = manager.getBackend()
 	const monitor = useDragSourceMonitor<DragObject, CustomProps>(manager, spec)

--- a/packages/react-dnd/src/hooks/useDrag.ts
+++ b/packages/react-dnd/src/hooks/useDrag.ts
@@ -41,17 +41,15 @@ export function useDrag<
 	 */
 	useEffect(
 		function connectDragPreview() {
-			const connectPreview = (p: any) => {
-				const previewNode = isRef(p) ? (p as Ref<any>).current : p
+			if (preview) {
+				const previewNode = isRef(preview)
+					? (preview as Ref<any>).current
+					: preview
 				return backend.connectDragPreview(
 					monitor.getHandlerId(),
 					previewNode,
 					previewOptions,
 				)
-			}
-
-			if (preview) {
-				connectPreview(preview)
 			}
 		},
 		[preview && (preview as Ref<any>).current],

--- a/packages/react-dnd/src/hooks/useDrag.ts
+++ b/packages/react-dnd/src/hooks/useDrag.ts
@@ -11,9 +11,11 @@ const invariant = require('invariant')
  * useDragSource hook (This API is experimental and subject to breaking changes in non-major versions)
  * @param sourceSpec The drag source specification *
  */
-export function useDrag<DragObject extends DragObjectWithType, CustomProps>(
-	spec: DragSourceHookSpec<DragObject, CustomProps>,
-): CustomProps {
+export function useDrag<
+	DragObject extends DragObjectWithType,
+	DropResult,
+	CustomProps
+>(spec: DragSourceHookSpec<DragObject, DropResult, CustomProps>): CustomProps {
 	const { ref, item, options, preview, previewOptions, collect } = spec
 	invariant(ref != null, 'ref instance must be defined')
 	invariant(typeof ref === 'object', 'ref must be a ref object')
@@ -21,7 +23,10 @@ export function useDrag<DragObject extends DragObjectWithType, CustomProps>(
 	invariant(item.type != null, 'item type must be defined')
 	const manager = useDragDropManager()
 	const backend = manager.getBackend()
-	const monitor = useDragSourceMonitor<DragObject, CustomProps>(manager, spec)
+	const monitor = useDragSourceMonitor<DragObject, DropResult, CustomProps>(
+		manager,
+		spec,
+	)
 
 	/*
 	 * Connect the Drag Source Element to the Backend

--- a/packages/react-dnd/src/hooks/useDrag.ts
+++ b/packages/react-dnd/src/hooks/useDrag.ts
@@ -1,5 +1,5 @@
 declare var require: any
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { DragSourceHookSpec, DragObjectWithType } from '../interfaces'
 import { useDragSourceMonitor } from './internal/useDragSourceMonitor'
 import { useDragDropManager } from './internal/useDragDropManager'
@@ -14,25 +14,30 @@ const invariant = require('invariant')
 export function useDrag<
 	DragObject extends DragObjectWithType,
 	DropResult,
-	CustomProps
->(spec: DragSourceHookSpec<DragObject, DropResult, CustomProps>): CustomProps {
-	const { ref, item, options, preview, previewOptions, collect } = spec
-	invariant(ref != null, 'ref instance must be defined')
-	invariant(typeof ref === 'object', 'ref must be a ref object')
+	CollectedProps,
+	ElementType extends Element
+>(
+	spec: DragSourceHookSpec<DragObject, DropResult, CollectedProps>,
+): CollectedProps & { ref: React.RefObject<ElementType> } {
+	const { item, options, preview, previewOptions, collect } = spec
+	let { ref } = spec
 	invariant(item != null, 'item must be defined')
 	invariant(item.type != null, 'item type must be defined')
 	const manager = useDragDropManager()
 	const backend = manager.getBackend()
-	const monitor = useDragSourceMonitor<DragObject, DropResult, CustomProps>(
+	const monitor = useDragSourceMonitor<DragObject, DropResult, CollectedProps>(
 		manager,
 		spec,
 	)
+	if (!ref) {
+		ref = useRef(null)
+	}
 
 	/*
 	 * Connect the Drag Source Element to the Backend
 	 */
 	useEffect(function connectDragSource() {
-		const node = ref.current
+		const node = ref!.current
 		return backend.connectDragSource(monitor.getHandlerId(), node, options)
 	}, [])
 
@@ -55,9 +60,9 @@ export function useDrag<
 		[preview && (preview as Ref<any>).current],
 	)
 
-	if (collect) {
-		return useMonitorOutput(monitor as any, collect as any)
-	} else {
-		return {} as CustomProps
-	}
+	const result: CollectedProps & { ref: React.RefObject<Element> } = collect
+		? (useMonitorOutput(monitor as any, collect as any) as any)
+		: (({} as CollectedProps) as any)
+	result.ref = ref!
+	return result as any
 }

--- a/packages/react-dnd/src/hooks/useDrag.ts
+++ b/packages/react-dnd/src/hooks/useDrag.ts
@@ -14,11 +14,10 @@ const invariant = require('invariant')
 export function useDrag<
 	DragObject extends DragObjectWithType,
 	DropResult,
-	CollectedProps,
-	ElementType extends Element
+	CollectedProps
 >(
 	spec: DragSourceHookSpec<DragObject, DropResult, CollectedProps>,
-): CollectedProps & { ref: React.RefObject<ElementType> } {
+): [CollectedProps, React.RefObject<any>] {
 	const { item, options, preview, previewOptions, collect } = spec
 	let { ref } = spec
 	invariant(item != null, 'item must be defined')
@@ -63,6 +62,5 @@ export function useDrag<
 	const result: CollectedProps & { ref: React.RefObject<Element> } = collect
 		? (useMonitorOutput(monitor as any, collect as any) as any)
 		: (({} as CollectedProps) as any)
-	result.ref = ref!
-	return result as any
+	return [result, ref]
 }

--- a/packages/react-dnd/src/hooks/useDrag.ts
+++ b/packages/react-dnd/src/hooks/useDrag.ts
@@ -50,12 +50,7 @@ export function useDrag<
 				)
 			}
 
-			if (preview == null) {
-				return
-			}
-			if (typeof (preview as any).then === 'function') {
-				;(preview as any).then((p: any) => connectPreview(p))
-			} else {
+			if (preview) {
 				connectPreview(preview)
 			}
 		},

--- a/packages/react-dnd/src/hooks/useDragPreview.ts
+++ b/packages/react-dnd/src/hooks/useDragPreview.ts
@@ -7,7 +7,7 @@ import { createPortal } from 'react-dom'
  */
 export function useDragPreview<Props>(
 	DragPreview: React.RefForwardingComponent<Element, Props>,
-): [React.RefObject<Element>, React.FC<Props>] {
+): [React.FC<Props>, React.RefObject<Element>] {
 	// drag previews won't have layered functionality, so we can create the ref for them
 	// here
 	const ref = React.useRef(null)
@@ -22,5 +22,5 @@ export function useDragPreview<Props>(
 		)
 	}
 
-	return [ref, portaledComponent]
+	return [portaledComponent, ref]
 }

--- a/packages/react-dnd/src/hooks/useDragPreview.ts
+++ b/packages/react-dnd/src/hooks/useDragPreview.ts
@@ -1,0 +1,26 @@
+import * as React from 'react'
+import { createPortal } from 'react-dom'
+
+/**
+ * Hook for showing a dragPreview
+ * @param DragPreview The drag preview component to render
+ */
+export function useDragPreview<Props>(
+	DragPreview: React.RefForwardingComponent<Element, Props>,
+): [React.RefObject<Element>, React.FC<Props>] {
+	// drag previews won't have layered functionality, so we can create the ref for them
+	// here
+	const ref = React.useRef(null)
+
+	// render the dragPreview into a detached element to prevent it from appearing too early
+	const dragPreviewRoot = document.createElement('div')
+	const portaledComponent = (props: Props) => {
+		const sendProps = { ...props, ref }
+		return createPortal(
+			React.createElement(DragPreview, sendProps),
+			dragPreviewRoot,
+		)
+	}
+
+	return [ref, portaledComponent]
+}

--- a/packages/react-dnd/src/hooks/useDrop.ts
+++ b/packages/react-dnd/src/hooks/useDrop.ts
@@ -10,8 +10,8 @@ const invariant = require('invariant')
  * useDropTarget Hook (This API is experimental and subject to breaking changes in non-breaking versions)
  * @param spec The drop target specification
  */
-export function useDrop<CustomProps>(
-	spec: DropTargetHookSpec<CustomProps>,
+export function useDrop<DragObject, DropResult, CustomProps>(
+	spec: DropTargetHookSpec<DragObject, DropResult, CustomProps>,
 ): CustomProps {
 	const { ref, type, options, collect } = spec
 	invariant(ref != null, 'ref instance must be defined')

--- a/packages/react-dnd/src/hooks/useDrop.ts
+++ b/packages/react-dnd/src/hooks/useDrop.ts
@@ -10,14 +10,9 @@ const invariant = require('invariant')
  * useDropTarget Hook (This API is experimental and subject to breaking changes in non-breaking versions)
  * @param spec The drop target specification
  */
-export function useDrop<
-	DragObject,
-	DropResult,
-	CollectedProps,
-	ElementType extends Element
->(
+export function useDrop<DragObject, DropResult, CollectedProps>(
 	spec: DropTargetHookSpec<DragObject, DropResult, CollectedProps>,
-): CollectedProps & { ref: React.RefObject<ElementType> } {
+): [CollectedProps, React.RefObject<any>] {
 	const { accept, options, collect } = spec
 	invariant(accept != null, 'accept must be defined')
 	let { ref } = spec
@@ -44,6 +39,5 @@ export function useDrop<
 	const result: CollectedProps & { ref: React.RefObject<Element> } = collect
 		? (useMonitorOutput(monitor as any, collect as any) as any)
 		: (({} as CollectedProps) as any)
-	result.ref = ref!
-	return result as any
+	return [result, ref]
 }

--- a/packages/react-dnd/src/hooks/useDrop.ts
+++ b/packages/react-dnd/src/hooks/useDrop.ts
@@ -13,10 +13,10 @@ const invariant = require('invariant')
 export function useDrop<DragObject, DropResult, CustomProps>(
 	spec: DropTargetHookSpec<DragObject, DropResult, CustomProps>,
 ): CustomProps {
-	const { ref, type, options, collect } = spec
+	const { ref, accept, options, collect } = spec
 	invariant(ref != null, 'ref instance must be defined')
 	invariant(typeof ref === 'object', 'ref must be a ref object')
-	invariant(type != null, 'type must be defined')
+	invariant(accept != null, 'accept must be defined')
 
 	const manager = useDragDropManager()
 	const backend = manager.getBackend()

--- a/packages/react-dnd/src/index.ts
+++ b/packages/react-dnd/src/index.ts
@@ -8,10 +8,11 @@ export { default as DragLayer } from './DragLayer'
 export { default as DragSource } from './DragSource'
 export { default as DropTarget } from './DropTarget'
 export * from './interfaces'
-import { useDrag, useDragLayer, useDrop } from './hooks'
+import { useDrag, useDragLayer, useDrop, useDragPreview } from './hooks'
 
 export const __EXPERIMENTAL_DND_HOOKS_THAT_MAY_CHANGE_AND_BREAK_MY_BUILD__ = {
 	useDrag,
 	useDragLayer,
 	useDrop,
+	useDragPreview,
 }

--- a/packages/react-dnd/src/interfaces/hooksApi.ts
+++ b/packages/react-dnd/src/interfaces/hooksApi.ts
@@ -6,7 +6,7 @@ import { DragSourceOptions, DragPreviewOptions } from './options'
 /**
  * Interface for the DropTarget specification object
  */
-export interface DropTargetHookSpec<CollectedProps> {
+export interface DropTargetHookSpec<DragObject, DropResult, CollectedProps> {
 	ref: RefObject<any>
 	type: TargetType
 	options?: any
@@ -21,7 +21,10 @@ export interface DropTargetHookSpec<CollectedProps> {
 	 * the source's endDrag method are good places to fire Flux actions. This method will not be called if canDrop()
 	 * is defined and returns false.
 	 */
-	drop?: (monitor: DropTargetMonitor) => any
+	drop?: (
+		item: DragObject,
+		monitor: DropTargetMonitor,
+	) => DropResult | undefined
 
 	/**
 	 * Optional.
@@ -29,14 +32,14 @@ export interface DropTargetHookSpec<CollectedProps> {
 	 * the hover happens over just the current target, or over a nested one. Unlike drop(), this method will be called even
 	 * if canDrop() is defined and returns false. You can check monitor.canDrop() to test whether this is the case.
 	 */
-	hover?: (monitor: DropTargetMonitor) => void
+	hover?: (item: DragObject, monitor: DropTargetMonitor) => void
 
 	/**
 	 * Optional. Use it to specify whether the drop target is able to accept the item. If you want to always allow it, just
 	 * omit this method. Specifying it is handy if you'd like to disable dropping based on some predicate over props or
 	 * monitor.getItem(). Note: You may not call monitor.canDrop() inside this method.
 	 */
-	canDrop?: (monitor: DropTargetMonitor) => boolean
+	canDrop?: (item: DragObject, monitor: DropTargetMonitor) => boolean
 
 	/**
 	 * A function to collect rendering properties
@@ -50,6 +53,7 @@ export interface DragObjectWithType {
 
 export interface DragSourceHookSpec<
 	DragObject extends DragObjectWithType,
+	DropResult,
 	CollectedProps
 > {
 	ref: RefObject<any>
@@ -67,6 +71,9 @@ export interface DragSourceHookSpec<
 	 */
 	item: DragObject
 
+	/**
+	 * The drag source options
+	 */
 	options?: DragSourceOptions
 
 	/**
@@ -92,7 +99,7 @@ export interface DragSourceHookSpec<
 	 * monitor.getDropResult(). This method is a good place to fire a Flux action. Note: If the component is unmounted while dragging,
 	 * component parameter is set to be null.
 	 */
-	end?: (monitor: DragSourceMonitor) => void
+	end?: (dropResult: DropResult | undefined, monitor: DragSourceMonitor) => void
 
 	/**
 	 * Optional.

--- a/packages/react-dnd/src/interfaces/hooksApi.ts
+++ b/packages/react-dnd/src/interfaces/hooksApi.ts
@@ -44,21 +44,45 @@ export interface DropTargetHookSpec<CollectedProps> {
 	collect?: (monitor: DropTargetMonitor) => CollectedProps
 }
 
-export interface DragSourceHookSpec<DragObject, CollectedProps> {
-	ref: RefObject<any>
+export interface DragObjectWithType {
 	type: SourceType
+}
+
+export interface DragSourceHookSpec<
+	DragObject extends DragObjectWithType,
+	CollectedProps
+> {
+	ref: RefObject<any>
+
+	/**
+	 * A plain javascript item describing the data being dragged.
+	 * This is the only information available to the drop targets about the drag
+	 * source so it's important to pick the minimal data they need to know.
+	 *
+	 * You may be tempted to put a reference to the component or complex object here,
+	 * but you shouldx try very hard to avoid doing this because it couples the
+	 * drag sources and drop targets. It's a good idea to use something like
+	 * { id: props.id }
+	 *
+	 */
+	item: DragObject
+
 	options?: DragSourceOptions
+
+	/**
+	 * An optional dragPreview
+	 */
 	preview?: React.Ref<any> | Element | Promise<React.Ref<any> | Element>
+
+	/**
+	 * DragPreview options
+	 */
 	previewOptions?: DragPreviewOptions
 
 	/**
-	 * When the dragging starts, beginDrag is called. You must return a plain JavaScript object describing the
-	 * data being dragged. What you return is the only information available to the drop targets about the drag
-	 * source so it's important to pick the minimal data they need to know. You may be tempted to put a reference
-	 * to the component into it, but you should try very hard to avoid doing this because it couples the drag
-	 * sources and drop targets. It's a good idea to return something like { id: props.id } from this method.
+	 * When the dragging starts, beginDrag is called.
 	 */
-	begin?: (monitor: DragSourceMonitor) => DragObject
+	begin?: (monitor: DragSourceMonitor) => void
 
 	/**
 	 * Optional.

--- a/packages/react-dnd/src/interfaces/hooksApi.ts
+++ b/packages/react-dnd/src/interfaces/hooksApi.ts
@@ -31,7 +31,7 @@ export interface DragSourceHookSpec<
 	/**
 	 * An optional dragPreview
 	 */
-	preview?: React.Ref<any> | Element | Promise<React.Ref<any> | Element>
+	preview?: RefObject<any> | Element
 
 	/**
 	 * DragPreview options

--- a/packages/react-dnd/src/interfaces/hooksApi.ts
+++ b/packages/react-dnd/src/interfaces/hooksApi.ts
@@ -8,7 +8,11 @@ export interface DragSourceHookSpec<
 	DropResult,
 	CollectedProps
 > {
-	ref: RefObject<any>
+	/**
+	 * The ref object to associated with this dragged itom. If this is not specified it will be
+	 * returned in the `ref` field of the result object.
+	 */
+	ref?: RefObject<any>
 
 	/**
 	 * A plain javascript item describing the data being dragged.
@@ -83,8 +87,20 @@ export interface DragSourceHookSpec<
  * Interface for the DropTarget specification object
  */
 export interface DropTargetHookSpec<DragObject, DropResult, CollectedProps> {
-	ref: RefObject<any>
+	/**
+	 * The ref object to associated with this dragged itom. If this is not specified it will be
+	 * returned in the `ref` field of the result object.
+	 */
+	ref?: RefObject<any>
+
+	/**
+	 * The kinds of dragItems this dropTarget accepts
+	 */
 	accept: TargetType
+
+	/**
+	 * The drop target optinos
+	 */
 	options?: any
 
 	/**

--- a/packages/react-dnd/src/interfaces/hooksApi.ts
+++ b/packages/react-dnd/src/interfaces/hooksApi.ts
@@ -3,54 +3,6 @@ import { DropTargetMonitor, DragSourceMonitor } from './monitors'
 import { RefObject } from 'react'
 import { DragSourceOptions, DragPreviewOptions } from './options'
 
-/**
- * Interface for the DropTarget specification object
- */
-export interface DropTargetHookSpec<DragObject, DropResult, CollectedProps> {
-	ref: RefObject<any>
-	type: TargetType
-	options?: any
-
-	/**
-	 * Optional.
-	 * Called when a compatible item is dropped on the target. You may either return undefined, or a plain object.
-	 * If you return an object, it is going to become the drop result and will be available to the drag source in its
-	 * endDrag method as monitor.getDropResult(). This is useful in case you want to perform different actions
-	 * depending on which target received the drop. If you have nested drop targets, you can test whether a nested
-	 * target has already handled drop by checking monitor.didDrop() and monitor.getDropResult(). Both this method and
-	 * the source's endDrag method are good places to fire Flux actions. This method will not be called if canDrop()
-	 * is defined and returns false.
-	 */
-	drop?: (
-		item: DragObject,
-		monitor: DropTargetMonitor,
-	) => DropResult | undefined
-
-	/**
-	 * Optional.
-	 * Called when an item is hovered over the component. You can check monitor.isOver({ shallow: true }) to test whether
-	 * the hover happens over just the current target, or over a nested one. Unlike drop(), this method will be called even
-	 * if canDrop() is defined and returns false. You can check monitor.canDrop() to test whether this is the case.
-	 */
-	hover?: (item: DragObject, monitor: DropTargetMonitor) => void
-
-	/**
-	 * Optional. Use it to specify whether the drop target is able to accept the item. If you want to always allow it, just
-	 * omit this method. Specifying it is handy if you'd like to disable dropping based on some predicate over props or
-	 * monitor.getItem(). Note: You may not call monitor.canDrop() inside this method.
-	 */
-	canDrop?: (item: DragObject, monitor: DropTargetMonitor) => boolean
-
-	/**
-	 * A function to collect rendering properties
-	 */
-	collect?: (monitor: DropTargetMonitor) => CollectedProps
-}
-
-export interface DragObjectWithType {
-	type: SourceType
-}
-
 export interface DragSourceHookSpec<
 	DragObject extends DragObjectWithType,
 	DropResult,
@@ -125,4 +77,52 @@ export interface DragSourceHookSpec<
 	 * A function to collect rendering properties
 	 */
 	collect?: (monitor: DragSourceMonitor) => CollectedProps
+}
+
+/**
+ * Interface for the DropTarget specification object
+ */
+export interface DropTargetHookSpec<DragObject, DropResult, CollectedProps> {
+	ref: RefObject<any>
+	accept: TargetType
+	options?: any
+
+	/**
+	 * Optional.
+	 * Called when a compatible item is dropped on the target. You may either return undefined, or a plain object.
+	 * If you return an object, it is going to become the drop result and will be available to the drag source in its
+	 * endDrag method as monitor.getDropResult(). This is useful in case you want to perform different actions
+	 * depending on which target received the drop. If you have nested drop targets, you can test whether a nested
+	 * target has already handled drop by checking monitor.didDrop() and monitor.getDropResult(). Both this method and
+	 * the source's endDrag method are good places to fire Flux actions. This method will not be called if canDrop()
+	 * is defined and returns false.
+	 */
+	drop?: (
+		item: DragObject,
+		monitor: DropTargetMonitor,
+	) => DropResult | undefined
+
+	/**
+	 * Optional.
+	 * Called when an item is hovered over the component. You can check monitor.isOver({ shallow: true }) to test whether
+	 * the hover happens over just the current target, or over a nested one. Unlike drop(), this method will be called even
+	 * if canDrop() is defined and returns false. You can check monitor.canDrop() to test whether this is the case.
+	 */
+	hover?: (item: DragObject, monitor: DropTargetMonitor) => void
+
+	/**
+	 * Optional. Use it to specify whether the drop target is able to accept the item. If you want to always allow it, just
+	 * omit this method. Specifying it is handy if you'd like to disable dropping based on some predicate over props or
+	 * monitor.getItem(). Note: You may not call monitor.canDrop() inside this method.
+	 */
+	canDrop?: (item: DragObject, monitor: DropTargetMonitor) => boolean
+
+	/**
+	 * A function to collect rendering properties
+	 */
+	collect?: (monitor: DropTargetMonitor) => CollectedProps
+}
+
+export interface DragObjectWithType {
+	type: SourceType
 }


### PR DESCRIPTION
__useDrag__
* beginDrag()'s invariant to return the dragItem has been replaced with an `item` field on the spec. This field contains the dragItem type (which is required), and is no longer required on the top-level spe
* make ref argument optional. If no ref is passed in, then a ref will be created for the client.

e.g.:

```js
const ref = useRef(null)
const collectedProps = useDrag({
  ref, 
  type, 
  beginDrag: () => {id}
})

=> 

const [collectedProps, ref] = useDrag({
  item: {type, id}
})
```

* dropResult has been added as the first parameter of `drop()`

__useDrop__
* `type` has been renamed `accept`
* dragItem has been added as the first parameter of `drop()`, `hover()`, and `canDrop()`
* make ref argument optional. If no ref is passed in, then a ref will be created for the client.

New Hook:
__usedDragPreview__
This hook wraps a refForwarding component and manages rendering it into a detached DOM element and rendering it in a React portal.

```js
const [DragPreviewComponent, dragPreviewRef] = useDragPreview(DragPreviewRefForwarding)
```