### PR TITLE
fix: remove the useEffect invocation from DragDropContextProvider

### DIFF
--- a/packages/react-dnd/src/DragDropContext.tsx
+++ b/packages/react-dnd/src/DragDropContext.tsx
@@ -54,12 +54,6 @@ export const DragDropContextProvider: React.FC<
 	DragDropContextProviderProps<any>
 > = ({ backend, context, debugMode, children }) => {
 	const contextValue = createChildContext(backend, context, debugMode)
-	React.useEffect(() => {
-		return () =>
-			contextValue.dragDropManager.dispatch({
-				type: 'DragDropContextProvider::Exiting',
-			})
-	})
 	return <Provider value={contextValue}>{children}</Provider>
 }
 


### PR DESCRIPTION
Should fix #1275. I don't believe this effect is really useful anyway.