### PR TITLE
Fix broken isActive styling in DnD file example

### DIFF
--- a/examples_hooks_js/06-other/native-files/src/TargetBox.jsx
+++ b/examples_hooks_js/06-other/native-files/src/TargetBox.jsx
@@ -18,8 +18,8 @@ const TargetBox = props => {
       }
     },
     collect: monitor => ({
-      isOver: monitor.isOver,
-      canDrop: monitor.canDrop,
+      isOver: monitor.isOver(),
+      canDrop: monitor.canDrop(),
     }),
   })
   const isActive = canDrop && isOver


### PR DESCRIPTION
Original writer forgot to call the `isOver` and `isDrop` functions in the `collect` function, resulting in `isActive` always being true.