### PR TITLE
fix: stale state in useMonitorOutput

### DIFF
--- a/packages/core/react-dnd/src/hooks/internal/useMonitorOutput.ts
+++ b/packages/core/react-dnd/src/hooks/internal/useMonitorOutput.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useLayoutEffect } from 'react'
 import { useCollector } from './useCollector'
 import { HandlerManager, MonitorEventEmitter } from '../../interfaces'
 
@@ -9,7 +9,7 @@ export function useMonitorOutput<Monitor extends HandlerManager, Collected>(
 ): Collected {
 	const [collected, updateCollected] = useCollector(monitor, collect, onCollect)
 
-	useEffect(
+	useLayoutEffect(
 		function subscribeToMonitorStateChange() {
 			const handlerId = monitor.getHandlerId()
 			if (handlerId == null) {


### PR DESCRIPTION
Fixes #1385
Between a render and the resubscription effect, the store can trigger a stale `updateCollected`, which may use a stale state to decide if a rerender should occurs or not.