### PR TITLE
Remove useless constraint

### DIFF
--- a/packages/react-dnd/src/interfaces/classApi.ts
+++ b/packages/react-dnd/src/interfaces/classApi.ts
@@ -220,7 +220,7 @@ export type Matching<InjectedProps, DecorationTargetProps> = {
  */
 export type Shared<
 	InjectedProps,
-	DecorationTargetProps extends Shared<InjectedProps, DecorationTargetProps>
+	DecorationTargetProps
 > = {
 	[P in Extract<
 		keyof InjectedProps,


### PR DESCRIPTION
I found this while testing DefinitelyTyped against https://github.com/Microsoft/TypeScript/pull/30637.

Fixing https://github.com/Microsoft/TypeScript/issues/30634 will make this constraint fail to check for most users - this type seems to have been copied from (to?) `react-redux`, which has taken in a similar change on DT:

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/34335
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/34339

The constraint on `DecorationTargetProps` was circularly defined _anyway_ so despite not having an error (due to deferral in the mapped type of `Shared`), it never actually _had_ an effective constraint.