### PR TITLE
docs: Fix end callback arguments of useDrag hook

### DIFF
--- a/packages/documentation/docsite/markdown/docs/01 Top Level API/useDrag.md
+++ b/packages/documentation/docsite/markdown/docs/01 Top Level API/useDrag.md
@@ -42,7 +42,7 @@ function DraggableComponent(props) {
 
 * **`begin(monitor)`**: Optional. Fired when a drag operation begins. Nothing needs to be returned, but if an object is returned it will override the default `item` property of the spec.
 
-* **`end(monitor)`**: Optional. When the dragging stops, `end` is called. For every `begin` call, a corresponding `end` call is guaranteed. You may call `monitor.didDrop()` to check whether or not the drop was handled by a compatible drop target. If it was handled, and the drop target specified a _drop result_ by returning a plain object from its `drop()` method, it will be available as `monitor.getDropResult()`. This method is a good place to fire a Flux action. _Note: If the component is unmounted while dragging, `component` parameter is set to be `null`._
+* **`end(item, monitor)`**: Optional. When the dragging stops, `end` is called. For every `begin` call, a corresponding `end` call is guaranteed. You may call `monitor.didDrop()` to check whether or not the drop was handled by a compatible drop target. If it was handled, and the drop target specified a _drop result_ by returning a plain object from its `drop()` method, it will be available as `monitor.getDropResult()`. This method is a good place to fire a Flux action. _Note: If the component is unmounted while dragging, `component` parameter is set to be `null`._
 
 * **`canDrag(monitor)`**: Optional. Use it to specify whether the dragging is currently allowed. If you want to always allow it, just omit this method. Specifying it is handy if you'd like to disable dragging based on some predicate over `props`. _Note: You may not call `monitor.canDrag()` inside this method._
 


### PR DESCRIPTION
I had some code like the following.
```
  const [{ isDragging }, dragRef] = useDrag({
    item: { type: 'knight', knightId },
    collect: monitor => ({
      isDragging: Boolean(monitor.isDragging()),
    }),
    end: (monitor) => {
      if (monitor.didDrop()) {
		// do something
      }
    },
  });
``` 
Luckily `TypeScript` was complaining about `monitor.didDrop`. At first I thought I'm running into the same issue as https://github.com/react-dnd/react-dnd/issues/1431 but when digging into the source code, I saw that simply the documentation was off and `item` should be the first argument of the end function.

See `Knight.tsx` in https://codesandbox.io/s/react-dnd-example-0-z9pxs 