### PR TITLE
Remove dependency on recompose

### DIFF
--- a/packages/react-dnd/package.json
+++ b/packages/react-dnd/package.json
@@ -25,7 +25,6 @@
 		"hoist-non-react-statics": "^3.3.0",
 		"invariant": "^2.1.0",
 		"lodash": "^4.17.11",
-		"recompose": "^0.30.0",
 		"shallowequal": "^1.1.0"
 	},
 	"devDependencies": {

--- a/packages/react-dnd/src/decorateHandler.tsx
+++ b/packages/react-dnd/src/decorateHandler.tsx
@@ -11,11 +11,17 @@ import {
 	SerialDisposable,
 } from './utils/disposables'
 import { Connector } from './SourceConnector'
-const isClassComponent = require('recompose/isClassComponent').default
 const isPlainObject = require('lodash/isPlainObject')
 const invariant = require('invariant')
 const hoistStatics = require('hoist-non-react-statics')
 const shallowEqual = require('shallowequal')
+
+const isClassComponent = (Component: any) =>
+  Boolean(
+    Component &&
+      Component.prototype &&
+      typeof Component.prototype.render === 'function'
+)
 
 export interface DecorateHandlerArgs<Props, ItemIdType> {
 	DecoratedComponent: any


### PR DESCRIPTION
This removes the "recompose" dependency [by copying `isClassComponent` from the recompose module](https://github.com/acdlite/recompose/blob/master/src/packages/recompose/isClassComponent.js); the predicate itself is trivial and recompose is not actively maintained anymore so this shaves off over 8 MB, or more than half of all production dependencies when installing via NPM. (I know most people will use bundlers anyway, but the extra weight still hurts in some situations.)

As far as I can tell `isClassComponent` was the only part of recompose that was actually used; I hope I did not miss anything!

Before:
![Screenshot from 2019-03-26 12-50-04](https://user-images.githubusercontent.com/325102/54996063-99914a00-4fc8-11e9-90b5-6b22f3bbcedc.png)

After:
![Screenshot from 2019-03-26 12-55-17](https://user-images.githubusercontent.com/325102/54996071-a01fc180-4fc8-11e9-8244-96b61127acb2.png)

Although unrelated, should close #1229 

Thanks for react-dnd!