### PR TITLE
Babel Interface Fixes

### DIFF
--- a/packages/core/dnd-core/src/interfaces.ts
+++ b/packages/core/dnd-core/src/interfaces.ts
@@ -1,5 +1,3 @@
-import { Unsubscribe } from 'redux'
-
 export type Identifier = string | symbol
 export type SourceType = Identifier
 export type TargetType = Identifier | Identifier[]

--- a/packages/core/react-dnd/src/common/DndContext.ts
+++ b/packages/core/react-dnd/src/common/DndContext.ts
@@ -8,14 +8,14 @@ import {
 /**
  * The React context type
  */
-export interface DndContext {
+export interface DndContextType {
 	dragDropManager: DragDropManager | undefined
 }
 
 /**
  * Create the React Context
  */
-export const DndContext = React.createContext<DndContext>({
+export const DndContext = React.createContext<DndContextType>({
 	dragDropManager: undefined,
 })
 

--- a/packages/core/react-dnd/src/common/index.ts
+++ b/packages/core/react-dnd/src/common/index.ts
@@ -1,3 +1,3 @@
-export { DndContext, createDndContext } from './DndContext'
+export { DndContextType, DndContext, createDndContext } from './DndContext'
 export { DndProvider } from './DndProvider'
 export { DragPreviewImage } from './DragPreviewImage'


### PR DESCRIPTION
* Remove Unsubscribe import from 'redux' in react-dnd
* Rename DndContext interface to DndContextType to prevent double export issue (fixes #1456)