### PR TITLE
build: fixed the order as lerna was not building in proper order

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"homepage": "https://github.com/react-dnd/react-dnd",
 	"scripts": {
 		"clean": "lerna run clean",
-		"build": "lerna run build --stream",
+		"build": "lerna run build --scope=dnd-core --scope=react-dnd --stream",
 		"unit_test": "jest",
 		"jest:watch": "jest --watch",
 		"jest:cov": "jest --coverage",


### PR DESCRIPTION
Lerna was not building `react-dnd` before building docs, due to which the build was failing (cannot find module 'react-dnd')