### PR TITLE
chore: update vscode tslint recommended package

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
 	"recommendations": [
-		"eg2.tslint",
+		"ms-vscode.vscode-typescript-tslint-plugin",
 		"esbenp.prettier-vscode"
 	]
 }


### PR DESCRIPTION
The currently recommended `tslint` package is now deprecated in favor of Microsoft's own plugin. This PR updates that.