### PR TITLE
Hooks API: dragSpec.begin() may now return a DragObject

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,6 +1,20 @@
 module.exports = {
 	extends: ['@commitlint/config-conventional'],
 	rules: {
+		// 72 is too constricting, especially with a required subject
 		'header-max-length': [2, 'always', '120'],
 	},
 }
+
+// config-conventional defines the following subjects:
+// 'build',
+// 'chore',
+// 'ci',
+// 'docs',
+// 'feat',
+// 'fix',
+// 'perf',
+// 'refactor',
+// 'revert',
+// 'style',
+// 'test'

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,6 @@
-module.exports = { extends: ['@commitlint/config-conventional'] }
+module.exports = {
+	extends: ['@commitlint/config-conventional'],
+	rules: {
+		'header-max-length': [2, 'always', '120'],
+	},
+}

--- a/packages/documentation/markdown/docs/05 Hooks-Based API/useDrag.md
+++ b/packages/documentation/markdown/docs/05 Hooks-Based API/useDrag.md
@@ -46,7 +46,7 @@ function DraggableComponent(props) {
 
 * **`options`**: Optional. A plain object. If some of the props to your component are not scalar (that is, are not primitive values or functions), specifying a custom`arePropsEqual(props, otherProps)`function inside the`options` object can improve the performance. Unless you have performance problems, don't worry about it.
 
-* **`begin(monitor)`**: Optionaln. Fired when a drag operation begins.
+* **`begin(monitor)`**: Optional. Fired when a drag operation begins. Nothing needs to be returned, but if an object is returned it will override the default `item` property of the spec.
 
 * **`end(monitor)`**: Optional. When the dragging stops, `end` is called. For every `begin` call, a corresponding `end` call is guaranteed. You may call `monitor.didDrop()` to check whether or not the drop was handled by a compatible drop target. If it was handled, and the drop target specified a _drop result_ by returning a plain object from its `drop()` method, it will be available as `monitor.getDropResult()`. This method is a good place to fire a Flux action. _Note: If the component is unmounted while dragging, `component` parameter is set to be `null`._
 

--- a/packages/react-dnd/src/hooks/internal/useDragSourceMonitor.ts
+++ b/packages/react-dnd/src/hooks/internal/useDragSourceMonitor.ts
@@ -43,7 +43,8 @@ export function useDragSourceMonitor<
 				beginDrag() {
 					const { begin, item } = sourceSpecRef.current
 					if (begin) {
-						begin(monitor)
+						const beginResult = begin(monitor)
+						return beginResult || item || {}
 					}
 					return item || {}
 				},

--- a/packages/react-dnd/src/hooks/internal/useDragSourceMonitor.ts
+++ b/packages/react-dnd/src/hooks/internal/useDragSourceMonitor.ts
@@ -1,3 +1,4 @@
+declare var require: any
 import { useMemo, useEffect, useRef } from 'react'
 import { DragSource, DragDropManager } from 'dnd-core'
 import {
@@ -7,6 +8,7 @@ import {
 } from '../../interfaces'
 import DragSourceMonitorImpl from '../../DragSourceMonitorImpl'
 import registerSource from '../../registerSource'
+const invariant = require('invariant')
 
 export function useDragSourceMonitor<
 	DragObject extends DragObjectWithType,
@@ -44,6 +46,10 @@ export function useDragSourceMonitor<
 					const { begin, item } = sourceSpecRef.current
 					if (begin) {
 						const beginResult = begin(monitor)
+						invariant(
+							beginResult == null || typeof beginResult === 'object',
+							'dragSpec.begin() must either return an object, undefined, or null',
+						)
 						return beginResult || item || {}
 					}
 					return item || {}

--- a/packages/react-dnd/src/interfaces/hooksApi.ts
+++ b/packages/react-dnd/src/interfaces/hooksApi.ts
@@ -43,9 +43,9 @@ export interface DragSourceHookSpec<
 	previewOptions?: DragPreviewOptions
 
 	/**
-	 * When the dragging starts, beginDrag is called.
+	 * When the dragging starts, beginDrag is called. If an object is returned from this function it will overide the default dragItem
 	 */
-	begin?: (monitor: DragSourceMonitor) => void
+	begin?: (monitor: DragSourceMonitor) => DragObject | undefined
 
 	/**
 	 * Optional.


### PR DESCRIPTION
This is optional, but if begin() is defined and it returns an object, it will override the dragItem on the drag spec. The drag spec item is still required to set the item type.

Fixes #1263 