### PR TITLE
Jest Testing & Documentation Updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,12 +108,12 @@
 			"<rootDir>/packages/testing/"
 		],
 		"moduleNameMapper": {
-			"^dnd-core$": "dnd-core-cjs",
-			"^react-dnd$": "react-dnd-cjs",
-			"^react-dnd-html5-backend$": "react-dnd-html5-backend-cjs",
-			"^react-dnd-touch-backend$": "react-dnd-touch-backend-cjs",
-			"^react-dnd-test-backend$": "react-dnd-test-backend-cjs",
-			"^react-dnd-test-utils$": "react-dnd-test-utils-cjs"
+			"^dnd-core$": "<rootDir>/packages/core/dnd-core/src",
+			"^react-dnd$": "<rootDir>/packages/core/react-dnd/src",
+			"^react-dnd-html5-backend$": "<rootDir>/packages/core/html5-backend/src",
+			"^react-dnd-touch-backend$": "<rootDir>/packages/core/touch-backend/src",
+			"^react-dnd-test-backend$": "<rootDir>/packages/testing/test-backend/src",
+			"^react-dnd-test-utils$": "<rootDir>/packages/testing/test-utils/src"
 		},
 		"collectCoverageFrom": [
 			"packages/core/**/*.{ts,tsx}",

--- a/packages/core/react-dnd/src/__tests__/DndProvider.tsx
+++ b/packages/core/react-dnd/src/__tests__/DndProvider.tsx
@@ -7,7 +7,7 @@ import TestBackend from 'react-dnd-test-backend'
 describe('DndProvider', () => {
 	it('reuses DragDropManager provided to it', () => {
 		let capturedManager
-		const manager = createDragDropManager(TestBackend, {})
+		const manager = createDragDropManager(TestBackend, {}, {})
 
 		const ManagerCapture = () => (
 			<DndContext.Provider value={{ dragDropManager: manager }}>

--- a/packages/core/react-dnd/src/__tests__/DndProvider.tsx
+++ b/packages/core/react-dnd/src/__tests__/DndProvider.tsx
@@ -4,7 +4,7 @@ import * as TestUtils from 'react-dom/test-utils'
 import { DndContext } from '..'
 import TestBackend from 'react-dnd-test-backend'
 
-describe('DragDropContextProvider', () => {
+describe('DndProvider', () => {
 	it('reuses DragDropManager provided to it', () => {
 		let capturedManager
 		const manager = createDragDropManager(TestBackend, {})

--- a/packages/core/react-dnd/src/decorators/DragLayer.tsx
+++ b/packages/core/react-dnd/src/decorators/DragLayer.tsx
@@ -108,7 +108,7 @@ export function DragLayer<RequiredProps, CollectedProps = {}>(
 				invariant(
 					typeof dragDropManager === 'object',
 					'Could not find the drag and drop manager in the context of %s. ' +
-						'Make sure to wrap the top-level component of your app with DragDropContext. ' +
+						'Make sure to render a DndProvider component in your top-level component. ' +
 						'Read more: http://react-dnd.github.io/react-dnd/docs/troubleshooting#could-not-find-the-drag-and-drop-manager-in-the-context',
 					displayName,
 					displayName,

--- a/packages/core/react-dnd/src/decorators/__tests__/ConnectorFunctions.spec.tsx
+++ b/packages/core/react-dnd/src/decorators/__tests__/ConnectorFunctions.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import * as TestUtils from 'react-dom/test-utils'
+import { mount } from 'enzyme'
 import { wrapInTestContext } from 'react-dnd-test-utils'
 import { DropTarget } from '../DropTarget'
 
@@ -22,7 +22,7 @@ describe('Connectors', () => {
 
 		// Render with the test context that uses the test backend
 		const WrappedTarget = wrapInTestContext(Target)
-		TestUtils.renderIntoDocument(<WrappedTarget x={1} y={2} />)
+		mount(<WrappedTarget x={1} y={2} />)
 
 		expect(connectorFired).toBeTruthy()
 		expect(connectArgs.length).toEqual(3)

--- a/packages/core/react-dnd/src/decorators/__tests__/DragSource.spec.tsx
+++ b/packages/core/react-dnd/src/decorators/__tests__/DragSource.spec.tsx
@@ -43,7 +43,8 @@ describe('DragSource', () => {
 		expect(DecoratedComponent).toBeDefined()
 	})
 
-	it('throws an error if rendered outside a DragDropContext', () => {
+	it('throws an error if rendered outside a DndContext', () => {
+		console.error = jest.fn()
 		const Component: React.FC<{}> = () => null
 		const DecoratedComponent = DragSource(
 			'abc',

--- a/packages/core/react-dnd/src/decorators/__tests__/DropTarget.spec.tsx
+++ b/packages/core/react-dnd/src/decorators/__tests__/DropTarget.spec.tsx
@@ -29,6 +29,7 @@ describe('DropTarget', () => {
 	})
 
 	it('throws an error if rendered outside a DragDropContext', () => {
+		console.error = jest.fn()
 		const Component: React.FC<{}> = () => null
 		const DecoratedComponent = DropTarget(
 			'abc',
@@ -41,5 +42,6 @@ describe('DropTarget', () => {
 		expect(() => {
 			TestUtils.renderIntoDocument(<DecoratedComponent />)
 		}).toThrow(/Could not find the drag and drop manager in the context/)
+		expect(console.error).toHaveBeenCalled()
 	})
 })

--- a/packages/core/react-dnd/src/decorators/decorateHandler.tsx
+++ b/packages/core/react-dnd/src/decorators/decorateHandler.tsx
@@ -225,7 +225,7 @@ export default function decorateHandler<Props, CollectedProps, ItemIdType>({
 			invariant(
 				dragDropManager !== undefined,
 				'Could not find the drag and drop manager in the context of %s. ' +
-					'Make sure to wrap the top-level component of your app with DragDropContext. ' +
+					'Make sure to render a DndProvider component in your top-level component. ' +
 					'Read more: http://react-dnd.github.io/react-dnd/docs/troubleshooting#could-not-find-the-drag-and-drop-manager-in-the-context',
 				displayName,
 				displayName,

--- a/packages/core/react-dnd/src/decorators/interfaces.ts
+++ b/packages/core/react-dnd/src/decorators/interfaces.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { DragDropManager, Identifier } from 'dnd-core'
+import { Identifier } from 'dnd-core'
 import {
 	DropTargetMonitor,
 	DragSourceMonitor,
@@ -11,28 +11,11 @@ import {
 import { NonReactStatics } from 'hoist-non-react-statics'
 
 /**
- * The React Component that manages the DragDropContext for its children.
- */
-export interface ContextComponent<Props> extends React.Component<Props> {
-	getDecoratedComponentInstance(): React.Component<Props>
-	getManager(): DragDropManager
-}
-
-/**
  * A DnD interactive component
  */
 export interface DndComponent<Props> extends React.Component<Props> {
 	getDecoratedComponentInstance(): React.Component<Props> | null
 	getHandlerId(): Identifier
-}
-
-/**
- * The class interface for a context component
- */
-export interface ContextComponentClass<Props>
-	extends React.ComponentClass<Props> {
-	DecoratedComponent: React.ComponentType<Props>
-	new (props?: Props, context?: any): ContextComponent<Props>
 }
 
 /**

--- a/packages/documentation/examples-decorators/src/01-dustbin/multiple-targets/__tests__/multiple-target-integration.spec.tsx
+++ b/packages/documentation/examples-decorators/src/01-dustbin/multiple-targets/__tests__/multiple-target-integration.spec.tsx
@@ -4,18 +4,17 @@ import DndDustbin, { DustbinProps } from '../Dustbin'
 import DndBox, { BoxProps } from '../Box'
 import {
 	wrapInTestContext,
-	getBackendFromInstance,
 	simulateDragDropSequence,
 } from 'react-dnd-test-utils'
 import { mount } from 'enzyme'
-import { TestBackend } from 'react-dnd-test-backend'
+import { getInstance } from 'react-dnd-test-backend'
 import { DndComponent as DndC } from 'react-dnd'
 
 describe('Dustbin: Multiple Targets', () => {
 	it('behaves as expected', () => {
 		const Wrapped = wrapInTestContext(Example)
 		const root = mount(<Wrapped />)
-		const backend = getBackendFromInstance<TestBackend>(root.instance() as any)
+		const backend = getInstance()!
 
 		// Verify that all of the key components mounted
 		const dustbins = root.find(DndDustbin)

--- a/packages/testing/test-backend/src/index.ts
+++ b/packages/testing/test-backend/src/index.ts
@@ -2,7 +2,19 @@ import TestBackend from './TestBackend'
 import { DragDropManager, BackendFactory } from 'dnd-core'
 export { TestBackend } from './TestBackend'
 
-const createBackend: BackendFactory = (manager: DragDropManager) =>
-	new TestBackend(manager)
+let instance: TestBackend | undefined
+
+export function getInstance() {
+	return instance
+}
+
+export function clearInstance() {
+	instance = undefined
+}
+
+const createBackend: BackendFactory = (manager: DragDropManager) => {
+	instance = new TestBackend(manager)
+	return instance
+}
 
 export default createBackend

--- a/packages/testing/test-utils/src/utils.tsx
+++ b/packages/testing/test-utils/src/utils.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react'
-import TestBackendImpl, { TestBackend } from 'react-dnd-test-backend'
-import { ContextComponent, DndComponent, DndProvider } from 'react-dnd'
+import TestBackendImpl, {
+	TestBackend,
+	getInstance,
+} from 'react-dnd-test-backend'
+import { DndComponent, DndProvider } from 'react-dnd'
 import { Backend } from 'dnd-core'
 import { act } from 'react-dom/test-utils'
 
@@ -24,12 +27,12 @@ export function wrapInTestContext(DecoratedComponent: any): any {
  * one emitted from `wrapinTestContext`
  *
  * @param instance The instance to extract the backend fram
+ * @deprecated - This is no longer useful since ContextComponent was removed. This will be removed in a major version cut.
  */
 export function getBackendFromInstance<T extends Backend>(
-	instance: ContextComponent<any>,
+	instance: DndComponent<any>,
 ): T {
-	// Obtain a reference to the backend
-	return (instance.getManager().getBackend() as any) as T
+	return getInstance() as any
 }
 
 export function simulateDragDropSequence(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": "./tsconfig.base.json",
 	"compilerOptions": {
-		"noEmit": true,
 		"baseUrl": ".",
 		"allowSyntheticDefaultImports": true,
 		"paths": {


### PR DESCRIPTION
* Remove ContextClass interface from react-dnd, since the DragDropContext was removed
* Update invariant language to not mention the DragDropContext