### PR TITLE
Defines the XYCoord interface in React-Dnd package

### DIFF
--- a/packages/core/react-dnd/src/interfaces/index.ts
+++ b/packages/core/react-dnd/src/interfaces/index.ts
@@ -1,4 +1,3 @@
-export { XYCoord } from 'dnd-core'
 export * from './monitors'
 export * from './hooksApi'
 export * from './options'

--- a/packages/core/react-dnd/src/interfaces/monitors.ts
+++ b/packages/core/react-dnd/src/interfaces/monitors.ts
@@ -1,4 +1,9 @@
-import { Identifier, XYCoord, Unsubscribe } from 'dnd-core'
+import { Identifier, Unsubscribe } from 'dnd-core'
+
+export interface XYCoord {
+	x: number
+	y: number
+}
 
 export interface HandlerManager {
 	receiveHandlerId: (handlerId: Identifier | null) => void


### PR DESCRIPTION
Thy interface was exported from ‘dnd-core’, but babel transpiles this into a JS value export, which is causing runtime issues for some users.

Fixes #1450