### PR TITLE
Don't create native drags out of an array, and make them enumerable

### DIFF
--- a/packages/react-dnd-html5-backend/src/NativeDragSources/NativeDragSource.ts
+++ b/packages/react-dnd-html5-backend/src/NativeDragSources/NativeDragSource.ts
@@ -5,8 +5,9 @@ export class NativeDragSource {
 	public item: any
 
 	constructor(private config: NativeItemConfig) {
-		this.item = Object.create(
-			Object.keys(this.config.exposeProperties).map(property => ({
+		this.item = {}
+		Object.keys(this.config.exposeProperties).forEach(property => {
+			Object.defineProperty(this.item, property, {
 				configurable: true, // This is needed to allow redefining it later
 				get() {
 					// tslint:disable-next-line no-console
@@ -15,8 +16,8 @@ export class NativeDragSource {
 					)
 					return null
 				},
-			})),
-		)
+			})
+		})
 	}
 
 	public mutateItemByReadingDataTransfer(dataTransfer: DataTransfer | null) {

--- a/packages/react-dnd-html5-backend/src/NativeDragSources/NativeDragSource.ts
+++ b/packages/react-dnd-html5-backend/src/NativeDragSources/NativeDragSource.ts
@@ -9,6 +9,7 @@ export class NativeDragSource {
 		Object.keys(this.config.exposeProperties).forEach(property => {
 			Object.defineProperty(this.item, property, {
 				configurable: true, // This is needed to allow redefining it later
+				enumerable: true,
 				get() {
 					// tslint:disable-next-line no-console
 					console.warn(


### PR DESCRIPTION
The `Object.create()` thing was a weird one. It really meant to be a plain object, I think.

Then I made the properties enumerable so we can do stuff like `{ ...monitor.getItem() }` more easily 😄 