### PR TITLE
build: add "module" field to package.json files

### DIFF
--- a/packages/react-dnd-html5-backend/package.json
+++ b/packages/react-dnd-html5-backend/package.json
@@ -3,6 +3,7 @@
 	"version": "7.4.4",
 	"description": "HTML5 backend for React DnD",
 	"main": "lib/cjs/index.js",
+	"module": "lib/esm/index.js",
 	"types": "lib/cjs/index.d.ts",
 	"license": "MIT",
 	"repository": {

--- a/packages/react-dnd-test-backend/package.json
+++ b/packages/react-dnd-test-backend/package.json
@@ -3,6 +3,7 @@
 	"version": "7.4.4",
 	"description": "A mock backend for testing React DnD apps",
 	"main": "lib/cjs/index.js",
+	"module": "lib/esm/index.js",
 	"types": "lib/cjs/index.d.ts",
 	"license": "MIT",
 	"repository": {

--- a/packages/react-dnd-test-utils/package.json
+++ b/packages/react-dnd-test-utils/package.json
@@ -3,6 +3,7 @@
 	"version": "7.4.4",
 	"license": "MIT",
 	"main": "lib/cjs/index.js",
+	"module": "lib/esm/index.js",
 	"scripts": {
 		"clean": "rimraf lib",
 		"build:cjs": "tsc -b tsconfig.cjs.json",

--- a/packages/react-dnd/package.json
+++ b/packages/react-dnd/package.json
@@ -3,6 +3,7 @@
 	"version": "7.4.5",
 	"description": "Drag and Drop for React",
 	"main": "lib/cjs/index.js",
+	"module": "lib/esm/index.js",
 	"types": "lib/cjs/index.d.ts",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
https://github.com/react-dnd/react-dnd/pull/1205 added ES module output to the `/lib/esm` folder - this adds a "module" field to each package's `package.json` pointing to the ES module output.