### PR TITLE
fix: stale isDropping on drag source unmount/remount (hooks)

### DIFF
--- a/packages/core/react-dnd/src/hooks/internal/drag.ts
+++ b/packages/core/react-dnd/src/hooks/internal/drag.ts
@@ -71,7 +71,7 @@ export function useDragHandler<
 		} as DragSource
 	}, [])
 
-	useEffect(function registerHandler() {
+	const unregister = useMemo(function registerHandler() {
 		const [handlerId, unregister] = registerSource(
 			spec.current.item.type,
 			handler,
@@ -79,6 +79,10 @@ export function useDragHandler<
 		)
 		monitor.receiveHandlerId(handlerId)
 		connector.receiveHandlerId(handlerId)
+		return unregister
+	}, [])
+
+	useEffect(() => {
 		return unregister
 	}, [])
 }

--- a/packages/core/react-dnd/src/hooks/internal/drag.ts
+++ b/packages/core/react-dnd/src/hooks/internal/drag.ts
@@ -71,7 +71,7 @@ export function useDragHandler<
 		} as DragSource
 	}, [])
 
-	const unregister = useMemo(function registerHandler() {
+	useEffect(function registerHandler() {
 		const [handlerId, unregister] = registerSource(
 			spec.current.item.type,
 			handler,
@@ -79,10 +79,6 @@ export function useDragHandler<
 		)
 		monitor.receiveHandlerId(handlerId)
 		connector.receiveHandlerId(handlerId)
-		return unregister
-	}, [])
-
-	useEffect(() => {
 		return unregister
 	}, [])
 }

--- a/packages/core/react-dnd/src/hooks/internal/drag.ts
+++ b/packages/core/react-dnd/src/hooks/internal/drag.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, MutableRefObject } from 'react'
+import { useLayoutEffect, useMemo, MutableRefObject } from 'react'
 import invariant from 'invariant'
 import {
 	DragSourceHookSpec,
@@ -71,7 +71,7 @@ export function useDragHandler<
 		} as DragSource
 	}, [])
 
-	useEffect(function registerHandler() {
+	useLayoutEffect(function registerHandler() {
 		const [handlerId, unregister] = registerSource(
 			spec.current.item.type,
 			handler,

--- a/packages/core/react-dnd/src/hooks/internal/useCollector.ts
+++ b/packages/core/react-dnd/src/hooks/internal/useCollector.ts
@@ -1,9 +1,9 @@
 import shallowEqual from 'shallowequal'
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useLayoutEffect } from 'react'
 
 /**
  *
- * @param monitor The monitor to colelct state from
+ * @param monitor The monitor to collect state from
  * @param collect The collecting function
  * @param onUpdate A method to invoke when updates occur
  */
@@ -23,6 +23,8 @@ export function useCollector<T, S>(
 			}
 		}
 	}, [collected, monitor, onUpdate])
+
+	useLayoutEffect(updateCollected, [])
 
 	return [collected, updateCollected]
 }


### PR DESCRIPTION
Here is a [codesandbox](https://codesandbox.io/s/stale-isdragging-on-drag-source-unmountremount-using-hooks-nj3ip) to see the problem.

The drag source is registered on an effect, so the first render doesn't have the correct state.
And since the element is already dragging, the store subscription is not triggered.