### PR TITLE
Replace for...of statement for better legacy browser support

### DIFF
--- a/packages/core/dnd-core/src/actions/dragDrop/beginDrag.ts
+++ b/packages/core/dnd-core/src/actions/dragDrop/beginDrag.ts
@@ -84,9 +84,9 @@ function verifyInvariants(
 	registry: HandlerRegistry,
 ) {
 	invariant(!monitor.isDragging(), 'Cannot call beginDrag while dragging.')
-	for (const s of sourceIds) {
-		invariant(registry.getSource(s), 'Expected sourceIds to be registered.')
-	}
+	sourceIds.forEach(function(sourceId) {
+		invariant(registry.getSource(sourceId), 'Expected sourceIds to be registered.')
+	})
 }
 
 function verifyGetSourceClientOffsetIsFunction(getSourceClientOffset: any) {

--- a/packages/core/dnd-core/src/actions/dragDrop/hover.ts
+++ b/packages/core/dnd-core/src/actions/dragDrop/hover.ts
@@ -80,8 +80,8 @@ function hoverAllTargets(
 	registry: HandlerRegistry,
 ) {
 	// Finally call hover on all matching targets.
-	for (const targetId of targetIds) {
+	targetIds.forEach(function(targetId) {
 		const target = registry.getTarget(targetId)
 		target.hover(monitor, targetId)
-	}
+	})
 }


### PR DESCRIPTION
`for...of` gets transpiled (e.g. with Babel) to the usage of `Symbol.iterator`. This causes a Problem in IE 11 even with a `Symbol` polyfill in place.
I replaced `for...of` with `.forEach` (better browser support/easier to polyfill).