### PR TITLE
fix: update the isRef function's duck-typing

### DIFF
--- a/packages/react-dnd/src/utils/isRef.ts
+++ b/packages/react-dnd/src/utils/isRef.ts
@@ -3,9 +3,7 @@ export interface Ref<T> {
 }
 
 export function isRef(obj: any) {
-	if (obj !== null && typeof obj === 'object') {
-		const keys = Object.keys(obj)
-		return keys.length === 1 && keys[0] === 'current'
-	}
-	return false
+	return (
+		obj !== null && typeof obj === 'object' && obj.hasOwnProperty('current')
+	)
 }


### PR DESCRIPTION
This predicate will return false if properties other than `current` exist on the ref object. This PR removes that condition and only checks for the existence of a `current` property.

Fixes #1328