### PR TITLE
Restore UMD Builds as a new Package

### DIFF
--- a/packages/react-dnd-umd-builds/package.json
+++ b/packages/react-dnd-umd-builds/package.json
@@ -2,15 +2,19 @@
 	"name": "react-dnd-umd-builds",
 	"version": "7.6.0",
 	"license": "MIT",
-	"scripts": {},
+	"scripts": {
+		"bundle:development": "webpack --mode development",
+		"bundle:production": "webpack --mode production",
+		"build": "run-p bundle:*"
+	},
 	"devDependencies": {
 		"@babel/core": "^7.4.5",
 		"@babel/preset-env": "^7.4.5",
 		"babel-loader": "^8.0.6",
 		"react-dnd": "^7.6.0",
 		"react-dnd-html5-backend": "^7.6.0",
-		"webpack": "^4.34.0",
-		"webpack-cli": "^3.3.4"
+		"webpack-cli": "^3.3.4",
+		"npm-run-all": "^4.1.5"
 	},
 	"browserslist": "> 0.25%, not dead"
 }

--- a/packages/react-dnd-umd-builds/package.json
+++ b/packages/react-dnd-umd-builds/package.json
@@ -1,0 +1,16 @@
+{
+	"name": "react-dnd-umd-builds",
+	"version": "7.6.0",
+	"license": "MIT",
+	"scripts": {},
+	"devDependencies": {
+		"@babel/core": "^7.4.5",
+		"@babel/preset-env": "^7.4.5",
+		"babel-loader": "^8.0.6",
+		"react-dnd": "^7.6.0",
+		"react-dnd-html5-backend": "^7.6.0",
+		"webpack": "^4.34.0",
+		"webpack-cli": "^3.3.4"
+	},
+	"browserslist": "> 0.25%, not dead"
+}

--- a/packages/react-dnd-umd-builds/tsconfig.json
+++ b/packages/react-dnd-umd-builds/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"target": "es5",
+		"outDir": "./lib"
+	},
+	"include": ["./src/index.ts"]
+}

--- a/packages/react-dnd-umd-builds/webpack.config.js
+++ b/packages/react-dnd-umd-builds/webpack.config.js
@@ -1,14 +1,16 @@
-const webpack = require('webpack')
 const path = require('path')
 
