### PR TITLE
fix: don't handle dragstart event if default is prevented

### DIFF
--- a/packages/core/html5-backend/src/HTML5Backend.ts
+++ b/packages/core/html5-backend/src/HTML5Backend.ts
@@ -351,6 +351,10 @@ export default class HTML5Backend implements Backend {
 	}
 
 	private handleDragStart(e: DragEvent, sourceId: string) {
+		if (e.defaultPrevented) {
+			return
+		}
+
 		if (!this.dragStartSourceIds) {
 			this.dragStartSourceIds = []
 		}
@@ -358,6 +362,10 @@ export default class HTML5Backend implements Backend {
 	}
 
 	private handleTopDragStart = (e: DragEvent) => {
+		if (e.defaultPrevented) {
+			return
+		}
+
 		const { dragStartSourceIds } = this
 		this.dragStartSourceIds = null
 


### PR DESCRIPTION
If someone has invoked `preventDefault` on the `dragstart` event, `dragend` would never come, so it's probably better we just do nothing.