### PR TITLE
feat: let DragDropContextProvider reuse a DragDropManager

### DIFF
--- a/packages/react-dnd/src/DragDropContext.tsx
+++ b/packages/react-dnd/src/DragDropContext.tsx
@@ -42,19 +42,26 @@ export function createChildContext<BackendContext>(
 	}
 }
 
-export interface DragDropContextProviderProps<BackendContext> {
-	backend: BackendFactory
-	context?: BackendContext
-	debugMode?: boolean
-}
+export type DragDropContextProviderProps<BackendContext> =
+	| {
+			manager: DragDropManager<BackendContext>
+	  }
+	| {
+			backend: BackendFactory
+			context?: BackendContext
+			debugMode?: boolean
+	  }
 
 /**
  * A React component that provides the React-DnD context
  */
 export const DragDropContextProvider: React.FC<
 	DragDropContextProviderProps<any>
-> = ({ backend, context, debugMode, children }) => {
-	const contextValue = createChildContext(backend, context, debugMode)
+> = ({ children, ...props }) => {
+	const contextValue =
+		'manager' in props
+			? { dragDropManager: props.manager }
+			: createChildContext(props.backend, props.context, props.debugMode)
 	return <Provider value={contextValue}>{children}</Provider>
 }
 

--- a/packages/react-dnd/src/__tests__/DragDropContext.spec.tsx
+++ b/packages/react-dnd/src/__tests__/DragDropContext.spec.tsx
@@ -1,6 +1,12 @@
 // tslint:disable max-classes-per-file
+import { createDragDropManager } from 'dnd-core'
 import * as React from 'react'
-import { DragDropContext } from '../index'
+import * as TestUtils from 'react-dom/test-utils'
+import {
+	DragDropContext,
+	DragDropContextProvider,
+	DragDropContextConsumer,
+} from '../index'
 import TestBackend from 'react-dnd-test-backend'
 
 describe('DragDropContext', () => {
@@ -23,5 +29,26 @@ describe('DragDropContext', () => {
 		const Context = DragDropContext(TestBackend)(ContextComponent)
 
 		expect(Context).toBeDefined()
+	})
+})
+
+describe('DragDropContextProvider', () => {
+	it('reuses DragDropManager provided to it', () => {
+		let capturedManager
+		const manager = createDragDropManager(TestBackend, {})
+
+		const ManagerCapture = () => (
+			<DragDropContextProvider manager={manager}>
+				<DragDropContextConsumer>
+					{({ dragDropManager }) => {
+						capturedManager = dragDropManager
+						return null
+					}}
+				</DragDropContextConsumer>
+			</DragDropContextProvider>
+		)
+
+		TestUtils.renderIntoDocument(<ManagerCapture />)
+		expect(capturedManager).toBe(manager)
 	})
 })


### PR DESCRIPTION
**tl;dr:** this PR gives `DragDropContextProvider` an extra prop, `manager`, which will be reused instead of creating a new `DragDropManager`.

---

**Full explanation:**
I'm trying to load react-dnd conditionally in our app.
For mobile devices, for example, it doesn't make sense to have the same dnd interactions, so the chunk with this code doesn't need to be loaded at all.

I could _almost_ do this... however I hit a wall: if react-dnd finishes loading a few seconds _after_ the whole app is ready, the user will notice React remounting the _whole app_, because I had to reparent it with the `DragDropContext`.

To avoid this, each component with dnd interactions will be wrapped in a `DragDropContextProvider`, which unfortunately creates a new `DragDropManager` -- not ideal.

This PR then lets this component receive a `manager` prop, which will be reused instead of creating a new `DragDropManager` when rendered.
I can do this once in my app by calling `createDragDropManager` at the app's bootstrap level, and then passing it around with my own React context 🙂 

---

Unfortunately I'm not sure how to go about docs here.
dnd-core is undocumented, so I'm guessing any attempts of documenting the change to react-dnd would require documenting details about dnd-core (I'm happy to do it with some ideas).