-module.exports = {
-	entry: './src/index',
-	mode: 'none',
+const commonConfig = {
+	entry: './index.ts',
 	resolve: {
-		extensions: ['.ts', '.tsx', '.js'],
+		extensions: ['.js', '.jsx', '.json', '.ts', '.tsx'],
+		alias: {
+			'dnd-core': path.join(__dirname, '..', 'dnd-core', 'src', 'index.ts'),
+		},
 		modules: [
-			path.join(__dirname, 'node_modules'),
+			path.join(__dirname, '..', 'react-dnd'),
 			path.join(__dirname, '..', 'dnd-core', 'node_modules'),
+			path.join(__dirname, '..', 'react-dnd', 'node_modules'),
 			path.join(__dirname, '..', '..', 'node_modules'),
 		],
 	},
@@ -18,12 +20,26 @@ module.exports = {
 			{
 				test: /\.ts(x|)$/,
 				exclude: /node_modules/,
-				use: {
-					loader: 'ts-loader',
-					options: { transpileOnly: true },
-				},
+				use: [
+					{
+						loader: 'babel-loader',
+						options: {
+							presets: ['@babel/preset-env'],
+						},
+					},
+					{
+						loader: 'ts-loader',
+						options: {
+							transpileOnly: true,
+						},
+					},
+				],
 			},
 		],
+	},
+	output: {
+		path: path.resolve(__dirname, 'dist'),
+		libraryTarget: 'umd',
 	},
 	externals: [
 		{
@@ -35,15 +51,29 @@ module.exports = {
 			},
 		},
 	],
-	output: {
-		libraryTarget: 'umd',
-		library: 'ReactDnD',
-	},
-	plugins: [
-		new webpack.DefinePlugin({
-			'process.env': {
-				NODE_ENV: JSON.stringify('production'),
+}
+
+module.exports = (env, { mode }) => {
+	return [
+		{
+			...commonConfig,
+			context: path.resolve(__dirname, '../react-dnd/src'),
+			output: {
+				...commonConfig.output,
+				library: 'ReactDnD',
+				filename: `ReactDnD.${mode === 'production' ? 'min.' : ''}js`,
 			},
-		}),
-	],
+		},
+		{
+			...commonConfig,
+			context: path.resolve(__dirname, '../react-dnd-html5-backend/src'),
+			output: {
+				...commonConfig.output,
+				library: 'ReactDnDHTML5Backend',
+				filename: `ReactDnDHTML5Backend.${
+					mode === 'production' ? 'min.' : ''
+				}js`,
+			},
+		},
+	]
 }

--- a/packages/react-dnd-umd-builds/webpack.config.js
+++ b/packages/react-dnd-umd-builds/webpack.config.js
@@ -1,0 +1,49 @@
+const webpack = require('webpack')
+const path = require('path')
+
+module.exports = {
+	entry: './src/index',
+	mode: 'none',
+	resolve: {
+		extensions: ['.ts', '.tsx', '.js'],
+		modules: [
+			path.join(__dirname, 'node_modules'),
+			path.join(__dirname, '..', 'dnd-core', 'node_modules'),
+			path.join(__dirname, '..', '..', 'node_modules'),
+		],
+	},
+	module: {
+		rules: [
+			{ test: /\.js$/, use: 'babel-loader', exclude: /node_modules/ },
+			{
+				test: /\.ts(x|)$/,
+				exclude: /node_modules/,
+				use: {
+					loader: 'ts-loader',
+					options: { transpileOnly: true },
+				},
+			},
+		],
+	},
+	externals: [
+		{
+			react: {
+				root: 'React',
+				commonjs2: 'react',
+				commonjs: 'react',
+				amd: 'react',
+			},
+		},
+	],
+	output: {
+		libraryTarget: 'umd',
+		library: 'ReactDnD',
+	},
+	plugins: [
+		new webpack.DefinePlugin({
+			'process.env': {
+				NODE_ENV: JSON.stringify('production'),
+			},
+		}),
+	],
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5180,6 +5180,11 @@ detab@^2.0.0:
   dependencies:
     repeat-string "^1.5.4"
 
+detect-file@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
+  integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
+
 detect-indent@^5.0.0, detect-indent@~5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
@@ -6566,6 +6571,16 @@ find-versions@^3.0.0:
   dependencies:
     array-uniq "^2.1.0"
     semver-regex "^2.0.0"
+
+findup-sync@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-2.0.0.tgz#9326b1488c22d1a6088650a86901b2d9a90a2cbc"
+  integrity sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=
+  dependencies:
+    detect-file "^1.0.0"
+    is-glob "^3.1.0"
+    micromatch "^3.0.4"
+    resolve-dir "^1.0.1"
 
 flat-cache@^2.0.1:
   version "2.0.1"
@@ -8455,6 +8470,11 @@ internal-ip@^4.3.0:
   dependencies:
     default-gateway "^4.2.0"
     ipaddr.js "^1.9.0"
+
+interpret@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
+  integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
 into-stream@^3.1.0:
   version "3.1.0"
@@ -10719,7 +10739,7 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
-micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
+micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
@@ -12898,6 +12918,11 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
+prettier@^1.17.0:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+
 prettier@^1.17.1:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.1.tgz#ed64b4e93e370cb8a25b9ef7fef3e4fd1c0995db"
@@ -13961,7 +13986,7 @@ resolve-cwd@^2.0.0:
   dependencies:
     resolve-from "^3.0.0"
 
-resolve-dir@^1.0.0:
+resolve-dir@^1.0.0, resolve-dir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
   integrity sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=
@@ -16199,6 +16224,11 @@ v8-compile-cache@^1.1.0:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-1.1.2.tgz#8d32e4f16974654657e676e0e467a348e89b0dc4"
   integrity sha512-ejdrifsIydN1XDH7EuR2hn8ZrkRKUYF7tUcBjBy/lhrCvs2K+zRlbW9UHc0IQ9RsYFZJFqJrieoIHfkCa0DBRA==
 
+v8-compile-cache@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz#00f7494d2ae2b688cfe2899df6ed2c54bef91dbe"
+  integrity sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==
+
 valid-url@^1.0.9:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/valid-url/-/valid-url-1.0.9.tgz#1c14479b40f1397a75782f115e4086447433a200"
@@ -16320,6 +16350,24 @@ webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+
+webpack-cli@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.4.tgz#de27e281c48a897b8c219cb093e261d5f6afe44a"
+  integrity sha512-ubJGQEKMtBSpT+LiL5hXvn2GIOWiRWItR1DGUqJRhwRBeGhpRXjvF5f0erqdRJLErkfqS5/Ldkkedh4AL5Q1ZQ==
+  dependencies:
+    chalk "^2.4.1"
+    cross-spawn "^6.0.5"
+    enhanced-resolve "^4.1.0"
+    findup-sync "^2.0.0"
+    global-modules "^1.0.0"
+    import-local "^2.0.0"
+    interpret "^1.1.0"
+    loader-utils "^1.1.0"
+    prettier "^1.17.0"
+    supports-color "^5.5.0"
+    v8-compile-cache "^2.0.2"
+    yargs "^12.0.5"
 
 webpack-dev-middleware@^3.0.1, webpack-dev-middleware@^3.7.0:
   version "3.7.0"


### PR DESCRIPTION
This adds the UMD builds back in, but not as artifacts of the react-dnd and react-dnd-html5-backend packages, but as a separately built module.