### PR TITLE
docs(example): add script command line at docs

### DIFF
--- a/packages/documentation/markdown/docs/examples/examplesRoot.md
+++ b/packages/documentation/markdown/docs/examples/examplesRoot.md
@@ -28,6 +28,7 @@ To run these examples locally, clone the `react-dnd` repository, and run
 
 ```
 > yarn install
+> yarn build
 > yarn start
 ```
 


### PR DESCRIPTION
 add script command line at docs to run this project locally.
detail that can be found at #1333 
close #1333 