### PR TITLE
New Feature Proposal: Connect with Ref Objects

### DIFF
--- a/packages/dnd-core/package.json
+++ b/packages/dnd-core/package.json
@@ -10,8 +10,7 @@
 		"build:cjs": "tsc -b tsconfig.cjs.json",
 		"build": "run-p build:*",
 		"clean": "rimraf lib",
-		"watch": "tsc -w --preserveWatchOutput",
-		"start": "npm run watch",
+		"start": "tsc -b tsconfig.cjs.json -w --preserveWatchOutput",
 		"test": "run-s clean build"
 	},
 	"repository": {

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -49,8 +49,7 @@
 	},
 	"scripts": {
 		"clean": "rimraf .cache public apidocs static/examples_js",
-		"develop": "gatsby develop",
-		"start": "npm run develop",
+		"start": "gatsby develop",
 		"copy_example_source": "cp -r ../examples/lib/docs static/examples_js",
 		"format_example_source": "prettier 'static/examples_js/**/*.js*' --use-tabs=false --write",
 		"build_static_site": "gatsby build --prefix-paths",

--- a/packages/examples-hooks/package.json
+++ b/packages/examples-hooks/package.json
@@ -17,7 +17,7 @@
 		"build:docs": "tsc -b tsconfig.docs.json",
 		"build": "run-p build:*",
 		"test": "run-s clean build",
-		"start": "tsc -w --preserveWatchOutput"
+		"start": "tsc -b tsconfig.cjs.json -w --preserveWatchOutput"
 	},
 	"dependencies": {
 		"@types/faker": "^4.1.5",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -17,7 +17,7 @@
 		"build:docs": "tsc -b tsconfig.docs.json",
 		"build": "run-p build:*",
 		"test": "run-s clean build",
-		"start": "tsc -w --preserveWatchOutput"
+		"start": "tsc -b tsconfig.cjs.json -w --preserveWatchOutput"
 	},
 	"dependencies": {
 		"@types/faker": "^4.1.5",

--- a/packages/examples/src/01 Dustbin/Single Target/Box.tsx
+++ b/packages/examples/src/01 Dustbin/Single Target/Box.tsx
@@ -1,10 +1,5 @@
 import React from 'react'
-import {
-	ConnectDragSource,
-	DragSource,
-	DragSourceConnector,
-	DragSourceMonitor,
-} from 'react-dnd'
+import { DragSource, DragSourceConnector, DragSourceMonitor } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 
 const style: React.CSSProperties = {
@@ -23,7 +18,7 @@ interface BoxProps {
 
 interface BoxCollectedProps {
 	isDragging: boolean
-	connectDragSource: ConnectDragSource
+	dragSource: React.RefObject<any>
 }
 
 const boxSource = {
@@ -45,11 +40,15 @@ const boxSource = {
 
 class Box extends React.Component<BoxProps & BoxCollectedProps> {
 	public render() {
-		const { isDragging, connectDragSource } = this.props
+		const { isDragging, dragSource } = this.props
 		const { name } = this.props
 		const opacity = isDragging ? 0.4 : 1
 
-		return connectDragSource(<div style={{ ...style, opacity }}>{name}</div>)
+		return (
+			<div ref={dragSource} style={{ ...style, opacity }}>
+				{name}
+			</div>
+		)
 	}
 }
 
@@ -57,7 +56,7 @@ export default DragSource(
 	ItemTypes.BOX,
 	boxSource,
 	(connect: DragSourceConnector, monitor: DragSourceMonitor) => ({
-		connectDragSource: connect.dragSource(),
+		dragSource: connect.dragSourceRef,
 		isDragging: monitor.isDragging(),
 	}),
 )(Box)

--- a/packages/examples/src/01 Dustbin/Single Target/Dustbin.tsx
+++ b/packages/examples/src/01 Dustbin/Single Target/Dustbin.tsx
@@ -1,10 +1,5 @@
 import React from 'react'
-import {
-	DropTarget,
-	DropTargetConnector,
-	DropTargetMonitor,
-	ConnectDropTarget,
-} from 'react-dnd'
+import { DropTarget, DropTargetConnector, DropTargetMonitor } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 
 const style: React.CSSProperties = {
@@ -21,20 +16,18 @@ const style: React.CSSProperties = {
 }
 
 const boxTarget = {
-	drop() {
-		return { name: 'Dustbin' }
-	},
+	drop: () => ({ name: 'Dustbin' }),
 }
 
 export interface DustbinProps {
 	canDrop: boolean
 	isOver: boolean
-	connectDropTarget: ConnectDropTarget
+	dropTarget: React.RefObject<any>
 }
 
 class Dustbin extends React.Component<DustbinProps> {
 	public render() {
-		const { canDrop, isOver, connectDropTarget } = this.props
+		const { canDrop, isOver, dropTarget } = this.props
 		const isActive = canDrop && isOver
 
 		let backgroundColor = '#222'
@@ -44,10 +37,10 @@ class Dustbin extends React.Component<DustbinProps> {
 			backgroundColor = 'darkkhaki'
 		}
 
-		return connectDropTarget(
-			<div style={{ ...style, backgroundColor }}>
+		return (
+			<div ref={dropTarget} style={{ ...style, backgroundColor }}>
 				{isActive ? 'Release to drop' : 'Drag a box here'}
-			</div>,
+			</div>
 		)
 	}
 }
@@ -56,7 +49,7 @@ export default DropTarget(
 	ItemTypes.BOX,
 	boxTarget,
 	(connect: DropTargetConnector, monitor: DropTargetMonitor) => ({
-		connectDropTarget: connect.dropTarget(),
+		dropTarget: connect.dropTargetRef,
 		isOver: monitor.isOver(),
 		canDrop: monitor.canDrop(),
 	}),

--- a/packages/react-dnd-html5-backend/package.json
+++ b/packages/react-dnd-html5-backend/package.json
@@ -18,8 +18,7 @@
 		"bundle:min": "webpack --mode production --output-filename=ReactDnDHTML5Backend.min.js",
 		"build": "run-p bundle:* transpile",
 		"test": "run-s clean build",
-		"watch": "tsc -w --preserveWatchOutput",
-		"start": "npm run watch"
+		"start": "tsc -b tsconfig.esm.json -w --preserveWatchOutput"
 	},
 	"dependencies": {
 		"dnd-core": "^7.2.0",

--- a/packages/react-dnd/package.json
+++ b/packages/react-dnd/package.json
@@ -18,8 +18,7 @@
 		"transpile": "run-p transpile:*",
 		"build": "run-p bundle:* transpile",
 		"test": "run-s clean build",
-		"watch": "tsc -w --preserveWatchOutput",
-		"start": "npm run watch"
+		"start": "tsc -b tsconfig.cjs.json -w --preserveWatchOutput"
 	},
 	"dependencies": {
 		"dnd-core": "^7.2.0",

--- a/packages/react-dnd/src/createSourceConnector.ts
+++ b/packages/react-dnd/src/createSourceConnector.ts
@@ -1,9 +1,7 @@
-declare var require: any
 import * as React from 'react'
 import wrapConnectorHooks from './wrapConnectorHooks'
 import { Backend, Unsubscribe, Identifier } from 'dnd-core'
 import { isRef } from './hooks/util'
-const shallowEqual = require('shallowequal')
 
 export default function createSourceConnector(backend: Backend) {
 	let currentHandlerId: Identifier
@@ -62,46 +60,29 @@ export default function createSourceConnector(backend: Backend) {
 		reconnectDragPreview()
 	}
 
-	const hooks = wrapConnectorHooks({
-		dragSourceRef,
-		dragPreviewRef,
-
-		dragSource: function connectDragSource(node: any, options?: any) {
-			// check for a ref object being passed in
-			if (isRef(node)) {
-				dragSourceRef = node
-				return
-			}
-
-			if (node === dragSourceNode && shallowEqual(options, dragSourceOptions)) {
-				return
-			}
-
-			dragSourceNode = node
-			dragSourceOptions = options
-		},
-
-		dragPreview: function connectDragPreview(node: any, options?: any) {
-			// check for a ref object being passed in
-			if (isRef(node)) {
-				dragPreviewRef = node
-				return
-			}
-			if (
-				node === dragPreviewNode &&
-				shallowEqual(options, dragPreviewOptions)
-			) {
-				return
-			}
-
-			dragPreviewNode = node
-			dragPreviewOptions = options
-		},
-	})
-
 	return {
 		receiveHandlerId,
-		hooks,
+		hooks: wrapConnectorHooks({
+			dragSourceRef,
+			dragPreviewRef,
+			dragSource: function connectDragSource(node: any, options?: any) {
+				dragSourceOptions = options
+				if (isRef(node)) {
+					dragSourceRef = node
+				} else {
+					dragSourceNode = node
+				}
+			},
+
+			dragPreview: function connectDragPreview(node: any, options?: any) {
+				dragPreviewOptions = options
+				if (isRef(node)) {
+					dragPreviewRef = node
+				} else {
+					dragPreviewNode = node
+				}
+			},
+		}),
 		reconnect: () => {
 			reconnectDragSource()
 			reconnectDragPreview()

--- a/packages/react-dnd/src/createSourceConnector.ts
+++ b/packages/react-dnd/src/createSourceConnector.ts
@@ -2,19 +2,20 @@ declare var require: any
 import * as React from 'react'
 import wrapConnectorHooks from './wrapConnectorHooks'
 import { Backend, Unsubscribe, Identifier } from 'dnd-core'
+import { isRef } from './hooks/util'
 const shallowEqual = require('shallowequal')
 
 export default function createSourceConnector(backend: Backend) {
 	let currentHandlerId: Identifier
 
 	// The drop target may either be attached via ref or connect function
-	const dragSourceRef = React.createRef<any>()
+	let dragSourceRef = React.createRef<any>()
 	let dragSourceNode: any
 	let dragSourceOptions: any
 	let disconnectDragSource: Unsubscribe | undefined
 
 	// The drag preview may either be attached via ref or connect function
-	const dragPreviewRef = React.createRef<any>()
+	let dragPreviewRef = React.createRef<any>()
 	let dragPreviewNode: any
 	let dragPreviewOptions: any
 	let disconnectDragPreview: Unsubscribe | undefined
@@ -65,7 +66,13 @@ export default function createSourceConnector(backend: Backend) {
 		dragSourceRef,
 		dragPreviewRef,
 
-		dragSource: function connectDragSource(node: any, options: any) {
+		dragSource: function connectDragSource(node: any, options?: any) {
+			// check for a ref object being passed in
+			if (isRef(node)) {
+				dragSourceRef = node
+				return
+			}
+
 			if (node === dragSourceNode && shallowEqual(options, dragSourceOptions)) {
 				return
 			}
@@ -74,7 +81,12 @@ export default function createSourceConnector(backend: Backend) {
 			dragSourceOptions = options
 		},
 
-		dragPreview: function connectDragPreview(node: any, options: any) {
+		dragPreview: function connectDragPreview(node: any, options?: any) {
+			// check for a ref object being passed in
+			if (isRef(node)) {
+				dragPreviewRef = node
+				return
+			}
 			if (
 				node === dragPreviewNode &&
 				shallowEqual(options, dragPreviewOptions)

--- a/packages/react-dnd/src/createTargetConnector.ts
+++ b/packages/react-dnd/src/createTargetConnector.ts
@@ -2,12 +2,13 @@ declare var require: any
 import * as React from 'react'
 import wrapConnectorHooks from './wrapConnectorHooks'
 import { Backend, Unsubscribe, Identifier } from 'dnd-core'
+import { isRef } from './hooks/util'
 const shallowEqual = require('shallowequal')
 
 export default function createTargetConnector(backend: Backend) {
 	let handlerId: Identifier
 	// The drop target may either be attached via ref or connect function
-	const dropTargetRef = React.createRef<any>()
+	let dropTargetRef = React.createRef<any>()
 	let dropTargetNode: any
 	let dropTargetOptions: any
 	let disconnectDropTarget: Unsubscribe | undefined
@@ -40,6 +41,12 @@ export default function createTargetConnector(backend: Backend) {
 	const hooks = wrapConnectorHooks({
 		dropTargetRef,
 		dropTarget: function connectDropTarget(node: any, options: any) {
+			// check for a ref object being passed in
+			if (isRef(node)) {
+				dropTargetRef = node
+				return
+			}
+
 			if (node === dropTargetNode && shallowEqual(options, dropTargetOptions)) {
 				return
 			}

--- a/packages/react-dnd/src/createTargetConnector.ts
+++ b/packages/react-dnd/src/createTargetConnector.ts
@@ -1,9 +1,7 @@
-declare var require: any
 import * as React from 'react'
 import wrapConnectorHooks from './wrapConnectorHooks'
 import { Backend, Unsubscribe, Identifier } from 'dnd-core'
 import { isRef } from './hooks/util'
-const shallowEqual = require('shallowequal')
 
 export default function createTargetConnector(backend: Backend) {
 	let handlerId: Identifier
@@ -38,27 +36,19 @@ export default function createTargetConnector(backend: Backend) {
 		reconnectDropTarget()
 	}
 
-	const hooks = wrapConnectorHooks({
-		dropTargetRef,
-		dropTarget: function connectDropTarget(node: any, options: any) {
-			// check for a ref object being passed in
-			if (isRef(node)) {
-				dropTargetRef = node
-				return
-			}
-
-			if (node === dropTargetNode && shallowEqual(options, dropTargetOptions)) {
-				return
-			}
-
-			dropTargetNode = node
-			dropTargetOptions = options
-		},
-	})
-
 	return {
 		receiveHandlerId,
-		hooks,
+		hooks: wrapConnectorHooks({
+			dropTargetRef,
+			dropTarget: function connectDropTarget(node: any, options: any) {
+				dropTargetOptions = options
+				if (isRef(node)) {
+					dropTargetRef = node
+				} else {
+					dropTargetNode = node
+				}
+			},
+		}),
 		reconnect: reconnectDropTarget,
 	}
 }

--- a/packages/react-dnd/src/decorateHandler.tsx
+++ b/packages/react-dnd/src/decorateHandler.tsx
@@ -41,6 +41,8 @@ interface Handler<Props> {
 
 interface HandlerConnector extends HandlerReceiver {
 	hooks: any[]
+	receiveHandlerId: (handleId: any) => void
+	reconnect: () => void
 }
 
 export default function decorateHandler<Props, ItemIdType>({
@@ -205,6 +207,7 @@ export default function decorateHandler<Props, ItemIdType>({
 							return null
 						}
 						this.receiveDragDropManager(dragDropManager)
+						requestAnimationFrame(() => this.handlerConnector!.reconnect())
 
 						return (
 							<Decorated

--- a/packages/react-dnd/src/interfaces/classApi.ts
+++ b/packages/react-dnd/src/interfaces/classApi.ts
@@ -116,7 +116,11 @@ export interface DragSourceSpec<Props, DragObject> {
 	isDragging?: (props: Props, monitor: DragSourceMonitor) => boolean
 }
 
-export type ConnectedElement = React.ReactElement | Element | null
+export type ConnectedElement =
+	| React.RefObject<any>
+	| React.ReactElement
+	| Element
+	| null
 export type DragElementWrapper<Options> = <Props>(
 	elementOrNode: ConnectedElement,
 	options?: Options,

--- a/packages/react-dnd/src/interfaces/classApi.ts
+++ b/packages/react-dnd/src/interfaces/classApi.ts
@@ -131,6 +131,16 @@ export type ConnectDragPreview = DragElementWrapper<DragPreviewOptions>
  */
 export interface DragSourceConnector {
 	/**
+	 * A React ref object to attach to the drag source. This replaces the dragSource() function described below.
+	 */
+	dragSourceRef: React.RefObject<any>
+
+	/**
+	 * A React ref object to attach to the drag preview. This replaces the dragPreview() function described below.
+	 */
+	dragPreviewRef: React.RefObject<any>
+
+	/**
 	 * Returns a function that must be used inside the component to assign the drag source role to a node. By
 	 * returning { connectDragSource: connect.dragSource() } from your collecting function, you can mark any React
 	 * element as the draggable node. To do that, replace any element with this.props.connectDragSource(element) inside
@@ -160,6 +170,11 @@ export interface DragSourceConnector {
  * that lets you assign the drop target role to one of your component's DOM nodes.
  */
 export interface DropTargetConnector {
+	/**
+	 * A React ref object to attach to the drop target. This replaces the dropTarget() function described below.
+	 */
+	dropTargetRef: React.RefObject<any>
+
 	/**
 	 * Returns a function that must be used inside the component to assign the drop target role to a node.
 	 * By returning { connectDropTarget: connect.dropTarget() } from your collecting function, you can mark any React element

--- a/packages/react-dnd/src/wrapConnectorHooks.ts
+++ b/packages/react-dnd/src/wrapConnectorHooks.ts
@@ -44,8 +44,14 @@ export default function wrapConnectorHooks(hooks: any) {
 
 	Object.keys(hooks).forEach(key => {
 		const hook = hooks[key]
-		const wrappedHook = wrapHookToRecognizeElement(hook)
-		wrappedHooks[key] = () => wrappedHook
+
+		// ref objects should be passed straight through without wrapping
+		if (key.endsWith('Ref')) {
+			wrappedHooks[key] = hooks[key]
+		} else {
+			const wrappedHook = wrapHookToRecognizeElement(hook)
+			wrappedHooks[key] = () => wrappedHook
+		}
 	})
 
 	return wrappedHooks


### PR DESCRIPTION
The current mechanism for wiring react elements into the backends seems dated. It was designed before React ref objects were conceived of in React.

The proposed mechanism here will be more straightforward, and will mirror what we see in the hooks-based API.  

The `dragSourceConnector` has the following new properties: `dragSourceRef`, `dragPreviewRef`.
The `dropTargetConnector` has the following new property: `dropTargetRef`

If the existing `connect<X>()` functions are used, they will take precedence over the ref objects.

__Basic Example__
```js
function Card({ dragSource, text }) {
  return(
    <div ref={dragSource}>
      {text}
    </div>
  );
}
export default DragSource(
  ...
  (connect, monitor) => ({
    dragSource: connect.dragSourceRef,
  })
)(Card);
```

__Composite Example with Dnd-Provided Ref__
```js
function Card({ dragSource, connectDropTarget, text }) {
  connectDropTarget(dragSource);
  return(
    <div ref={dragSource}>
      {text}
    </div>
  );
}

export default DragSource(
    ...
  (connect, monitor) => ({
      dragSource: connect.dragSourceRef,
    })
)(DropTarget(
 ...,
 (connect) => ({
    connectDropTarget: connect.dropTarget()
  })
)(Card);
```

__Composite Example with Client-Provided Ref__
```js
function Card({ connectDragSource, connectDropTarget, text }) {
  const ref = useRef(null);
  connectDragSource(ref)
  connectDropTarget(ref);
  return(
    <div ref={ref}>
      {text}
    </div>
  );
}

export default DragSource(
    ...
  (connect, monitor) => ({
      dragSource: connect.dragSource()
    })
)(DropTarget(
 ...,
 (connect) => ({
    connectDropTarget: connect.dropTarget()
  })
)(Card);
```