### PR TITLE
Improve Decorator Typings

### DIFF
--- a/packages/examples/src/00 Chessboard/Knight.tsx
+++ b/packages/examples/src/00 Chessboard/Knight.tsx
@@ -16,13 +16,13 @@ const knightStyle: React.CSSProperties = {
 	cursor: 'move',
 }
 
-export interface KnightProps {
+export interface CollectedKnightProps {
 	connectDragSource: ConnectDragSource
 	connectDragPreview: ConnectDragPreview
 	isDragging?: boolean
 }
 
-const Knight: React.FC<KnightProps> = ({
+const Knight: React.FC<CollectedKnightProps> = ({
 	connectDragSource,
 	connectDragPreview,
 	isDragging,
@@ -43,7 +43,7 @@ const Knight: React.FC<KnightProps> = ({
 	)
 }
 
-export default DragSource(
+export default DragSource<{}, CollectedKnightProps>(
 	ItemTypes.KNIGHT,
 	{
 		beginDrag: () => ({}),

--- a/packages/examples/src/00 Chessboard/Knight.tsx
+++ b/packages/examples/src/00 Chessboard/Knight.tsx
@@ -43,7 +43,7 @@ const Knight: React.FC<CollectedKnightProps> = ({
 	)
 }
 
-export default DragSource<{}, CollectedKnightProps>(
+export default DragSource(
 	ItemTypes.KNIGHT,
 	{
 		beginDrag: () => ({}),

--- a/packages/examples/src/01 Dustbin/Copy or Move/Box.tsx
+++ b/packages/examples/src/01 Dustbin/Copy or Move/Box.tsx
@@ -16,37 +16,6 @@ const style: React.CSSProperties = {
 	float: 'left',
 }
 
-const boxSource = {
-	beginDrag(props: BoxProps) {
-		return {
-			name: props.name,
-		}
-	},
-
-	endDrag(props: BoxProps, monitor: DragSourceMonitor) {
-		const item = monitor.getItem()
-		const dropResult = monitor.getDropResult()
-
-		if (dropResult) {
-			let alertMessage = ''
-			const isDropAllowed =
-				dropResult.allowedDropEffect === 'any' ||
-				dropResult.allowedDropEffect === dropResult.dropEffect
-
-			if (isDropAllowed) {
-				const isCopyAction = dropResult.dropEffect === 'copy'
-				const actionName = isCopyAction ? 'copied' : 'moved'
-				alertMessage = `You ${actionName} ${item.name} into ${dropResult.name}!`
-			} else {
-				alertMessage = `You cannot ${dropResult.dropEffect} an item into the ${
-					dropResult.name
-				}`
-			}
-			alert(alertMessage)
-		}
-	},
-}
-
 export interface BoxProps {
 	name: string
 }
@@ -66,9 +35,40 @@ class Box extends React.Component<BoxProps & BoxCollectedProps> {
 	}
 }
 
-export default DragSource(
+export default DragSource<BoxProps, BoxCollectedProps>(
 	ItemTypes.BOX,
-	boxSource,
+	{
+		beginDrag(props: BoxProps) {
+			return {
+				name: props.name,
+			}
+		},
+
+		endDrag(props: BoxProps, monitor: DragSourceMonitor) {
+			const item = monitor.getItem()
+			const dropResult = monitor.getDropResult()
+
+			if (dropResult) {
+				let alertMessage = ''
+				const isDropAllowed =
+					dropResult.allowedDropEffect === 'any' ||
+					dropResult.allowedDropEffect === dropResult.dropEffect
+
+				if (isDropAllowed) {
+					const isCopyAction = dropResult.dropEffect === 'copy'
+					const actionName = isCopyAction ? 'copied' : 'moved'
+					alertMessage = `You ${actionName} ${item.name} into ${
+						dropResult.name
+					}!`
+				} else {
+					alertMessage = `You cannot ${
+						dropResult.dropEffect
+					} an item into the ${dropResult.name}`
+				}
+				alert(alertMessage)
+			}
+		},
+	},
 	(connect: DragSourceConnector, monitor: DragSourceMonitor) => ({
 		connectDragSource: connect.dragSource(),
 		isDragging: monitor.isDragging(),

--- a/packages/examples/src/01 Dustbin/Copy or Move/Box.tsx
+++ b/packages/examples/src/01 Dustbin/Copy or Move/Box.tsx
@@ -35,7 +35,7 @@ class Box extends React.Component<BoxProps & BoxCollectedProps> {
 	}
 }
 
-export default DragSource<BoxProps, BoxCollectedProps>(
+export default DragSource(
 	ItemTypes.BOX,
 	{
 		beginDrag(props: BoxProps) {

--- a/packages/examples/src/01 Dustbin/Copy or Move/Dustbin.tsx
+++ b/packages/examples/src/01 Dustbin/Copy or Move/Dustbin.tsx
@@ -57,12 +57,8 @@ class Dustbin extends React.Component<DustbinProps & DustbinCollectedProps> {
 	}
 }
 
-export default DropTarget<DustbinProps, DustbinCollectedProps>(
-	ItemTypes.BOX,
-	boxTarget,
-	(connect, monitor) => ({
-		connectDropTarget: connect.dropTarget(),
-		isOver: monitor.isOver(),
-		canDrop: monitor.canDrop(),
-	}),
-)(Dustbin)
+export default DropTarget(ItemTypes.BOX, boxTarget, (connect, monitor) => ({
+	connectDropTarget: connect.dropTarget(),
+	isOver: monitor.isOver(),
+	canDrop: monitor.canDrop(),
+}))(Dustbin)

--- a/packages/examples/src/01 Dustbin/Copy or Move/Dustbin.tsx
+++ b/packages/examples/src/01 Dustbin/Copy or Move/Dustbin.tsx
@@ -57,8 +57,12 @@ class Dustbin extends React.Component<DustbinProps & DustbinCollectedProps> {
 	}
 }
 
-export default DropTarget(ItemTypes.BOX, boxTarget, (connect, monitor) => ({
-	connectDropTarget: connect.dropTarget(),
-	isOver: monitor.isOver(),
-	canDrop: monitor.canDrop(),
-}))(Dustbin)
+export default DropTarget<DustbinProps, DustbinCollectedProps>(
+	ItemTypes.BOX,
+	boxTarget,
+	(connect, monitor) => ({
+		connectDropTarget: connect.dropTarget(),
+		isOver: monitor.isOver(),
+		canDrop: monitor.canDrop(),
+	}),
+)(Dustbin)

--- a/packages/examples/src/01 Dustbin/Multiple Targets/Box.tsx
+++ b/packages/examples/src/01 Dustbin/Multiple Targets/Box.tsx
@@ -48,7 +48,7 @@ class Box extends React.Component<BoxProps & BoxCollectedProps> {
 	}
 }
 
-export default DragSource<BoxProps, BoxCollectedProps>(
+export default DragSource(
 	(props: BoxProps) => props.type,
 	boxSource,
 	(connect: DragSourceConnector, monitor: DragSourceMonitor) => ({

--- a/packages/examples/src/01 Dustbin/Multiple Targets/Dustbin.tsx
+++ b/packages/examples/src/01 Dustbin/Multiple Targets/Dustbin.tsx
@@ -64,7 +64,7 @@ class Dustbin extends React.Component<DustbinProps & DustbinCollectedProps> {
 	}
 }
 
-export default DropTarget<DustbinProps, DustbinCollectedProps>(
+export default DropTarget(
 	(props: DustbinProps) => props.accepts,
 	dustbinTarget,
 	(connect, monitor) => ({

--- a/packages/examples/src/01 Dustbin/Single Target with FCs/Box.tsx
+++ b/packages/examples/src/01 Dustbin/Single Target with FCs/Box.tsx
@@ -42,7 +42,7 @@ const Box: React.FC<BoxProps & BoxCollectedProps> = ({
 		: null
 }
 
-export default DragSource<BoxProps, BoxCollectedProps>(
+export default DragSource(
 	ItemTypes.BOX,
 	{
 		beginDrag(props: BoxProps) {

--- a/packages/examples/src/01 Dustbin/Single Target with FCs/Dustbin.tsx
+++ b/packages/examples/src/01 Dustbin/Single Target with FCs/Dustbin.tsx
@@ -49,7 +49,7 @@ const Dustbin: React.FC<DustbinCollectedProps> = ({
 		: null
 }
 
-export default DropTarget<{}, DustbinCollectedProps>(
+export default DropTarget(
 	ItemTypes.BOX,
 	{
 		drop() {

--- a/packages/examples/src/01 Dustbin/Stress Test/Box.tsx
+++ b/packages/examples/src/01 Dustbin/Stress Test/Box.tsx
@@ -52,7 +52,7 @@ class Box extends React.Component<BoxProps & BoxCollectedProps> {
 	}
 }
 
-export default DragSource<BoxProps, BoxCollectedProps>(
+export default DragSource(
 	(props: BoxProps) => props.type,
 	boxSource,
 	(connect: DragSourceConnector, monitor: DragSourceMonitor) => ({

--- a/packages/examples/src/02 Drag Around/Custom Drag Layer/CustomDragLayer.tsx
+++ b/packages/examples/src/02 Drag Around/Custom Drag Layer/CustomDragLayer.tsx
@@ -3,6 +3,7 @@ import { DragLayer, XYCoord } from 'react-dnd'
 import ItemTypes from './ItemTypes'
 import BoxDragPreview from './BoxDragPreview'
 import snapToGrid from './snapToGrid'
+import { Identifier } from 'dnd-core'
 
 const layerStyles: React.CSSProperties = {
 	position: 'fixed',
@@ -41,9 +42,9 @@ function getItemStyles(props: CustomDragLayerProps) {
 
 export interface CustomDragLayerProps {
 	item?: any
-	itemType?: string
-	initialOffset?: XYCoord
-	currentOffset?: XYCoord
+	itemType?: Identifier | null
+	initialOffset?: XYCoord | null
+	currentOffset?: XYCoord | null
 	isDragging?: boolean
 	snapToGrid: boolean
 }
@@ -70,7 +71,7 @@ const CustomDragLayer: React.SFC<CustomDragLayerProps> = props => {
 	)
 }
 
-export default DragLayer<CustomDragLayerProps>(monitor => ({
+export default DragLayer(monitor => ({
 	item: monitor.getItem(),
 	itemType: monitor.getItemType(),
 	initialOffset: monitor.getInitialSourceClientOffset(),

--- a/packages/examples/src/02 Drag Around/Naive/Box.tsx
+++ b/packages/examples/src/02 Drag Around/Naive/Box.tsx
@@ -49,11 +49,7 @@ class Box extends React.Component<BoxProps & BoxCollectedProps> {
 	}
 }
 
-export default DragSource<BoxProps, BoxCollectedProps>(
-	ItemTypes.BOX,
-	boxSource,
-	(connect, monitor) => ({
-		connectDragSource: connect.dragSource(),
-		isDragging: monitor.isDragging(),
-	}),
-)(Box)
+export default DragSource(ItemTypes.BOX, boxSource, (connect, monitor) => ({
+	connectDragSource: connect.dragSource(),
+	isDragging: monitor.isDragging(),
+}))(Box)

--- a/packages/examples/src/02 Drag Around/Naive/Container.tsx
+++ b/packages/examples/src/02 Drag Around/Naive/Container.tsx
@@ -94,10 +94,6 @@ class Container extends React.Component<
 	}
 }
 
-export default DropTarget<ContainerProps, ContainerCollectedProps>(
-	ItemTypes.BOX,
-	boxTarget,
-	(connect: any) => ({
-		connectDropTarget: connect.dropTarget(),
-	}),
-)(Container)
+export default DropTarget(ItemTypes.BOX, boxTarget, (connect: any) => ({
+	connectDropTarget: connect.dropTarget(),
+}))(Container)

--- a/packages/examples/src/03 Nesting/Drag Sources/TargetBox.tsx
+++ b/packages/examples/src/03 Nesting/Drag Sources/TargetBox.tsx
@@ -66,7 +66,7 @@ class TargetBoxRaw extends React.Component<
 	}
 }
 
-const TargetBox = DropTarget<TargetBoxProps, TargetBoxCollectedProps>(
+const TargetBox = DropTarget(
 	[Colors.YELLOW, Colors.BLUE],
 	ColorTarget,
 	(connect, monitor) => ({

--- a/packages/examples/src/03 Nesting/Drop Targets/Dustbin.tsx
+++ b/packages/examples/src/03 Nesting/Drop Targets/Dustbin.tsx
@@ -91,8 +91,12 @@ class Dustbin extends React.Component<
 		)
 	}
 }
-export default DropTarget(ItemTypes.BOX, boxTarget, (connect, monitor) => ({
-	connectDropTarget: connect.dropTarget(),
-	isOver: monitor.isOver(),
-	isOverCurrent: monitor.isOver({ shallow: true }),
-}))(Dustbin)
+export default DropTarget<DustbinProps, DustbinCollectedProps>(
+	ItemTypes.BOX,
+	boxTarget,
+	(connect, monitor) => ({
+		connectDropTarget: connect.dropTarget(),
+		isOver: monitor.isOver(),
+		isOverCurrent: monitor.isOver({ shallow: true }),
+	}),
+)(Dustbin)

--- a/packages/examples/src/03 Nesting/Drop Targets/Dustbin.tsx
+++ b/packages/examples/src/03 Nesting/Drop Targets/Dustbin.tsx
@@ -91,12 +91,8 @@ class Dustbin extends React.Component<
 		)
 	}
 }
-export default DropTarget<DustbinProps, DustbinCollectedProps>(
-	ItemTypes.BOX,
-	boxTarget,
-	(connect, monitor) => ({
-		connectDropTarget: connect.dropTarget(),
-		isOver: monitor.isOver(),
-		isOverCurrent: monitor.isOver({ shallow: true }),
-	}),
-)(Dustbin)
+export default DropTarget(ItemTypes.BOX, boxTarget, (connect, monitor) => ({
+	connectDropTarget: connect.dropTarget(),
+	isOver: monitor.isOver(),
+	isOverCurrent: monitor.isOver({ shallow: true }),
+}))(Dustbin)

--- a/packages/examples/src/04 Sortable/Cancel on Drop Outside/Card.tsx
+++ b/packages/examples/src/04 Sortable/Cancel on Drop Outside/Card.tsx
@@ -85,19 +85,11 @@ class Card extends React.Component<
 	}
 }
 
-export default DropTarget<CardProps, CardTargetCollectedProps>(
-	ItemTypes.CARD,
-	cardTarget,
-	connect => ({
-		connectDropTarget: connect.dropTarget(),
-	}),
-)(
-	DragSource<CardProps, CardSourceCollectedProps>(
-		ItemTypes.CARD,
-		cardSource,
-		(connect, monitor) => ({
-			connectDragSource: connect.dragSource(),
-			isDragging: monitor.isDragging(),
-		}),
-	)(Card),
+export default DropTarget(ItemTypes.CARD, cardTarget, connect => ({
+	connectDropTarget: connect.dropTarget(),
+}))(
+	DragSource(ItemTypes.CARD, cardSource, (connect, monitor) => ({
+		connectDragSource: connect.dragSource(),
+		isDragging: monitor.isDragging(),
+	}))(Card),
 )

--- a/packages/examples/src/04 Sortable/Simple/Card.tsx
+++ b/packages/examples/src/04 Sortable/Simple/Card.tsx
@@ -116,14 +116,14 @@ class Card extends React.Component<
 	}
 }
 
-export default DropTarget<CardProps, CardTargetCollectedProps>(
+export default DropTarget(
 	ItemTypes.CARD,
 	cardTarget,
 	(connect: DropTargetConnector) => ({
 		connectDropTarget: connect.dropTarget(),
 	}),
 )(
-	DragSource<CardProps, CardSourceCollectedProps>(
+	DragSource(
 		ItemTypes.CARD,
 		cardSource,
 		(connect: DragSourceConnector, monitor: DragSourceMonitor) => ({

--- a/packages/examples/src/04 Sortable/Stress Test/Card.tsx
+++ b/packages/examples/src/04 Sortable/Stress Test/Card.tsx
@@ -65,19 +65,11 @@ class Card extends React.Component<
 	}
 }
 
-export default DropTarget<CardProps, CardTargetCollectedProps>(
-	ItemTypes.CARD,
-	cardTarget,
-	connect => ({
-		connectDropTarget: connect.dropTarget(),
-	}),
-)(
-	DragSource<CardProps, CardSourceCollectedProps>(
-		ItemTypes.CARD,
-		cardSource,
-		(connect, monitor) => ({
-			connectDragSource: connect.dragSource(),
-			isDragging: monitor.isDragging(),
-		}),
-	)(Card),
+export default DropTarget(ItemTypes.CARD, cardTarget, connect => ({
+	connectDropTarget: connect.dropTarget(),
+}))(
+	DragSource(ItemTypes.CARD, cardSource, (connect, monitor) => ({
+		connectDragSource: connect.dragSource(),
+		isDragging: monitor.isDragging(),
+	}))(Card),
 )

--- a/packages/examples/src/05 Customize/Drop Effects/SourceBox.tsx
+++ b/packages/examples/src/05 Customize/Drop Effects/SourceBox.tsx
@@ -43,11 +43,7 @@ class SourceBox extends React.Component<
 	}
 }
 
-export default DragSource<SourceBoxProps, SourceBoxCollectedProps>(
-	ItemTypes.BOX,
-	boxSource,
-	(connect, monitor) => ({
-		connectDragSource: connect.dragSource(),
-		isDragging: monitor.isDragging(),
-	}),
-)(SourceBox)
+export default DragSource(ItemTypes.BOX, boxSource, (connect, monitor) => ({
+	connectDragSource: connect.dragSource(),
+	isDragging: monitor.isDragging(),
+}))(SourceBox)

--- a/packages/examples/src/06 Other/Drag Source Rerender/Example.tsx
+++ b/packages/examples/src/06 Other/Drag Source Rerender/Example.tsx
@@ -13,7 +13,7 @@ const Parent: React.FC<ParentProps> = ({ isDragging, connectDragSource }) => {
 	)
 }
 
-export default DragSource(
+const Example = DragSource<{}, ParentProps>(
 	'KNIGHT',
 	{
 		beginDrag: () => ({}),
@@ -23,6 +23,7 @@ export default DragSource(
 		isDragging: monitor.isDragging(),
 	}),
 )(Parent)
+export default Example
 
 interface ChildProps {
 	connect: ConnectDragSource

--- a/packages/examples/src/06 Other/Drag Source Rerender/Example.tsx
+++ b/packages/examples/src/06 Other/Drag Source Rerender/Example.tsx
@@ -13,7 +13,7 @@ const Parent: React.FC<ParentProps> = ({ isDragging, connectDragSource }) => {
 	)
 }
 
-const Example = DragSource<{}, ParentProps>(
+const Example = DragSource(
 	'KNIGHT',
 	{
 		beginDrag: () => ({}),

--- a/packages/examples/src/06 Other/Native Files/TargetBox.tsx
+++ b/packages/examples/src/06 Other/Native Files/TargetBox.tsx
@@ -14,14 +14,6 @@ const style: React.CSSProperties = {
 	textAlign: 'center',
 }
 
-const boxTarget = {
-	drop(props: TargetBoxProps, monitor: DropTargetMonitor) {
-		if (props.onDrop) {
-			props.onDrop(props, monitor)
-		}
-	},
-}
-
 export interface TargetBoxProps {
 	accepts: string[]
 	onDrop: (props: TargetBoxProps, monitor: DropTargetMonitor) => void
@@ -48,9 +40,15 @@ class TargetBox extends React.Component<
 	}
 }
 
-export default DropTarget<TargetBoxProps, TargetBoxCollectedProps>(
+export default DropTarget(
 	(props: TargetBoxProps) => props.accepts,
-	boxTarget,
+	{
+		drop(props: TargetBoxProps, monitor: DropTargetMonitor) {
+			if (props.onDrop) {
+				props.onDrop(props, monitor)
+			}
+		},
+	},
 	(connect: DropTargetConnector, monitor: DropTargetMonitor) => ({
 		connectDropTarget: connect.dropTarget(),
 		isOver: monitor.isOver(),

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -33,7 +33,7 @@ export const componentIndex: {
 	'drag-around-naive': dragAroundNaive,
 	'nesting-drag-sources': nestingDragSources,
 	'nesting-drop-targets': nestingDropTargets,
-	'sortable-cancel-on-drop-outside': sortableCancelOnDropOutside,
+	'sortable-cancel-on-drop-outside': sortableCancelOnDropOutside as any,
 	'sortable-simple': sortableSimple,
 	'sortable-stress-test': sortableStressTest,
 	'customize-drop-effects': customizeDropEffects,

--- a/packages/react-dnd/package.json
+++ b/packages/react-dnd/package.json
@@ -31,6 +31,7 @@
 	"devDependencies": {
 		"@babel/cli": "^7.2.3",
 		"@babel/core": "^7.3.4",
+		"@types/hoist-non-react-statics": "^3.3.0",
 		"@types/react": "^16.8.7",
 		"@types/react-dom": "^16.8.2",
 		"babel-loader": "^8.0.5",

--- a/packages/react-dnd/src/DragLayer.tsx
+++ b/packages/react-dnd/src/DragLayer.tsx
@@ -2,7 +2,11 @@ declare var require: any
 import * as React from 'react'
 import checkDecoratorArguments from './utils/checkDecoratorArguments'
 import { DragDropManager, Unsubscribe } from 'dnd-core'
-import { DragLayerCollector, DndOptions, DndComponentClass } from './interfaces'
+import {
+	DragLayerCollector,
+	DndOptions,
+	DndDecoratedComponent,
+} from './interfaces'
 import { Consumer } from './DragDropContext'
 const hoistStatics = require('hoist-non-react-statics')
 const isPlainObject = require('lodash/isPlainObject')
@@ -27,9 +31,11 @@ export default function DragLayer<Props, CollectedProps = {}>(
 		options,
 	)
 
-	return function decorateLayer<T>(
-		DecoratedComponent: React.ComponentType<T>,
-	): DndComponentClass<Props> {
+	return function decorateLayer<
+		ComponentType extends React.ComponentType<Props & CollectedProps>
+	>(
+		DecoratedComponent: ComponentType,
+	): DndDecoratedComponent<Props, CollectedProps, ComponentType> {
 		const Decorated = DecoratedComponent as any
 		const { arePropsEqual = shallowEqual } = options
 		const displayName = Decorated.displayName || Decorated.name || 'Component'
@@ -143,6 +149,6 @@ export default function DragLayer<Props, CollectedProps = {}>(
 		return hoistStatics(
 			DragLayerContainer,
 			DecoratedComponent,
-		) as DndComponentClass<Props>
+		) as DndDecoratedComponent<Props, CollectedProps, ComponentType>
 	}
 }

--- a/packages/react-dnd/src/DragLayer.tsx
+++ b/packages/react-dnd/src/DragLayer.tsx
@@ -5,7 +5,7 @@ import { DragDropManager, Unsubscribe } from 'dnd-core'
 import {
 	DragLayerCollector,
 	DndOptions,
-	DndDecoratedComponent,
+	DndComponentEnhancer,
 } from './interfaces'
 import { Consumer } from './DragDropContext'
 const hoistStatics = require('hoist-non-react-statics')
@@ -13,9 +13,9 @@ const isPlainObject = require('lodash/isPlainObject')
 const invariant = require('invariant')
 const shallowEqual = require('shallowequal')
 
-export default function DragLayer<Props, CollectedProps = {}>(
-	collect: DragLayerCollector<Props, CollectedProps>,
-	options: DndOptions<Props> = {},
+export default function DragLayer<RequiredProps, CollectedProps = {}>(
+	collect: DragLayerCollector<RequiredProps, CollectedProps>,
+	options: DndOptions<RequiredProps> = {},
 ) {
 	checkDecoratorArguments('DragLayer', 'collect[, options]', collect, options)
 	invariant(
@@ -32,15 +32,15 @@ export default function DragLayer<Props, CollectedProps = {}>(
 	)
 
 	return function decorateLayer<
-		ComponentType extends React.ComponentType<Props & CollectedProps>
+		ComponentType extends React.ComponentType<RequiredProps & CollectedProps>
 	>(
 		DecoratedComponent: ComponentType,
-	): DndDecoratedComponent<Props, CollectedProps, ComponentType> {
+	): DndComponentEnhancer<RequiredProps, CollectedProps> {
 		const Decorated = DecoratedComponent as any
 		const { arePropsEqual = shallowEqual } = options
 		const displayName = Decorated.displayName || Decorated.name || 'Component'
 
-		class DragLayerContainer extends React.Component<Props> {
+		class DragLayerContainer extends React.Component<RequiredProps> {
 			public static displayName = `DragLayer(${displayName})`
 			public static DecoratedComponent = DecoratedComponent
 
@@ -149,6 +149,6 @@ export default function DragLayer<Props, CollectedProps = {}>(
 		return hoistStatics(
 			DragLayerContainer,
 			DecoratedComponent,
-		) as DndDecoratedComponent<Props, CollectedProps, ComponentType>
+		) as DndComponentEnhancer<RequiredProps, CollectedProps>
 	}
 }

--- a/packages/react-dnd/src/DragLayer.tsx
+++ b/packages/react-dnd/src/DragLayer.tsx
@@ -16,7 +16,7 @@ const shallowEqual = require('shallowequal')
 export default function DragLayer<RequiredProps, CollectedProps = {}>(
 	collect: DragLayerCollector<RequiredProps, CollectedProps>,
 	options: DndOptions<RequiredProps> = {},
-) {
+): DndComponentEnhancer<CollectedProps> {
 	checkDecoratorArguments('DragLayer', 'collect[, options]', collect, options)
 	invariant(
 		typeof collect === 'function',
@@ -31,11 +31,9 @@ export default function DragLayer<RequiredProps, CollectedProps = {}>(
 		options,
 	)
 
-	return function decorateLayer<
+	return (function decorateLayer<
 		ComponentType extends React.ComponentType<RequiredProps & CollectedProps>
-	>(
-		DecoratedComponent: ComponentType,
-	): DndComponentEnhancer<RequiredProps, CollectedProps> {
+	>(DecoratedComponent: ComponentType): DndComponentEnhancer<CollectedProps> {
 		const Decorated = DecoratedComponent as any
 		const { arePropsEqual = shallowEqual } = options
 		const displayName = Decorated.displayName || Decorated.name || 'Component'
@@ -146,9 +144,6 @@ export default function DragLayer<RequiredProps, CollectedProps = {}>(
 			}
 		}
 
-		return hoistStatics(
-			DragLayerContainer,
-			DecoratedComponent,
-		) as DndComponentEnhancer<RequiredProps, CollectedProps>
-	}
+		return hoistStatics(DragLayerContainer, DecoratedComponent)
+	} as any) as DndComponentEnhancer<CollectedProps>
 }

--- a/packages/react-dnd/src/DragSource.ts
+++ b/packages/react-dnd/src/DragSource.ts
@@ -1,12 +1,7 @@
 declare var require: any
 import * as React from 'react'
 import { SourceType, DragDropManager } from 'dnd-core'
-import {
-	DragSourceSpec,
-	DragSourceCollector,
-	DndOptions,
-	DndComponentClass,
-} from './interfaces'
+import { DragSourceSpec, DragSourceCollector, DndOptions } from './interfaces'
 import checkDecoratorArguments from './utils/checkDecoratorArguments'
 import decorateHandler from './decorateHandler'
 import registerSource from './registerSource'
@@ -14,6 +9,7 @@ import createSourceFactory from './createSourceFactory'
 import DragSourceMonitorImpl from './DragSourceMonitorImpl'
 import SourceConnector from './SourceConnector'
 import isValidType from './utils/isValidType'
+import { DndDecoratedComponent } from './interfaces'
 const invariant = require('invariant')
 const isPlainObject = require('lodash/isPlainObject')
 
@@ -77,9 +73,11 @@ export default function DragSource<Props, CollectedProps = {}, DragObject = {}>(
 		collect,
 	)
 
-	return function decorateSource<T>(
-		DecoratedComponent: React.ComponentType<T>,
-	): DndComponentClass<Props> {
+	return function decorateSource<
+		ComponentType extends React.ComponentType<Props & CollectedProps>
+	>(
+		DecoratedComponent: ComponentType,
+	): DndDecoratedComponent<Props, CollectedProps, ComponentType> {
 		return decorateHandler<Props, SourceType>({
 			containerDisplayName: 'DragSource',
 			createHandler: createSource as any,
@@ -91,6 +89,6 @@ export default function DragSource<Props, CollectedProps = {}, DragObject = {}>(
 			getType,
 			collect,
 			options,
-		})
+		}) as any
 	}
 }

--- a/packages/react-dnd/src/DragSource.ts
+++ b/packages/react-dnd/src/DragSource.ts
@@ -29,7 +29,7 @@ export default function DragSource<
 	spec: DragSourceSpec<RequiredProps, DragObject>,
 	collect: DragSourceCollector<CollectedProps, RequiredProps>,
 	options: DndOptions<RequiredProps> = {},
-) {
+): DndComponentEnhancer<CollectedProps> {
 	checkDecoratorArguments(
 		'DragSource',
 		'type, spec, collect[, options]',
@@ -77,11 +77,9 @@ export default function DragSource<
 		collect,
 	)
 
-	return function decorateSource<
+	return (function decorateSource<
 		ComponentType extends React.ComponentType<RequiredProps & CollectedProps>
-	>(
-		DecoratedComponent: ComponentType,
-	): DndComponentEnhancer<RequiredProps, CollectedProps> {
+	>(DecoratedComponent: ComponentType) {
 		return decorateHandler<RequiredProps, CollectedProps, SourceType>({
 			containerDisplayName: 'DragSource',
 			createHandler: createSource as any,
@@ -94,5 +92,5 @@ export default function DragSource<
 			collect,
 			options,
 		})
-	}
+	} as any) as DndComponentEnhancer<CollectedProps>
 }

--- a/packages/react-dnd/src/DragSource.ts
+++ b/packages/react-dnd/src/DragSource.ts
@@ -9,7 +9,7 @@ import createSourceFactory from './createSourceFactory'
 import DragSourceMonitorImpl from './DragSourceMonitorImpl'
 import SourceConnector from './SourceConnector'
 import isValidType from './utils/isValidType'
-import { DndDecoratedComponent } from './interfaces'
+import { DndComponentEnhancer } from './interfaces'
 const invariant = require('invariant')
 const isPlainObject = require('lodash/isPlainObject')
 
@@ -20,11 +20,15 @@ const isPlainObject = require('lodash/isPlainObject')
  * @param collect The props collector function
  * @param options DnD options
  */
-export default function DragSource<Props, CollectedProps = {}, DragObject = {}>(
-	type: SourceType | ((props: Props) => SourceType),
-	spec: DragSourceSpec<Props, DragObject>,
-	collect: DragSourceCollector<CollectedProps, Props>,
-	options: DndOptions<Props> = {},
+export default function DragSource<
+	RequiredProps,
+	CollectedProps = {},
+	DragObject = {}
+>(
+	type: SourceType | ((props: RequiredProps) => SourceType),
+	spec: DragSourceSpec<RequiredProps, DragObject>,
+	collect: DragSourceCollector<CollectedProps, RequiredProps>,
+	options: DndOptions<RequiredProps> = {},
 ) {
 	checkDecoratorArguments(
 		'DragSource',
@@ -34,8 +38,8 @@ export default function DragSource<Props, CollectedProps = {}, DragObject = {}>(
 		collect,
 		options,
 	)
-	let getType: (props: Props) => SourceType = type as ((
-		props: Props,
+	let getType: (props: RequiredProps) => SourceType = type as ((
+		props: RequiredProps,
 	) => SourceType)
 	if (typeof type !== 'function') {
 		invariant(
@@ -74,11 +78,11 @@ export default function DragSource<Props, CollectedProps = {}, DragObject = {}>(
 	)
 
 	return function decorateSource<
-		ComponentType extends React.ComponentType<Props & CollectedProps>
+		ComponentType extends React.ComponentType<RequiredProps & CollectedProps>
 	>(
 		DecoratedComponent: ComponentType,
-	): DndDecoratedComponent<Props, CollectedProps, ComponentType> {
-		return decorateHandler<Props, SourceType>({
+	): DndComponentEnhancer<RequiredProps, CollectedProps> {
+		return decorateHandler<RequiredProps, CollectedProps, SourceType>({
 			containerDisplayName: 'DragSource',
 			createHandler: createSource as any,
 			registerHandler: registerSource,
@@ -89,6 +93,6 @@ export default function DragSource<Props, CollectedProps = {}, DragObject = {}>(
 			getType,
 			collect,
 			options,
-		}) as any
+		})
 	}
 }

--- a/packages/react-dnd/src/DropTarget.ts
+++ b/packages/react-dnd/src/DropTarget.ts
@@ -6,6 +6,7 @@ import {
 	DndOptions,
 	DropTargetCollector,
 	DndComponentEnhancer,
+	DndComponent,
 } from './interfaces'
 import checkDecoratorArguments from './utils/checkDecoratorArguments'
 import decorateHandler from './decorateHandler'
@@ -22,7 +23,7 @@ export default function DropTarget<RequiredProps, CollectedProps = {}>(
 	spec: DropTargetSpec<RequiredProps>,
 	collect: DropTargetCollector<CollectedProps, RequiredProps>,
 	options: DndOptions<RequiredProps> = {},
-) {
+): DndComponentEnhancer<CollectedProps> {
 	checkDecoratorArguments(
 		'DropTarget',
 		'type, spec, collect[, options]',
@@ -70,11 +71,9 @@ export default function DropTarget<RequiredProps, CollectedProps = {}>(
 		collect,
 	)
 
-	return function decorateTarget<
+	return (function decorateTarget<
 		ComponentType extends React.ComponentType<RequiredProps & CollectedProps>
-	>(
-		DecoratedComponent: ComponentType,
-	): DndComponentEnhancer<RequiredProps, CollectedProps> {
+	>(DecoratedComponent: ComponentType): DndComponent<RequiredProps> {
 		return decorateHandler<RequiredProps, CollectedProps, TargetType>({
 			containerDisplayName: 'DropTarget',
 			createHandler: createTarget as any,
@@ -87,5 +86,5 @@ export default function DropTarget<RequiredProps, CollectedProps = {}>(
 			collect,
 			options,
 		})
-	}
+	} as any) as DndComponentEnhancer<CollectedProps>
 }

--- a/packages/react-dnd/src/DropTarget.ts
+++ b/packages/react-dnd/src/DropTarget.ts
@@ -5,7 +5,7 @@ import {
 	DropTargetSpec,
 	DndOptions,
 	DropTargetCollector,
-	DndComponentClass,
+	DndDecoratedComponent,
 } from './interfaces'
 import checkDecoratorArguments from './utils/checkDecoratorArguments'
 import decorateHandler from './decorateHandler'
@@ -70,9 +70,11 @@ export default function DropTarget<Props, CollectedProps = {}>(
 		collect,
 	)
 
-	return function decorateTarget<T>(
-		DecoratedComponent: React.ComponentType<T>,
-	): DndComponentClass<Props> {
+	return function decorateTarget<
+		ComponentType extends React.ComponentType<Props & CollectedProps>
+	>(
+		DecoratedComponent: ComponentType,
+	): DndDecoratedComponent<Props, CollectedProps, ComponentType> {
 		return decorateHandler<Props, TargetType>({
 			containerDisplayName: 'DropTarget',
 			createHandler: createTarget as any,
@@ -84,6 +86,6 @@ export default function DropTarget<Props, CollectedProps = {}>(
 			getType,
 			collect,
 			options,
-		})
+		}) as any
 	}
 }

--- a/packages/react-dnd/src/DropTarget.ts
+++ b/packages/react-dnd/src/DropTarget.ts
@@ -5,7 +5,7 @@ import {
 	DropTargetSpec,
 	DndOptions,
 	DropTargetCollector,
-	DndDecoratedComponent,
+	DndComponentEnhancer,
 } from './interfaces'
 import checkDecoratorArguments from './utils/checkDecoratorArguments'
 import decorateHandler from './decorateHandler'
@@ -17,11 +17,11 @@ import TargetConnector from './TargetConnector'
 const invariant = require('invariant')
 const isPlainObject = require('lodash/isPlainObject')
 
-export default function DropTarget<Props, CollectedProps = {}>(
-	type: TargetType | ((props: Props) => TargetType),
-	spec: DropTargetSpec<Props>,
-	collect: DropTargetCollector<CollectedProps, Props>,
-	options: DndOptions<Props> = {},
+export default function DropTarget<RequiredProps, CollectedProps = {}>(
+	type: TargetType | ((props: RequiredProps) => TargetType),
+	spec: DropTargetSpec<RequiredProps>,
+	collect: DropTargetCollector<CollectedProps, RequiredProps>,
+	options: DndOptions<RequiredProps> = {},
 ) {
 	checkDecoratorArguments(
 		'DropTarget',
@@ -31,8 +31,8 @@ export default function DropTarget<Props, CollectedProps = {}>(
 		collect,
 		options,
 	)
-	let getType: (props: Props) => TargetType = type as ((
-		props: Props,
+	let getType: (props: RequiredProps) => TargetType = type as ((
+		props: RequiredProps,
 	) => TargetType)
 	if (typeof type !== 'function') {
 		invariant(
@@ -71,11 +71,11 @@ export default function DropTarget<Props, CollectedProps = {}>(
 	)
 
 	return function decorateTarget<
-		ComponentType extends React.ComponentType<Props & CollectedProps>
+		ComponentType extends React.ComponentType<RequiredProps & CollectedProps>
 	>(
 		DecoratedComponent: ComponentType,
-	): DndDecoratedComponent<Props, CollectedProps, ComponentType> {
-		return decorateHandler<Props, TargetType>({
+	): DndComponentEnhancer<RequiredProps, CollectedProps> {
+		return decorateHandler<RequiredProps, CollectedProps, TargetType>({
 			containerDisplayName: 'DropTarget',
 			createHandler: createTarget as any,
 			registerHandler: registerTarget,
@@ -86,6 +86,6 @@ export default function DropTarget<Props, CollectedProps = {}>(
 			getType,
 			collect,
 			options,
-		}) as any
+		})
 	}
 }

--- a/packages/react-dnd/src/decorateHandler.tsx
+++ b/packages/react-dnd/src/decorateHandler.tsx
@@ -3,7 +3,7 @@ declare var process: any
 
 import * as React from 'react'
 import { DragDropManager, Identifier } from 'dnd-core'
-import { DndComponentClass, DndComponent } from './interfaces'
+import { DndComponent, DndComponentEnhancer } from './interfaces'
 import { Consumer } from './DragDropContext'
 import {
 	Disposable,
@@ -40,7 +40,11 @@ interface Handler<Props> {
 	receiveProps(props: Props): void
 }
 
-export default function decorateHandler<Props, ItemIdType>({
+export default function decorateHandler<
+	RequiredProps,
+	CollectedProps,
+	ItemIdType
+>({
 	DecoratedComponent,
 	createHandler,
 	createMonitor,
@@ -50,15 +54,18 @@ export default function decorateHandler<Props, ItemIdType>({
 	getType,
 	collect,
 	options,
-}: DecorateHandlerArgs<Props, ItemIdType>): DndComponentClass<Props> {
+}: DecorateHandlerArgs<RequiredProps, ItemIdType>): DndComponentEnhancer<
+	RequiredProps,
+	CollectedProps
+> {
 	const { arePropsEqual = shallowEqual } = options
 	const Decorated: any = DecoratedComponent
 
 	const displayName =
 		DecoratedComponent.displayName || DecoratedComponent.name || 'Component'
 
-	class DragDropContainer extends React.Component<Props>
-		implements DndComponent<Props> {
+	class DragDropContainer extends React.Component<RequiredProps>
+		implements DndComponent<RequiredProps> {
 		public static DecoratedComponent = DecoratedComponent
 		public static displayName = `${containerDisplayName}(${displayName})`
 
@@ -67,11 +74,11 @@ export default function decorateHandler<Props, ItemIdType>({
 		private manager: DragDropManager<any> | undefined
 		private handlerMonitor: HandlerReceiver | undefined
 		private handlerConnector: Connector | undefined
-		private handler: Handler<Props> | undefined
+		private handler: Handler<RequiredProps> | undefined
 		private disposable: any
 		private currentType: any
 
-		constructor(props: Props) {
+		constructor(props: RequiredProps) {
 			super(props)
 			this.disposable = new SerialDisposable()
 			this.receiveProps(props)
@@ -104,7 +111,7 @@ export default function decorateHandler<Props, ItemIdType>({
 			this.handleChange()
 		}
 
-		public componentDidUpdate(prevProps: Props) {
+		public componentDidUpdate(prevProps: RequiredProps) {
 			if (!arePropsEqual(this.props, prevProps)) {
 				this.receiveProps(this.props)
 				this.handleChange()
@@ -243,5 +250,5 @@ export default function decorateHandler<Props, ItemIdType>({
 	return hoistStatics(
 		DragDropContainer,
 		DecoratedComponent,
-	) as DndComponentClass<Props>
+	) as DndComponentEnhancer<RequiredProps, CollectedProps>
 }

--- a/packages/react-dnd/src/decorateHandler.tsx
+++ b/packages/react-dnd/src/decorateHandler.tsx
@@ -3,7 +3,7 @@ declare var process: any
 
 import * as React from 'react'
 import { DragDropManager, Identifier } from 'dnd-core'
-import { DndComponent, DndComponentEnhancer } from './interfaces'
+import { DndComponent } from './interfaces'
 import { Consumer } from './DragDropContext'
 import {
 	Disposable,
@@ -40,11 +40,7 @@ interface Handler<Props> {
 	receiveProps(props: Props): void
 }
 
-export default function decorateHandler<
-	RequiredProps,
-	CollectedProps,
-	ItemIdType
->({
+export default function decorateHandler<Props, CollectedProps, ItemIdType>({
 	DecoratedComponent,
 	createHandler,
 	createMonitor,
@@ -54,18 +50,15 @@ export default function decorateHandler<
 	getType,
 	collect,
 	options,
-}: DecorateHandlerArgs<RequiredProps, ItemIdType>): DndComponentEnhancer<
-	RequiredProps,
-	CollectedProps
-> {
+}: DecorateHandlerArgs<Props, ItemIdType>): DndComponent<Props> {
 	const { arePropsEqual = shallowEqual } = options
 	const Decorated: any = DecoratedComponent
 
 	const displayName =
 		DecoratedComponent.displayName || DecoratedComponent.name || 'Component'
 
-	class DragDropContainer extends React.Component<RequiredProps>
-		implements DndComponent<RequiredProps> {
+	class DragDropContainer extends React.Component<Props>
+		implements DndComponent<Props> {
 		public static DecoratedComponent = DecoratedComponent
 		public static displayName = `${containerDisplayName}(${displayName})`
 
@@ -74,11 +67,11 @@ export default function decorateHandler<
 		private manager: DragDropManager<any> | undefined
 		private handlerMonitor: HandlerReceiver | undefined
 		private handlerConnector: Connector | undefined
-		private handler: Handler<RequiredProps> | undefined
+		private handler: Handler<Props> | undefined
 		private disposable: any
 		private currentType: any
 
-		constructor(props: RequiredProps) {
+		constructor(props: Props) {
 			super(props)
 			this.disposable = new SerialDisposable()
 			this.receiveProps(props)
@@ -111,7 +104,7 @@ export default function decorateHandler<
 			this.handleChange()
 		}
 
-		public componentDidUpdate(prevProps: RequiredProps) {
+		public componentDidUpdate(prevProps: Props) {
 			if (!arePropsEqual(this.props, prevProps)) {
 				this.receiveProps(this.props)
 				this.handleChange()
@@ -247,8 +240,8 @@ export default function decorateHandler<
 		}
 	}
 
-	return hoistStatics(
+	return (hoistStatics(
 		DragDropContainer,
 		DecoratedComponent,
-	) as DndComponentEnhancer<RequiredProps, CollectedProps>
+	) as any) as DndComponent<Props>
 }

--- a/packages/react-dnd/src/interfaces/classApi.ts
+++ b/packages/react-dnd/src/interfaces/classApi.ts
@@ -187,3 +187,12 @@ export type DragLayerCollector<TargetProps, CollectedProps> = (
 	monitor: DragLayerMonitor,
 	props: TargetProps,
 ) => CollectedProps
+
+export type Diff<T, U> = T extends U ? never : T
+
+export type DndDecoratedComponent<
+	Props,
+	CollectedProps,
+	ComponentType extends React.ComponentType<Props & CollectedProps>
+> = Diff<ComponentType, React.ComponentType<Props & CollectedProps>> &
+	DndComponentClass<Props>

--- a/packages/react-dnd/src/interfaces/classApi.ts
+++ b/packages/react-dnd/src/interfaces/classApi.ts
@@ -219,13 +219,13 @@ export type Matching<InjectedProps, DecorationTargetProps> = {
  * But any property required by the decorated component must be satisfied by the injected property.
  */
 export type Shared<
-	CollectedProps,
-	DecorationTargetProps extends Shared<CollectedProps, DecorationTargetProps>
+	InjectedProps,
+	DecorationTargetProps extends Shared<InjectedProps, DecorationTargetProps>
 > = {
 	[P in Extract<
-		keyof CollectedProps,
+		keyof InjectedProps,
 		keyof DecorationTargetProps
-	>]?: CollectedProps[P] extends DecorationTargetProps[P]
+	>]?: InjectedProps[P] extends DecorationTargetProps[P]
 		? DecorationTargetProps[P]
 		: never
 }
@@ -235,13 +235,13 @@ export type Shared<
  */
 export type GetProps<C> = C extends React.ComponentType<infer P> ? P : never
 
-export type DndComponentEnhancer<NeedsProps, CollectedProps> = <
+export type DndComponentEnhancer<CollectedProps> = <
 	C extends React.ComponentType<Matching<CollectedProps, GetProps<C>>>
 >(
 	component: C,
 ) => DndComponentClass<
 	C,
-	Omit<GetProps<C>, keyof Shared<CollectedProps, GetProps<C>>> & NeedsProps
+	Omit<GetProps<C>, keyof Shared<CollectedProps, GetProps<C>>>
 >
 
 // Applies LibraryManagedAttributes (proper handling of defaultProps

--- a/packages/react-dnd/src/interfaces/classApi.ts
+++ b/packages/react-dnd/src/interfaces/classApi.ts
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import { DragDropManager, Identifier } from 'dnd-core'
 import {
 	DropTargetMonitor,
@@ -5,6 +6,7 @@ import {
 	DragLayerMonitor,
 } from './monitors'
 import { DragSourceOptions, DragPreviewOptions } from './options'
+import { NonReactStatics } from 'hoist-non-react-statics'
 
 /**
  * The React Component that manages the DragDropContext for its children.
@@ -29,13 +31,6 @@ export interface ContextComponentClass<Props>
 	extends React.ComponentClass<Props> {
 	DecoratedComponent: React.ComponentType<Props>
 	new (props?: Props, context?: any): ContextComponent<Props>
-}
-/**
- * The class interface for a DnD component
- */
-export interface DndComponentClass<Props> extends React.ComponentClass<Props> {
-	DecoratedComponent: React.ComponentType<Props>
-	new (props?: Props, context?: any): DndComponent<Props>
 }
 
 /**
@@ -188,11 +183,71 @@ export type DragLayerCollector<TargetProps, CollectedProps> = (
 	props: TargetProps,
 ) => CollectedProps
 
-export type Diff<T, U> = T extends U ? never : T
+// Borrowing typings from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-redux/index.d.ts
 
-export type DndDecoratedComponent<
-	Props,
+// Omit taken from https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
+
+/**
+ * A property P will be present if:
+ * - it is present in DecorationTargetProps
+ *
+ * Its value will be dependent on the following conditions
+ * - if property P is present in InjectedProps and its definition extends the definition
+ *   in DecorationTargetProps, then its definition will be that of DecorationTargetProps[P]
+ * - if property P is not present in InjectedProps then its definition will be that of
+ *   DecorationTargetProps[P]
+ * - if property P is present in InjectedProps but does not extend the
+ *   DecorationTargetProps[P] definition, its definition will be that of InjectedProps[P]
+ */
+export type Matching<InjectedProps, DecorationTargetProps> = {
+	[P in keyof DecorationTargetProps]: P extends keyof InjectedProps
+		? InjectedProps[P] extends DecorationTargetProps[P]
+			? DecorationTargetProps[P]
+			: InjectedProps[P]
+		: DecorationTargetProps[P]
+}
+
+/**
+ * a property P will be present if :
+ * - it is present in both DecorationTargetProps and InjectedProps
+ * - InjectedProps[P] can satisfy DecorationTargetProps[P]
+ * ie: decorated component can accept more types than decorator is injecting
+ *
+ * For decoration, inject props or ownProps are all optionally
+ * required by the decorated (right hand side) component.
+ * But any property required by the decorated component must be satisfied by the injected property.
+ */
+export type Shared<
 	CollectedProps,
-	ComponentType extends React.ComponentType<Props & CollectedProps>
-> = Diff<ComponentType, React.ComponentType<Props & CollectedProps>> &
-	DndComponentClass<Props>
+	DecorationTargetProps extends Shared<CollectedProps, DecorationTargetProps>
+> = {
+	[P in Extract<
+		keyof CollectedProps,
+		keyof DecorationTargetProps
+	>]?: CollectedProps[P] extends DecorationTargetProps[P]
+		? DecorationTargetProps[P]
+		: never
+}
+
+/**
+ * Gets the props interface of a component using inference
+ */
+export type GetProps<C> = C extends React.ComponentType<infer P> ? P : never
+
+export type DndComponentEnhancer<NeedsProps, CollectedProps> = <
+	C extends React.ComponentType<Matching<CollectedProps, GetProps<C>>>
+>(
+	component: C,
+) => DndComponentClass<
+	C,
+	Omit<GetProps<C>, keyof Shared<CollectedProps, GetProps<C>>> & NeedsProps
+>
+
+// Applies LibraryManagedAttributes (proper handling of defaultProps
+// and propTypes), as well as defines WrappedComponent.
+export type DndComponentClass<
+	C extends React.ComponentType<any>,
+	P
+> = React.ComponentClass<JSX.LibraryManagedAttributes<C, P>> &
+	NonReactStatics<C> & { DecoratedComponent: C }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1708,6 +1708,13 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.2.tgz#0e670ea254d559241b6eeb3894f8754991e73220"
   integrity sha512-ui3WwXmjTaY73fOQ3/m3nnajU/Orhi6cEu5rzX+BrAAJxa3eITXZ5ch9suPqtM03OWhAHhPSyBGCN4UKoxO20Q==
 
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#a59c0c995cc885bef1b8ec2241b114f9b35b517b"
+  integrity sha512-O2OGyW9wlO2bbDmZRH17MecArQfsIa1g//ve2IJk6BnmwEglFz5kdhP1BlgeqjVNH5IHIhsc83DWFo8StCe8+Q==
+  dependencies:
+    "@types/react" "*"
+
 "@types/jest-diff@*":
   version "20.0.1"
   resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"


### PR DESCRIPTION
The existing typings for decorators don't include static members, and this has caused issues for some users. This PR is an attempt to model the HOC decoration more accurately type-wise. The updated types are based on DefinitelyTyped's typings for react-redux, which also has a prop-injected component mechanism.

~~Right now the examples don't compile. When they do, and the types are more locked in we can merge this.~~

Fixes #1287