### PR TITLE
Connector Ref Updates

### DIFF
--- a/packages/documentation/markdown/docs/02 Connecting to DOM/DragSourceConnector.md
+++ b/packages/documentation/markdown/docs/02 Connecting to DOM/DragSourceConnector.md
@@ -11,9 +11,9 @@ _New to React DnD? [Read the overview](/docs/overview) before jumping into the d
 
 ## Properties
 
-- **`dragSourceRef`**: A [ref](https://reactjs.org/docs/refs-and-the-dom.html) that may be used to attach to your Drag Source element. This may be used in lieu of the `dragSource()`function described below.
+- **`dragSourceRef()`**: A function that returns a new [ref](https://reactjs.org/docs/refs-and-the-dom.html) that may be used to attach to your Drag Source element. This may be used in lieu of the `dragSource()`function described below.
 
-- **`dragPreviewRef`**_(optional)_: A [ref](https://reactjs.org/docs/refs-and-the-dom.html) that may be used to attach to your Drag Preview element. This may be used in lieu of the `dragPreview()` function described below.
+- **`dragPreviewRef()`**_(optional)_: A function that returns a new [ref](https://reactjs.org/docs/refs-and-the-dom.html) that may be used to attach to your Drag Preview element. This may be used in lieu of the `dragPreview()` function described below.
 
 - **`dragSource() => (Element | Node | Ref, options?)`**: Returns a function that should be prop-injected into your component and used in that component's `render()` method. You may pass this function a react component, an DOM element, or a ref object to this method.
 
@@ -118,8 +118,8 @@ import { DragSource } from 'react-dnd';
 
 function collect(connect, monitor) {
   return {
-    dragSource: connect.dragSourceRef,
-    dragPreview: connect.dragPreviewRef
+    dragSource: connect.dragSourceRef(),
+    dragPreview: connect.dragPreviewRef()
   };
 }
 

--- a/packages/documentation/markdown/docs/02 Connecting to DOM/DragSourceConnector.md
+++ b/packages/documentation/markdown/docs/02 Connecting to DOM/DragSourceConnector.md
@@ -7,15 +7,17 @@ _New to React DnD? [Read the overview](/docs/overview) before jumping into the d
 
 # DragSourceConnector
 
-`DragSourceConnector` is an object passed to a collecting function of the [`DragSource`](/docs/api/drag-source). Its methods return functions that let you assign the roles to your component's DOM nodes.
+`DragSourceConnector` is an object passed to the _collecting function_ of the [`DragSource`](/docs/api/drag-source). It provides the ability to bind your React component to the Drag Source role. You **must** use one of the binding mechanisms provided by the connector for your component to be recognized as a Drag Source in React-DnD.
 
-### Methods
+## Properties
 
-Call the `DragSourceConnector` methods inside your _collecting function_. This will pass the returned functions to your component as props. You can then use them inside `render` or `componentDidMount` to indicate the DOM node roles. Internally they work by attaching a [callback ref](https://facebook.github.io/react/docs/more-about-refs.html#the-ref-callback-attribute) to the React elements you give them. These callbacks connect the DOM nodes of your component to the chosen DnD backend.
+- **`dragSourceRef`**: A [ref](https://reactjs.org/docs/refs-and-the-dom.html) that may be used to attach to your Drag Source element. This may be used in lieu of the `dragSource()`function described below.
 
-- **`dragSource() => (elementOrNode, options?)`**: Returns a function that must be used inside the component to assign the drag source role to a node. By returning `{ connectDragSource: connect.dragSource() }` from your collecting function, you can mark any React element as the draggable node. To do that, replace any `element` with `this.props.connectDragSource(element)` inside the `render` function.
+- **`dragPreviewRef`**_(optional)_: A [ref](https://reactjs.org/docs/refs-and-the-dom.html) that may be used to attach to your Drag Preview element. This may be used in lieu of the `dragPreview()` function described below.
 
-- **`dragPreview() => (elementOrNode, options?)`**: Optional. Returns a function that may be used inside the component to assign the drag preview role to a node. By returning `{ connectDragPreview: connect.dragPreview() }` from your collecting function, you can mark any React element as the drag preview node. To do that, replace any `element` with `this.props.connectDragPreview(element)` inside the `render` function. The drag preview is the node that will be screenshotted by the [HTML5 backend](/docs/backends/html5) when the drag begins. For example, if you want to make something draggable by a small custom handle, you can mark this handle as the `dragSource()`, but also mark an outer, larger component node as the `dragPreview()`. Thus the larger drag preview appears on the screenshot, but only the smaller drag source is actually draggable. Another possible customization is passing an [`Image`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/Image) instance to `dragPreview` from a lifecycle method like `componentDidMount`. This lets you use the actual images for drag previews. (Note that IE does not support this customization). See the example code below for the different usage examples.
+- **`dragSource() => (Element | Node | Ref, options?)`**: Returns a function that should be prop-injected into your component and used in that component's `render()` method. You may pass this function a react component, an DOM element, or a ref object to this method.
+
+- **`dragPreview() => (Element | Node | Ref, options?)`**_(optional)_: Returns a function that may be used inside the component to assign the drag preview role to a node. By returning `{ connectDragPreview: connect.dragPreview() }` from your collecting function, you can mark any React element as the drag preview node. To do that, replace any `element` with `this.props.connectDragPreview(element)` inside the `render` function. The drag preview is the node that will be screenshotted by the [HTML5 backend](/docs/backends/html5) when the drag begins. For example, if you want to make something draggable by a small custom handle, you can mark this handle as the `dragSource()`, but also mark an outer, larger component node as the `dragPreview()`. Thus the larger drag preview appears on the screenshot, but only the smaller drag source is actually draggable. Another possible customization is passing an [`Image`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/Image) instance to `dragPreview` from a lifecycle method like `componentDidMount`. This lets you use the actual images for drag previews. (Note that IE does not support this customization). See the example code below for the different usage examples.
 
 ### Method Options
 
@@ -37,9 +39,9 @@ The functions returned by the connector methods also accept options. They need t
 
 - `offsetY`: Optional. A number or null if not needed. By default, null. Specifies the vertical offset between the cursor and the drag preview element. If offsetY has a value, anchorY won't be used.
 
-### Example
+## Usage Patterns
 
-Check out [the tutorial](/docs/tutorial) for more real examples!
+### Pattern 1: Connector Functions
 
 ```js
 import React from 'react';
@@ -66,7 +68,7 @@ class ComponentWithCopyEffect {
     );
   }
 });
-ComponentWithCopyEffect = DragSource(/* ... */)(ComponentWithCopyEffect);
+ComponentWithCopyEffect = DragSource(type, {/* ... */}, collect)(ComponentWithCopyEffect);
 
 class ComponentWithHandle {
   render() {
@@ -82,7 +84,7 @@ class ComponentWithHandle {
     );
   }
 }
-ComponentWithHandle = DragSource(/* ... */)(ComponentWithHandle);
+ComponentWithHandle = DragSource(type, {/* ... */}, collect)(ComponentWithHandle);
 
 class ComponentWithImagePreview {
   componentDidMount() {
@@ -103,5 +105,39 @@ class ComponentWithImagePreview {
     );
   }
 }
-ComponentWithImagePreview = DragSource(/* ... */)(ComponentWithImagePreview);
+ComponentWithImagePreview = DragSource(type, {/* ... */}, collect)(ComponentWithImagePreview);
 ```
+
+### Pattern 2: Provided Refs
+
+```js
+import React from 'react';
+import { DragSource } from 'react-dnd';
+
+/* ... */
+
+function collect(connect, monitor) {
+  return {
+    dragSource: connect.dragSourceRef,
+    dragPreview: connect.dragPreviewRef
+  };
+}
+
+class ComponentWithHandle {
+  render() {
+    const { dragSource, dragPreview } = this.props;
+
+    return
+      <div ref={dragPreview}>
+        This div is draggable by a handle!
+        <div ref={dragSource}>drag me</div>
+      </div>
+    );
+  }
+}
+ComponentWithHandle = DragSource(type, {/* ... */}, collect)(ComponentWithHandle);
+```
+
+### Example
+
+Check out [the tutorial](/docs/tutorial) for more real examples!

--- a/packages/documentation/markdown/docs/02 Connecting to DOM/DragSourceConnector.md
+++ b/packages/documentation/markdown/docs/02 Connecting to DOM/DragSourceConnector.md
@@ -7,21 +7,13 @@ _New to React DnD? [Read the overview](/docs/overview) before jumping into the d
 
 # DragSourceConnector
 
-`DragSourceConnector` is an object passed to the _collecting function_ of the [`DragSource`](/docs/api/drag-source). It provides the ability to bind your React component to the Drag Source role. You **must** use one of the binding mechanisms provided by the connector for your component to be recognized as a Drag Source in React-DnD.
+`DragSourceConnector` is an object passed to the _collecting function_ of the [`DragSource`](/docs/api/drag-source). It provides the ability to bind your React component to the Drag Source role.
 
 ## Properties
 
-- **`dragSource() => (Element | Node | Ref, options?)`**: Returns a function that should be prop-injected into your component and used in that component's `render()` method. You may pass this function a react component, an DOM element, or a ref object to this method.
+- **`dragSource() => (Element | Node | Ref, options?)`**: Returns a function that must be prop-injected into your component and used in that component's `render()` method. You may pass this function a react component, an DOM element, or a ref object to this method.
 
 - **`dragPreview() => (Element | Node | Ref, options?)`**_(optional)_: Returns a function that may be used inside the component to assign the drag preview role to a node. By returning `{ connectDragPreview: connect.dragPreview() }` from your collecting function, you can mark any React element as the drag preview node. To do that, replace any `element` with `this.props.connectDragPreview(element)` inside the `render` function. The drag preview is the node that will be screenshotted by the [HTML5 backend](/docs/backends/html5) when the drag begins. For example, if you want to make something draggable by a small custom handle, you can mark this handle as the `dragSource()`, but also mark an outer, larger component node as the `dragPreview()`. Thus the larger drag preview appears on the screenshot, but only the smaller drag source is actually draggable. Another possible customization is passing an [`Image`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/Image) instance to `dragPreview` from a lifecycle method like `componentDidMount`. This lets you use the actual images for drag previews. (Note that IE does not support this customization). See the example code below for the different usage examples.
-
-* **`dragSourceRef`**: A [ref](https://reactjs.org/docs/refs-and-the-dom.html) that may be used to attach to your Drag Source element. This may be used in lieu of the `dragSource()`function described above.
-
-* **`dragPreviewRef`**_(optional)_: A [ref](https://reactjs.org/docs/refs-and-the-dom.html) that may be used to attach to your Drag Preview element. This may be used in lieu of the `dragPreview()` function described above.
-
-* **`dragSourceOptions(options?)`**_(optional)_: Returns a function that may be used inside the component to configure the drag source. This is used in tandem with the `dragSourceRef` property.
-
-* **`dragPreviewOptions(options?)`**_(optional)_: Returns a function that may be used inside the component to configure the drag preview. This is used in tandem with the `dragPreviewRef` property.
 
 ### Method Options
 
@@ -43,9 +35,7 @@ The functions returned by the connector methods also accept options. They need t
 
 - `offsetY`: Optional. A number or null if not needed. By default, null. Specifies the vertical offset between the cursor and the drag preview element. If offsetY has a value, anchorY won't be used.
 
-## Usage Patterns
-
-### Pattern 1: Connector Functions
+## Usage
 
 ```js
 import React from 'react';
@@ -104,71 +94,6 @@ class ComponentWithImagePreview {
 
     return connectDragSource(
       <div>
-        This div shows an image when dragged!
-      </div>
-    );
-  }
-}
-ComponentWithImagePreview = DragSource(type, {/* ... */}, collect)(ComponentWithImagePreview);
-```
-
-### Pattern 2: Provided Refs
-
-```js
-import React from 'react';
-import { DragSource } from 'react-dnd';
-
-/* ... */
-
-function collect(connect, monitor) {
-  return {
-    dragSource: connect.dragSourceRef(),
-    dragPreview: connect.dragPreviewRef(),
-    setDragSourceOptions: connect.dragSourceOptions()
-    setDragPreviewOPtions: connect.dragPreviewOptions()
-  };
-}
-
-class ComponentWithCopyEffect {
-  render() {
-    const { dragSource, setDragSourceOptions } = this.props;
-
-    setDragSourceOptions({dropEffect: 'copy'})
-    return (
-      <div ref={dragSource}>
-        This div shows a plus icon in some browsers.
-      </div>
-    );
-  }
-});
-ComponentWithCopyEffect = DragSource(type, {/* ... */}, collect)(ComponentWithCopyEffect);
-
-class ComponentWithHandle {
-  render() {
-    const { dragSource, dragPreview } = this.props;
-    return connectDragPreview(
-      <div ref={dragPreview}>
-        This div is draggable by a handle!
-        <div ref={dragSource}>drag me</div>
-      </div>
-    );
-  }
-}
-ComponentWithHandle = DragSource(type, {/* ... */}, collect)(ComponentWithHandle);
-
-class ComponentWithImagePreview {
-  componentDidMount() {
-    const { connectDragPreview } = this.props;
-
-    const img = new Image();
-    img.src = 'http://mysite.com/image.jpg';
-    img.onload = () => connectDragPreview(img);
-  }
-
-  render() {
-    const { dragSource } = this.props;
-    return dragSource(
-      <div ref={dragSource}>
         This div shows an image when dragged!
       </div>
     );

--- a/packages/documentation/markdown/docs/02 Connecting to DOM/DragSourceConnector.md
+++ b/packages/documentation/markdown/docs/02 Connecting to DOM/DragSourceConnector.md
@@ -11,13 +11,17 @@ _New to React DnD? [Read the overview](/docs/overview) before jumping into the d
 
 ## Properties
 
-- **`dragSourceRef(options?) => Ref`**: A function that returns a new [ref](https://reactjs.org/docs/refs-and-the-dom.html) that may be used to attach to your Drag Source element. This may be used in lieu of the `dragSource()`function described below.
-
-- **`dragPreviewRef(options?) => Ref`**_(optional)_: A function that returns a new [ref](https://reactjs.org/docs/refs-and-the-dom.html) that may be used to attach to your Drag Preview element. This may be used in lieu of the `dragPreview()` function described below.
-
 - **`dragSource() => (Element | Node | Ref, options?)`**: Returns a function that should be prop-injected into your component and used in that component's `render()` method. You may pass this function a react component, an DOM element, or a ref object to this method.
 
 - **`dragPreview() => (Element | Node | Ref, options?)`**_(optional)_: Returns a function that may be used inside the component to assign the drag preview role to a node. By returning `{ connectDragPreview: connect.dragPreview() }` from your collecting function, you can mark any React element as the drag preview node. To do that, replace any `element` with `this.props.connectDragPreview(element)` inside the `render` function. The drag preview is the node that will be screenshotted by the [HTML5 backend](/docs/backends/html5) when the drag begins. For example, if you want to make something draggable by a small custom handle, you can mark this handle as the `dragSource()`, but also mark an outer, larger component node as the `dragPreview()`. Thus the larger drag preview appears on the screenshot, but only the smaller drag source is actually draggable. Another possible customization is passing an [`Image`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/Image) instance to `dragPreview` from a lifecycle method like `componentDidMount`. This lets you use the actual images for drag previews. (Note that IE does not support this customization). See the example code below for the different usage examples.
+
+* **`dragSourceRef`**: A [ref](https://reactjs.org/docs/refs-and-the-dom.html) that may be used to attach to your Drag Source element. This may be used in lieu of the `dragSource()`function described above.
+
+* **`dragPreviewRef`**_(optional)_: A [ref](https://reactjs.org/docs/refs-and-the-dom.html) that may be used to attach to your Drag Preview element. This may be used in lieu of the `dragPreview()` function described above.
+
+* **`dragSourceOptions(options?)`**_(optional)_: Returns a function that may be used inside the component to configure the drag source. This is used in tandem with the `dragSourceRef` property.
+
+* **`dragPreviewOptions(options?)`**_(optional)_: Returns a function that may be used inside the component to configure the drag preview. This is used in tandem with the `dragPreviewRef` property.
 
 ### Method Options
 
@@ -119,15 +123,30 @@ import { DragSource } from 'react-dnd';
 function collect(connect, monitor) {
   return {
     dragSource: connect.dragSourceRef(),
-    dragPreview: connect.dragPreviewRef()
+    dragPreview: connect.dragPreviewRef(),
+    setDragSourceOptions: connect.dragSourceOptions()
+    setDragPreviewOPtions: connect.dragPreviewOptions()
   };
 }
+
+class ComponentWithCopyEffect {
+  render() {
+    const { dragSource, setDragSourceOptions } = this.props;
+
+    setDragSourceOptions({dropEffect: 'copy'})
+    return (
+      <div ref={dragSource}>
+        This div shows a plus icon in some browsers.
+      </div>
+    );
+  }
+});
+ComponentWithCopyEffect = DragSource(type, {/* ... */}, collect)(ComponentWithCopyEffect);
 
 class ComponentWithHandle {
   render() {
     const { dragSource, dragPreview } = this.props;
-
-    return
+    return connectDragPreview(
       <div ref={dragPreview}>
         This div is draggable by a handle!
         <div ref={dragSource}>drag me</div>
@@ -136,6 +155,26 @@ class ComponentWithHandle {
   }
 }
 ComponentWithHandle = DragSource(type, {/* ... */}, collect)(ComponentWithHandle);
+
+class ComponentWithImagePreview {
+  componentDidMount() {
+    const { connectDragPreview } = this.props;
+
+    const img = new Image();
+    img.src = 'http://mysite.com/image.jpg';
+    img.onload = () => connectDragPreview(img);
+  }
+
+  render() {
+    const { dragSource } = this.props;
+    return dragSource(
+      <div ref={dragSource}>
+        This div shows an image when dragged!
+      </div>
+    );
+  }
+}
+ComponentWithImagePreview = DragSource(type, {/* ... */}, collect)(ComponentWithImagePreview);
 ```
 
 ### Example

--- a/packages/documentation/markdown/docs/02 Connecting to DOM/DragSourceConnector.md
+++ b/packages/documentation/markdown/docs/02 Connecting to DOM/DragSourceConnector.md
@@ -11,9 +11,9 @@ _New to React DnD? [Read the overview](/docs/overview) before jumping into the d
 
 ## Properties
 
-- **`dragSourceRef()`**: A function that returns a new [ref](https://reactjs.org/docs/refs-and-the-dom.html) that may be used to attach to your Drag Source element. This may be used in lieu of the `dragSource()`function described below.
+- **`dragSourceRef(options?) => Ref`**: A function that returns a new [ref](https://reactjs.org/docs/refs-and-the-dom.html) that may be used to attach to your Drag Source element. This may be used in lieu of the `dragSource()`function described below.
 
-- **`dragPreviewRef()`**_(optional)_: A function that returns a new [ref](https://reactjs.org/docs/refs-and-the-dom.html) that may be used to attach to your Drag Preview element. This may be used in lieu of the `dragPreview()` function described below.
+- **`dragPreviewRef(options?) => Ref`**_(optional)_: A function that returns a new [ref](https://reactjs.org/docs/refs-and-the-dom.html) that may be used to attach to your Drag Preview element. This may be used in lieu of the `dragPreview()` function described below.
 
 - **`dragSource() => (Element | Node | Ref, options?)`**: Returns a function that should be prop-injected into your component and used in that component's `render()` method. You may pass this function a react component, an DOM element, or a ref object to this method.
 

--- a/packages/documentation/markdown/docs/02 Connecting to DOM/DropTargetConnector.md
+++ b/packages/documentation/markdown/docs/02 Connecting to DOM/DropTargetConnector.md
@@ -11,8 +11,8 @@ _New to React DnD? [Read the overview](/docs/overview) before jumping into the d
 
 ## Properties
 
-- **`dropTargetRef() => Ref`**: A function that returns a new [ref](https://reactjs.org/docs/refs-and-the-dom.html) that may be used to attach to your Drop Target element. This may be used in lieu of the `dropTarget()` function described below.
 - **`dropTarget() => (Element | Node | Ref)`**: Returns a function that should be prop-injected into your component and used in that component's `render()` method. You may pass this function a react component, an DOM element, or a ref object to this method.
+- **`dropTargetRef`**: A [ref](https://reactjs.org/docs/refs-and-the-dom.html) that may be used to attach to your Drop Target element. This may be used in lieu of the `dropTarget()` function described above.
 
 ## Usage Patterns
 

--- a/packages/documentation/markdown/docs/02 Connecting to DOM/DropTargetConnector.md
+++ b/packages/documentation/markdown/docs/02 Connecting to DOM/DropTargetConnector.md
@@ -7,16 +7,13 @@ _New to React DnD? [Read the overview](/docs/overview) before jumping into the d
 
 # DropTargetConnector
 
-`DropTargetConnector` is an object passed to the _collecting function_ of the [`DropTarget`](/docs/api/drop-target). It provides the ability to bind your React component to the Drop Target role. You **must** use one of the binding mechanisms provided by the connector for your component to be recognized as a Drop Target in React-DnD.
+`DropTargetConnector` is an object passed to the _collecting function_ of the [`DropTarget`](/docs/api/drop-target). It provides the ability to bind your React component to the Drop Target role.
 
 ## Properties
 
-- **`dropTarget() => (Element | Node | Ref)`**: Returns a function that should be prop-injected into your component and used in that component's `render()` method. You may pass this function a react component, an DOM element, or a ref object to this method.
-- **`dropTargetRef`**: A [ref](https://reactjs.org/docs/refs-and-the-dom.html) that may be used to attach to your Drop Target element. This may be used in lieu of the `dropTarget()` function described above.
+- **`dropTarget() => (Element | Node | Ref)`**: Returns a function that must be prop-injected into your component and used in that component's `render()` method. You may pass this function a react component, an DOM element, or a ref object to this method.
 
-## Usage Patterns
-
-### Pattern 1: Connector Function
+## Usage
 
 ```js
 import React from 'react'
@@ -40,30 +37,6 @@ export default DropTarget(
 )(DropZone)
 ```
 
-### Pattern 2: Provided Ref
-
-```js
-import React from 'react'
-import { DropTarget } from 'react-dnd'
-
-class DropZone {
-  render() {
-    const { dropTarget } = this.props
-    return <div ref={dropTarget}>You can drop here!</div>)
-  }
-}
-
-export default DropTarget(
-  ItemTypes.Item,
-  {
-    /*...*/
-  },
-  (connect, monitor) => ({
-    dropTarget: connect.dropTargetRef(),
-  }),
-)(DropZone)
-```
-
-### Example
+### Examples
 
 Check out [the tutorial](/docs/tutorial) for more real examples!

--- a/packages/documentation/markdown/docs/02 Connecting to DOM/DropTargetConnector.md
+++ b/packages/documentation/markdown/docs/02 Connecting to DOM/DropTargetConnector.md
@@ -7,37 +7,63 @@ _New to React DnD? [Read the overview](/docs/overview) before jumping into the d
 
 # DropTargetConnector
 
-`DropTargetConnector` is an object passed to a collecting function of the [`DropTarget`](/docs/api/drop-target). Its only method `dropTarget()` returns a function that lets you assign the drop target role to one of your component's DOM nodes.
+`DropTargetConnector` is an object passed to the _collecting function_ of the [`DropTarget`](/docs/api/drop-target). It provides the ability to bind your React component to the Drop Target role. You **must** use one of the binding mechanisms provided by the connector for your component to be recognized as a Drop Target in React-DnD.
 
-### Methods
+## Properties
 
-Call the `DropTargetConnector`'s `dropTarget()` method inside your _collecting function_. This will pass the returned function to your component as a prop. You can then use it inside `render` or `componentDidMount` to indicate a DOM node should react to drop target events. Internally it works by attaching a [callback ref](https://facebook.github.io/react/docs/more-about-refs.html#the-ref-callback-attribute) to the React element you give it. This callback connects the DOM node of your component to the chosen DnD backend.
+- **`dropTargetRef`**: A [ref](https://reactjs.org/docs/refs-and-the-dom.html) that may be used to attach to your Drop Target element. This may be used in lieu of the `dropTarget()` function described below.
+- **`dropTarget() => (Element | Node | Ref)`**: Returns a function that should be prop-injected into your component and used in that component's `render()` method. You may pass this function a react component, an DOM element, or a ref object to this method.
 
-- **`dropTarget() => (elementOrNode)`**: Returns a function that must be used inside the component to assign the drop target role to a node. By returning `{ connectDropTarget: connect.dropTarget() }` from your collecting function, you can mark any React element as the droppable node. To do that, replace any `element` with `this.props.connectDropTarget(element)` inside the `render` function.
+## Usage Patterns
 
-### Example
-
-Check out [the tutorial](/docs/tutorial) for more real examples!
+### Pattern 1: Connector Function
 
 ```js
 import React from 'react'
 import { DropTarget } from 'react-dnd'
 
-/* ... */
-
-function collect(connect, monitor) {
-  return {
-    connectDropTarget: connect.dropTarget(),
-  }
-}
-
 class DropZone {
   render() {
     const { connectDropTarget } = this.props
-
     return connectDropTarget(<div>You can drop here!</div>)
   }
 }
 
-export default DropTarget(/* ... */)(DropZone)
+export default DropTarget(
+  ItemTypes.Item,
+  {
+    /*...*/
+  },
+  (connect, monitor) => ({
+    connectDropTarget: connect.dropTarget(),
+  }),
+)(DropZone)
 ```
+
+### Pattern 2: Provided Ref
+
+```js
+import React from 'react'
+import { DropTarget } from 'react-dnd'
+
+class DropZone {
+  render() {
+    const { dropTarget } = this.props
+    return <div ref={dropTarget}>You can drop here!</div>)
+  }
+}
+
+export default DropTarget(
+  ItemTypes.Item,
+  {
+    /*...*/
+  },
+  (connect, monitor) => ({
+    dropTarget: connect.dropTargetRef,
+  }),
+)(DropZone)
+```
+
+### Example
+
+Check out [the tutorial](/docs/tutorial) for more real examples!

--- a/packages/documentation/markdown/docs/02 Connecting to DOM/DropTargetConnector.md
+++ b/packages/documentation/markdown/docs/02 Connecting to DOM/DropTargetConnector.md
@@ -11,7 +11,7 @@ _New to React DnD? [Read the overview](/docs/overview) before jumping into the d
 
 ## Properties
 
-- **`dropTargetRef`**: A [ref](https://reactjs.org/docs/refs-and-the-dom.html) that may be used to attach to your Drop Target element. This may be used in lieu of the `dropTarget()` function described below.
+- **`dropTargetRef`**: A function that returns a new [ref](https://reactjs.org/docs/refs-and-the-dom.html) that may be used to attach to your Drop Target element. This may be used in lieu of the `dropTarget()` function described below.
 - **`dropTarget() => (Element | Node | Ref)`**: Returns a function that should be prop-injected into your component and used in that component's `render()` method. You may pass this function a react component, an DOM element, or a ref object to this method.
 
 ## Usage Patterns
@@ -59,7 +59,7 @@ export default DropTarget(
     /*...*/
   },
   (connect, monitor) => ({
-    dropTarget: connect.dropTargetRef,
+    dropTarget: connect.dropTargetRef(),
   }),
 )(DropZone)
 ```

--- a/packages/documentation/markdown/docs/02 Connecting to DOM/DropTargetConnector.md
+++ b/packages/documentation/markdown/docs/02 Connecting to DOM/DropTargetConnector.md
@@ -11,7 +11,7 @@ _New to React DnD? [Read the overview](/docs/overview) before jumping into the d
 
 ## Properties
 
-- **`dropTargetRef`**: A function that returns a new [ref](https://reactjs.org/docs/refs-and-the-dom.html) that may be used to attach to your Drop Target element. This may be used in lieu of the `dropTarget()` function described below.
+- **`dropTargetRef() => Ref`**: A function that returns a new [ref](https://reactjs.org/docs/refs-and-the-dom.html) that may be used to attach to your Drop Target element. This may be used in lieu of the `dropTarget()` function described below.
 - **`dropTarget() => (Element | Node | Ref)`**: Returns a function that should be prop-injected into your component and used in that component's `render()` method. You may pass this function a react component, an DOM element, or a ref object to this method.
 
 ## Usage Patterns

--- a/packages/examples/src/01 Dustbin/Single Target/Box.tsx
+++ b/packages/examples/src/01 Dustbin/Single Target/Box.tsx
@@ -1,5 +1,10 @@
 import React from 'react'
-import { DragSource, DragSourceConnector, DragSourceMonitor } from 'react-dnd'
+import {
+	DragSource,
+	DragSourceMonitor,
+	ConnectDragSource,
+	DragSourceConnector,
+} from 'react-dnd'
 import ItemTypes from './ItemTypes'
 
 const style: React.CSSProperties = {
@@ -18,7 +23,7 @@ interface BoxProps {
 
 interface BoxCollectedProps {
 	isDragging: boolean
-	dragSource: React.RefObject<any>
+	connectDragSource: ConnectDragSource
 }
 
 const boxSource = {
@@ -39,13 +44,15 @@ const boxSource = {
 }
 
 class Box extends React.Component<BoxProps & BoxCollectedProps> {
+	private dragSource: React.RefObject<HTMLDivElement> = React.createRef()
+
 	public render() {
-		const { isDragging, dragSource } = this.props
-		const { name } = this.props
+		const { name, isDragging, connectDragSource } = this.props
 		const opacity = isDragging ? 0.4 : 1
+		connectDragSource(this.dragSource)
 
 		return (
-			<div ref={dragSource} style={{ ...style, opacity }}>
+			<div ref={this.dragSource} style={{ ...style, opacity }}>
 				{name}
 			</div>
 		)
@@ -56,7 +63,7 @@ export default DragSource(
 	ItemTypes.BOX,
 	boxSource,
 	(connect: DragSourceConnector, monitor: DragSourceMonitor) => ({
-		dragSource: connect.dragSourceRef,
+		dragSource: connect.dragSource(),
 		isDragging: monitor.isDragging(),
 	}),
 )(Box)

--- a/packages/examples/src/01 Dustbin/Single Target/Box.tsx
+++ b/packages/examples/src/01 Dustbin/Single Target/Box.tsx
@@ -56,7 +56,7 @@ export default DragSource(
 	ItemTypes.BOX,
 	boxSource,
 	(connect: DragSourceConnector, monitor: DragSourceMonitor) => ({
-		dragSource: connect.dragSourceRef,
+		dragSource: connect.dragSourceRef(),
 		isDragging: monitor.isDragging(),
 	}),
 )(Box)

--- a/packages/examples/src/01 Dustbin/Single Target/Box.tsx
+++ b/packages/examples/src/01 Dustbin/Single Target/Box.tsx
@@ -63,7 +63,7 @@ export default DragSource(
 	ItemTypes.BOX,
 	boxSource,
 	(connect: DragSourceConnector, monitor: DragSourceMonitor) => ({
-		dragSource: connect.dragSource(),
+		connectDragSource: connect.dragSource(),
 		isDragging: monitor.isDragging(),
 	}),
 )(Box)

--- a/packages/examples/src/01 Dustbin/Single Target/Box.tsx
+++ b/packages/examples/src/01 Dustbin/Single Target/Box.tsx
@@ -56,7 +56,7 @@ export default DragSource(
 	ItemTypes.BOX,
 	boxSource,
 	(connect: DragSourceConnector, monitor: DragSourceMonitor) => ({
-		dragSource: connect.dragSourceRef(),
+		dragSource: connect.dragSourceRef,
 		isDragging: monitor.isDragging(),
 	}),
 )(Box)

--- a/packages/examples/src/01 Dustbin/Single Target/Dustbin.tsx
+++ b/packages/examples/src/01 Dustbin/Single Target/Dustbin.tsx
@@ -57,7 +57,7 @@ export default DropTarget(
 	ItemTypes.BOX,
 	boxTarget,
 	(connect: DropTargetConnector, monitor: DropTargetMonitor) => ({
-		dropTarget: connect.dropTarget(),
+		connectDropTarget: connect.dropTarget(),
 		isOver: monitor.isOver(),
 		canDrop: monitor.canDrop(),
 	}),

--- a/packages/examples/src/01 Dustbin/Single Target/Dustbin.tsx
+++ b/packages/examples/src/01 Dustbin/Single Target/Dustbin.tsx
@@ -49,7 +49,7 @@ export default DropTarget(
 	ItemTypes.BOX,
 	boxTarget,
 	(connect: DropTargetConnector, monitor: DropTargetMonitor) => ({
-		dropTarget: connect.dropTargetRef,
+		dropTarget: connect.dropTargetRef(),
 		isOver: monitor.isOver(),
 		canDrop: monitor.canDrop(),
 	}),

--- a/packages/examples/src/01 Dustbin/Single Target/Dustbin.tsx
+++ b/packages/examples/src/01 Dustbin/Single Target/Dustbin.tsx
@@ -1,5 +1,10 @@
 import React from 'react'
-import { DropTarget, DropTargetConnector, DropTargetMonitor } from 'react-dnd'
+import {
+	DropTarget,
+	ConnectDropTarget,
+	DropTargetMonitor,
+	DropTargetConnector,
+} from 'react-dnd'
 import ItemTypes from './ItemTypes'
 
 const style: React.CSSProperties = {
@@ -22,13 +27,16 @@ const boxTarget = {
 export interface DustbinProps {
 	canDrop: boolean
 	isOver: boolean
-	dropTarget: React.RefObject<any>
+	connectDropTarget: ConnectDropTarget
 }
 
 class Dustbin extends React.Component<DustbinProps> {
+	private dropTarget: React.RefObject<HTMLDivElement> = React.createRef()
+
 	public render() {
-		const { canDrop, isOver, dropTarget } = this.props
+		const { canDrop, isOver, connectDropTarget } = this.props
 		const isActive = canDrop && isOver
+		connectDropTarget(this.dropTarget)
 
 		let backgroundColor = '#222'
 		if (isActive) {
@@ -38,7 +46,7 @@ class Dustbin extends React.Component<DustbinProps> {
 		}
 
 		return (
-			<div ref={dropTarget} style={{ ...style, backgroundColor }}>
+			<div ref={this.dropTarget} style={{ ...style, backgroundColor }}>
 				{isActive ? 'Release to drop' : 'Drag a box here'}
 			</div>
 		)
@@ -49,7 +57,7 @@ export default DropTarget(
 	ItemTypes.BOX,
 	boxTarget,
 	(connect: DropTargetConnector, monitor: DropTargetMonitor) => ({
-		dropTarget: connect.dropTargetRef,
+		dropTarget: connect.dropTarget(),
 		isOver: monitor.isOver(),
 		canDrop: monitor.canDrop(),
 	}),

--- a/packages/examples/src/01 Dustbin/Single Target/Dustbin.tsx
+++ b/packages/examples/src/01 Dustbin/Single Target/Dustbin.tsx
@@ -49,7 +49,7 @@ export default DropTarget(
 	ItemTypes.BOX,
 	boxTarget,
 	(connect: DropTargetConnector, monitor: DropTargetMonitor) => ({
-		dropTarget: connect.dropTargetRef(),
+		dropTarget: connect.dropTargetRef,
 		isOver: monitor.isOver(),
 		canDrop: monitor.canDrop(),
 	}),

--- a/packages/react-dnd/src/createSourceConnector.ts
+++ b/packages/react-dnd/src/createSourceConnector.ts
@@ -102,11 +102,6 @@ export default function createSourceConnector(backend: Backend) {
 				dragSourceRef = React.createRef()
 				return dragSourceRef
 			},
-			dragPreviewRef: (options?: DragPreviewOptions) => {
-				dragPreviewOptions = options
-				dragPreviewRef = React.createRef()
-				return dragPreviewRef
-			},
 			dragSource: (
 				node: Element | React.ReactElement | React.Ref<any>,
 				options?: DragSourceOptions,
@@ -118,7 +113,11 @@ export default function createSourceConnector(backend: Backend) {
 					dragSourceNode = node
 				}
 			},
-
+			dragPreviewRef: (options?: DragPreviewOptions) => {
+				dragPreviewOptions = options
+				dragPreviewRef = React.createRef()
+				return dragPreviewRef
+			},
 			dragPreview: (node: any, options?: DragPreviewOptions) => {
 				dragPreviewOptions = options
 				if (isRef(node)) {

--- a/packages/react-dnd/src/createSourceConnector.ts
+++ b/packages/react-dnd/src/createSourceConnector.ts
@@ -3,6 +3,7 @@ import * as React from 'react'
 import wrapConnectorHooks from './wrapConnectorHooks'
 import { Backend, Unsubscribe, Identifier } from 'dnd-core'
 import { isRef } from './hooks/util'
+import { DragSourceOptions, DragPreviewOptions } from './interfaces'
 const shallowEqual = require('shallowequal')
 
 export default function createSourceConnector(backend: Backend) {
@@ -96,18 +97,20 @@ export default function createSourceConnector(backend: Backend) {
 	return {
 		receiveHandlerId,
 		hooks: wrapConnectorHooks({
-			dragSourceRef: () => {
+			dragSourceRef: (options?: DragSourceOptions) => {
+				dragSourceOptions = options
 				dragSourceRef = React.createRef()
 				return dragSourceRef
 			},
-			dragPreviewRef: () => {
+			dragPreviewRef: (options?: DragPreviewOptions) => {
+				dragPreviewOptions = options
 				dragPreviewRef = React.createRef()
 				return dragPreviewRef
 			},
-			dragSource: function connectDragSource(
+			dragSource: (
 				node: Element | React.ReactElement | React.Ref<any>,
-				options?: any,
-			) {
+				options?: DragSourceOptions,
+			) => {
 				dragSourceOptions = options
 				if (isRef(node)) {
 					dragSourceRef = node as React.RefObject<any>
@@ -116,7 +119,7 @@ export default function createSourceConnector(backend: Backend) {
 				}
 			},
 
-			dragPreview: function connectDragPreview(node: any, options?: any) {
+			dragPreview: (node: any, options?: DragPreviewOptions) => {
 				dragPreviewOptions = options
 				if (isRef(node)) {
 					dragPreviewRef = node

--- a/packages/react-dnd/src/createSourceConnector.ts
+++ b/packages/react-dnd/src/createSourceConnector.ts
@@ -97,18 +97,6 @@ export default function createSourceConnector(backend: Backend) {
 	return {
 		receiveHandlerId,
 		hooks: wrapConnectorHooks({
-			get dragSourceRef() {
-				if (dragSourceRef == null) {
-					dragSourceRef = React.createRef()
-				}
-				return dragSourceRef
-			},
-			get dragPreviewRef() {
-				if (dragPreviewRef == null) {
-					dragPreviewRef = React.createRef()
-				}
-				return dragPreviewRef
-			},
 			dragSource: (
 				node: Element | React.ReactElement | React.Ref<any>,
 				options?: DragSourceOptions,
@@ -128,10 +116,6 @@ export default function createSourceConnector(backend: Backend) {
 					dragPreviewNode = node
 				}
 			},
-			dragSourceOptions: (options?: DragSourceOptions) =>
-				(dragSourceOptions = options),
-			dragPreviewOptions: (options?: DragPreviewOptions) =>
-				(dragPreviewOptions = options),
 		}),
 		reconnect: () => {
 			reconnectDragSource()

--- a/packages/react-dnd/src/createSourceConnector.ts
+++ b/packages/react-dnd/src/createSourceConnector.ts
@@ -9,13 +9,13 @@ export default function createSourceConnector(backend: Backend) {
 	let handlerId: Identifier
 
 	// The drop target may either be attached via ref or connect function
-	let dragSourceRef = React.createRef<any>()
+	let dragSourceRef: React.RefObject<any> | null = null
 	let dragSourceNode: any
 	let dragSourceOptions: any
 	let disconnectDragSource: Unsubscribe | undefined
 
 	// The drag preview may either be attached via ref or connect function
-	let dragPreviewRef = React.createRef<any>()
+	let dragPreviewRef: React.RefObject<any> | null = null
 	let dragPreviewNode: any
 	let dragPreviewOptions: any
 	let disconnectDragPreview: Unsubscribe | undefined
@@ -27,7 +27,8 @@ export default function createSourceConnector(backend: Backend) {
 	let lastConnectedDragPreviewOptions: any = null
 
 	function reconnectDragSource() {
-		const dragSource = dragSourceNode || dragSourceRef.current
+		const dragSource =
+			dragSourceNode || (dragSourceRef && dragSourceRef.current)
 		if (!handlerId || !dragSource) {
 			return
 		}
@@ -55,7 +56,8 @@ export default function createSourceConnector(backend: Backend) {
 	}
 
 	function reconnectDragPreview() {
-		const dragPreview = dragPreviewNode || dragPreviewRef.current
+		const dragPreview =
+			dragPreviewNode || (dragPreviewRef && dragPreviewRef.current)
 		if (!handlerId || !dragPreview) {
 			return
 		}
@@ -94,12 +96,21 @@ export default function createSourceConnector(backend: Backend) {
 	return {
 		receiveHandlerId,
 		hooks: wrapConnectorHooks({
-			dragSourceRef,
-			dragPreviewRef,
-			dragSource: function connectDragSource(node: any, options?: any) {
+			dragSourceRef: () => {
+				dragSourceRef = React.createRef()
+				return dragSourceRef
+			},
+			dragPreviewRef: () => {
+				dragPreviewRef = React.createRef()
+				return dragPreviewRef
+			},
+			dragSource: function connectDragSource(
+				node: Element | React.ReactElement | React.Ref<any>,
+				options?: any,
+			) {
 				dragSourceOptions = options
 				if (isRef(node)) {
-					dragSourceRef = node
+					dragSourceRef = node as React.RefObject<any>
 				} else {
 					dragSourceNode = node
 				}

--- a/packages/react-dnd/src/createSourceConnector.ts
+++ b/packages/react-dnd/src/createSourceConnector.ts
@@ -97,10 +97,17 @@ export default function createSourceConnector(backend: Backend) {
 	return {
 		receiveHandlerId,
 		hooks: wrapConnectorHooks({
-			dragSourceRef: (options?: DragSourceOptions) => {
-				dragSourceOptions = options
-				dragSourceRef = React.createRef()
+			get dragSourceRef() {
+				if (dragSourceRef == null) {
+					dragSourceRef = React.createRef()
+				}
 				return dragSourceRef
+			},
+			get dragPreviewRef() {
+				if (dragPreviewRef == null) {
+					dragPreviewRef = React.createRef()
+				}
+				return dragPreviewRef
 			},
 			dragSource: (
 				node: Element | React.ReactElement | React.Ref<any>,
@@ -113,11 +120,6 @@ export default function createSourceConnector(backend: Backend) {
 					dragSourceNode = node
 				}
 			},
-			dragPreviewRef: (options?: DragPreviewOptions) => {
-				dragPreviewOptions = options
-				dragPreviewRef = React.createRef()
-				return dragPreviewRef
-			},
 			dragPreview: (node: any, options?: DragPreviewOptions) => {
 				dragPreviewOptions = options
 				if (isRef(node)) {
@@ -126,6 +128,10 @@ export default function createSourceConnector(backend: Backend) {
 					dragPreviewNode = node
 				}
 			},
+			dragSourceOptions: (options?: DragSourceOptions) =>
+				(dragSourceOptions = options),
+			dragPreviewOptions: (options?: DragPreviewOptions) =>
+				(dragPreviewOptions = options),
 		}),
 		reconnect: () => {
 			reconnectDragSource()

--- a/packages/react-dnd/src/createTargetConnector.ts
+++ b/packages/react-dnd/src/createTargetConnector.ts
@@ -57,12 +57,6 @@ export default function createTargetConnector(backend: Backend) {
 	return {
 		receiveHandlerId,
 		hooks: wrapConnectorHooks({
-			get dropTargetRef() {
-				if (dropTargetRef == null) {
-					dropTargetRef = React.createRef()
-				}
-				return dropTargetRef
-			},
 			dropTarget: (node: any, options: any) => {
 				dropTargetOptions = options
 				if (isRef(node)) {
@@ -71,7 +65,6 @@ export default function createTargetConnector(backend: Backend) {
 					dropTargetNode = node
 				}
 			},
-			dropTargetOptions: (options?: any) => (dropTargetOptions = options),
 		}),
 		reconnect: reconnectDropTarget,
 	}

--- a/packages/react-dnd/src/createTargetConnector.ts
+++ b/packages/react-dnd/src/createTargetConnector.ts
@@ -57,11 +57,12 @@ export default function createTargetConnector(backend: Backend) {
 	return {
 		receiveHandlerId,
 		hooks: wrapConnectorHooks({
-			dropTargetRef: () => {
+			dropTargetRef: (options: any) => {
+				dropTargetOptions = options
 				dropTargetRef = React.createRef()
 				return dropTargetRef
 			},
-			dropTarget: function connectDropTarget(node: any, options: any) {
+			dropTarget: (node: any, options: any) => {
 				dropTargetOptions = options
 				if (isRef(node)) {
 					dropTargetRef = node

--- a/packages/react-dnd/src/createTargetConnector.ts
+++ b/packages/react-dnd/src/createTargetConnector.ts
@@ -57,9 +57,10 @@ export default function createTargetConnector(backend: Backend) {
 	return {
 		receiveHandlerId,
 		hooks: wrapConnectorHooks({
-			dropTargetRef: (options: any) => {
-				dropTargetOptions = options
-				dropTargetRef = React.createRef()
+			get dropTargetRef() {
+				if (dropTargetRef == null) {
+					dropTargetRef = React.createRef()
+				}
 				return dropTargetRef
 			},
 			dropTarget: (node: any, options: any) => {
@@ -70,6 +71,7 @@ export default function createTargetConnector(backend: Backend) {
 					dropTargetNode = node
 				}
 			},
+			dropTargetOptions: (options?: any) => (dropTargetOptions = options),
 		}),
 		reconnect: reconnectDropTarget,
 	}

--- a/packages/react-dnd/src/createTargetConnector.ts
+++ b/packages/react-dnd/src/createTargetConnector.ts
@@ -8,7 +8,7 @@ const shallowEqual = require('shallowequal')
 export default function createTargetConnector(backend: Backend) {
 	let handlerId: Identifier
 	// The drop target may either be attached via ref or connect function
-	let dropTargetRef = React.createRef<any>()
+	let dropTargetRef: React.RefObject<any> | null = null
 	let dropTargetNode: any
 	let dropTargetOptions: any
 	let disconnectDropTarget: Unsubscribe | undefined
@@ -18,7 +18,8 @@ export default function createTargetConnector(backend: Backend) {
 	let lastConnectedDropTargetOptions: any = null
 
 	function reconnectDropTarget() {
-		const dropTarget = dropTargetNode || dropTargetRef.current
+		const dropTarget =
+			dropTargetNode || (dropTargetRef && dropTargetRef.current)
 		if (!handlerId || !dropTarget) {
 			return
 		}
@@ -56,7 +57,10 @@ export default function createTargetConnector(backend: Backend) {
 	return {
 		receiveHandlerId,
 		hooks: wrapConnectorHooks({
-			dropTargetRef,
+			dropTargetRef: () => {
+				dropTargetRef = React.createRef()
+				return dropTargetRef
+			},
 			dropTarget: function connectDropTarget(node: any, options: any) {
 				dropTargetOptions = options
 				if (isRef(node)) {

--- a/packages/react-dnd/src/interfaces/classApi.ts
+++ b/packages/react-dnd/src/interfaces/classApi.ts
@@ -137,12 +137,12 @@ export interface DragSourceConnector {
 	/**
 	 * A React ref object to attach to the drag source. This replaces the dragSource() function described below.
 	 */
-	dragSourceRef: React.RefObject<any>
+	dragSourceRef: () => React.RefObject<any>
 
 	/**
 	 * A React ref object to attach to the drag preview. This replaces the dragPreview() function described below.
 	 */
-	dragPreviewRef: React.RefObject<any>
+	dragPreviewRef: () => React.RefObject<any>
 
 	/**
 	 * Returns a function that must be used inside the component to assign the drag source role to a node. By
@@ -177,7 +177,7 @@ export interface DropTargetConnector {
 	/**
 	 * A React ref object to attach to the drop target. This replaces the dropTarget() function described below.
 	 */
-	dropTargetRef: React.RefObject<any>
+	dropTargetRef: () => React.RefObject<any>
 
 	/**
 	 * Returns a function that must be used inside the component to assign the drop target role to a node.

--- a/packages/react-dnd/src/interfaces/classApi.ts
+++ b/packages/react-dnd/src/interfaces/classApi.ts
@@ -137,12 +137,12 @@ export interface DragSourceConnector {
 	/**
 	 * A React ref object to attach to the drag source. This replaces the dragSource() function described below.
 	 */
-	dragSourceRef: () => React.RefObject<any>
+	dragSourceRef(options?: DragSourceOptions): React.RefObject<any>
 
 	/**
 	 * A React ref object to attach to the drag preview. This replaces the dragPreview() function described below.
 	 */
-	dragPreviewRef: () => React.RefObject<any>
+	dragPreviewRef(options?: DragPreviewOptions): React.RefObject<any>
 
 	/**
 	 * Returns a function that must be used inside the component to assign the drag source role to a node. By
@@ -153,7 +153,7 @@ export interface DragSourceConnector {
 	 * @param elementOrNode
 	 * @param options
 	 */
-	dragSource(): ConnectDragSource
+	dragSource(options?: DragSourceOptions): ConnectDragSource
 
 	/**
 	 * Optional. Returns a function that may be used inside the component to assign the drag preview role to a node. By
@@ -166,7 +166,7 @@ export interface DragSourceConnector {
 	 * from a lifecycle method like componentDidMount. This lets you use the actual images for drag previews. (Note that IE does not
 	 * support this customization). See the example code below for the different usage examples.
 	 */
-	dragPreview(): ConnectDragPreview
+	dragPreview(options?: DragPreviewOptions): ConnectDragPreview
 }
 
 /**
@@ -177,14 +177,14 @@ export interface DropTargetConnector {
 	/**
 	 * A React ref object to attach to the drop target. This replaces the dropTarget() function described below.
 	 */
-	dropTargetRef: () => React.RefObject<any>
+	dropTargetRef(options?: any): React.RefObject<any>
 
 	/**
 	 * Returns a function that must be used inside the component to assign the drop target role to a node.
 	 * By returning { connectDropTarget: connect.dropTarget() } from your collecting function, you can mark any React element
 	 * as the droppable node. To do that, replace any element with this.props.connectDropTarget(element) inside the render function.
 	 */
-	dropTarget(): ConnectDropTarget
+	dropTarget(options?: any): ConnectDropTarget
 }
 
 export type ConnectDropTarget = <Props>(

--- a/packages/react-dnd/src/interfaces/classApi.ts
+++ b/packages/react-dnd/src/interfaces/classApi.ts
@@ -130,23 +130,11 @@ export type DragElementWrapper<Options> = <Props>(
 export type ConnectDragSource = DragElementWrapper<DragSourceOptions>
 export type ConnectDragPreview = DragElementWrapper<DragPreviewOptions>
 
-export type ConnectOptions<T> = (options: T) => void
-
 /**
  * DragSourceConnector is an object passed to a collecting function of the DragSource.
  * Its methods return functions that let you assign the roles to your component's DOM nodes.
  */
 export interface DragSourceConnector {
-	/**
-	 * A React ref object to attach to the drag source. This may be used in lieu of the dragSource() function described below.
-	 */
-	dragSourceRef: React.RefObject<any>
-
-	/**
-	 * A React ref object to attach to the drag preview. This may be used in lieu of the dragPreview() function described below.
-	 */
-	dragPreviewRef: React.RefObject<any>
-
 	/**
 	 * Returns a function that must be used inside the component to assign the drag source role to a node. By
 	 * returning { connectDragSource: connect.dragSource() } from your collecting function, you can mark any React
@@ -167,9 +155,6 @@ export interface DragSourceConnector {
 	 * support this customization). See the example code below for the different usage examples.
 	 */
 	dragPreview(): ConnectDragPreview
-
-	dragSourceOptions(): ConnectOptions<DragSourceOptions>
-	dragPreviewOptions(): ConnectOptions<DragPreviewOptions>
 }
 
 /**
@@ -178,18 +163,11 @@ export interface DragSourceConnector {
  */
 export interface DropTargetConnector {
 	/**
-	 * A React ref object to attach to the drop target. This may be used in lieu of the dropTarget() function described below.
-	 */
-	dropTargetRef: React.RefObject<any>
-
-	/**
 	 * Returns a function that must be used inside the component to assign the drop target role to a node.
 	 * By returning { connectDropTarget: connect.dropTarget() } from your collecting function, you can mark any React element
 	 * as the droppable node. To do that, replace any element with this.props.connectDropTarget(element) inside the render function.
 	 */
 	dropTarget(): ConnectDropTarget
-
-	dropTargetOptions(): ConnectOptions<any>
 }
 
 export type ConnectDropTarget = <Props>(

--- a/packages/react-dnd/src/interfaces/classApi.ts
+++ b/packages/react-dnd/src/interfaces/classApi.ts
@@ -121,6 +121,7 @@ export type ConnectedElement =
 	| React.ReactElement
 	| Element
 	| null
+
 export type DragElementWrapper<Options> = <Props>(
 	elementOrNode: ConnectedElement,
 	options?: Options,
@@ -129,31 +130,30 @@ export type DragElementWrapper<Options> = <Props>(
 export type ConnectDragSource = DragElementWrapper<DragSourceOptions>
 export type ConnectDragPreview = DragElementWrapper<DragPreviewOptions>
 
+export type ConnectOptions<T> = (options: T) => void
+
 /**
  * DragSourceConnector is an object passed to a collecting function of the DragSource.
  * Its methods return functions that let you assign the roles to your component's DOM nodes.
  */
 export interface DragSourceConnector {
 	/**
-	 * A React ref object to attach to the drag source. This replaces the dragSource() function described below.
+	 * A React ref object to attach to the drag source. This may be used in lieu of the dragSource() function described below.
 	 */
-	dragSourceRef(options?: DragSourceOptions): React.RefObject<any>
+	dragSourceRef: React.RefObject<any>
 
 	/**
-	 * A React ref object to attach to the drag preview. This replaces the dragPreview() function described below.
+	 * A React ref object to attach to the drag preview. This may be used in lieu of the dragPreview() function described below.
 	 */
-	dragPreviewRef(options?: DragPreviewOptions): React.RefObject<any>
+	dragPreviewRef: React.RefObject<any>
 
 	/**
 	 * Returns a function that must be used inside the component to assign the drag source role to a node. By
 	 * returning { connectDragSource: connect.dragSource() } from your collecting function, you can mark any React
 	 * element as the draggable node. To do that, replace any element with this.props.connectDragSource(element) inside
 	 * the render function.
-	 *
-	 * @param elementOrNode
-	 * @param options
 	 */
-	dragSource(options?: DragSourceOptions): ConnectDragSource
+	dragSource(): ConnectDragSource
 
 	/**
 	 * Optional. Returns a function that may be used inside the component to assign the drag preview role to a node. By
@@ -166,7 +166,10 @@ export interface DragSourceConnector {
 	 * from a lifecycle method like componentDidMount. This lets you use the actual images for drag previews. (Note that IE does not
 	 * support this customization). See the example code below for the different usage examples.
 	 */
-	dragPreview(options?: DragPreviewOptions): ConnectDragPreview
+	dragPreview(): ConnectDragPreview
+
+	dragSourceOptions(): ConnectOptions<DragSourceOptions>
+	dragPreviewOptions(): ConnectOptions<DragPreviewOptions>
 }
 
 /**
@@ -175,16 +178,18 @@ export interface DragSourceConnector {
  */
 export interface DropTargetConnector {
 	/**
-	 * A React ref object to attach to the drop target. This replaces the dropTarget() function described below.
+	 * A React ref object to attach to the drop target. This may be used in lieu of the dropTarget() function described below.
 	 */
-	dropTargetRef(options?: any): React.RefObject<any>
+	dropTargetRef: React.RefObject<any>
 
 	/**
 	 * Returns a function that must be used inside the component to assign the drop target role to a node.
 	 * By returning { connectDropTarget: connect.dropTarget() } from your collecting function, you can mark any React element
 	 * as the droppable node. To do that, replace any element with this.props.connectDropTarget(element) inside the render function.
 	 */
-	dropTarget(options?: any): ConnectDropTarget
+	dropTarget(): ConnectDropTarget
+
+	dropTargetOptions(): ConnectOptions<any>
 }
 
 export type ConnectDropTarget = <Props>(


### PR DESCRIPTION
* Documentation updates
* ~~Update the connector ref mechanism so we provide a function that creates refs instead of creating refs aggressively.  This will also allow us to pass options into the connector-ref functions~~
* Update: I did not like how the new API was evolving, so I've pared this back to just allowing the connect function to accept a ref object.
```
function Box({dragSource}) {
  return <div ref={dragSource}>...</div>
}
export default DragSource(ItemTypes.Box, {/*...*/}, (connect, monitor) => ({
  dragSource: connect.dragSourceRef()
}));
```