### PR TITLE
Fix tutorial code

### DIFF
--- a/packages/documentation/docsite/markdown/docs/00 Quick Start/Tutorial.md
+++ b/packages/documentation/docsite/markdown/docs/00 Quick Start/Tutorial.md
@@ -596,6 +596,7 @@ function BoardSquare({ x, y, children }) {
 
   return (
     <div
+      ref={drop}
       style={{
         position: 'relative',
         width: '100%',
@@ -665,6 +666,7 @@ function BoardSquare({ x, y, children }) {
 
   return (
     <div
+      ref={drop}
       style={{
         position: 'relative',
         width: '100%',


### PR DESCRIPTION
Add the missing drop ref, so that `BoardSquare` could be a valid DropTarget.