### PR TITLE
Check handlerIds In DragSource/DropTarget Monitors

### DIFF
--- a/packages/react-dnd/src/DragSourceMonitorImpl.ts
+++ b/packages/react-dnd/src/DragSourceMonitorImpl.ts
@@ -45,6 +45,9 @@ export default class DragSourceMonitorImpl implements DragSourceMonitor {
 	}
 
 	public isDragging() {
+		if (!this.sourceId) {
+			return false
+		}
 		invariant(
 			!isCallingIsDragging,
 			'You may not call monitor.isDragging() inside your isDragging() implementation. ' +

--- a/packages/react-dnd/src/DragSourceMonitorImpl.ts
+++ b/packages/react-dnd/src/DragSourceMonitorImpl.ts
@@ -56,7 +56,7 @@ export default class DragSourceMonitorImpl implements DragSourceMonitor {
 
 		try {
 			isCallingIsDragging = true
-			return this.internalMonitor.isDraggingSource(this.sourceId!)
+			return this.internalMonitor.isDraggingSource(this.sourceId)
 		} finally {
 			isCallingIsDragging = false
 		}

--- a/packages/react-dnd/src/DropTargetMonitorImpl.ts
+++ b/packages/react-dnd/src/DropTargetMonitorImpl.ts
@@ -35,6 +35,12 @@ export default class DropTargetMonitorImpl implements DropTargetMonitor {
 	}
 
 	public canDrop() {
+		// Cut out early if the target id has not been set. This should prevent errors
+		// where the user has an older version of dnd-core like in
+		// https://github.com/react-dnd/react-dnd/issues/1310
+		if (!this.targetId) {
+			return false
+		}
 		invariant(
 			!isCallingCanDrop,
 			'You may not call monitor.canDrop() inside your canDrop() implementation. ' +
@@ -43,14 +49,17 @@ export default class DropTargetMonitorImpl implements DropTargetMonitor {
 
 		try {
 			isCallingCanDrop = true
-			return this.internalMonitor.canDropOnTarget(this.targetId!)
+			return this.internalMonitor.canDropOnTarget(this.targetId)
 		} finally {
 			isCallingCanDrop = false
 		}
 	}
 
 	public isOver(options: { shallow?: boolean }) {
-		return this.internalMonitor.isOverTarget(this.targetId!, options)
+		if (!this.targetId) {
+			return false
+		}
+		return this.internalMonitor.isOverTarget(this.targetId, options)
 	}
 
 	public getItemType() {


### PR DESCRIPTION
This should prevent issues like #1310 where users are using older versions of the dnd-core.