### PR TITLE
fix: suppress the useLayoutEffect warning on server side

### DIFF
--- a/packages/core/react-dnd/src/hooks/internal/drag.ts
+++ b/packages/core/react-dnd/src/hooks/internal/drag.ts
@@ -1,4 +1,4 @@
-import { useMemo, MutableRefObject, useLayoutEffect } from 'react'
+import { useMemo, MutableRefObject } from 'react'
 import invariant from 'invariant'
 import {
 	DragSourceHookSpec,
@@ -10,6 +10,7 @@ import { registerSource } from '../../common/registration'
 import { useDragDropManager } from './useDragDropManager'
 import { DragSourceMonitorImpl } from '../../common/DragSourceMonitorImpl'
 import { SourceConnector } from '../../common/SourceConnector'
+import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
 
 export function useDragSourceMonitor(): [DragSourceMonitor, SourceConnector] {
 	const manager = useDragDropManager()
@@ -71,7 +72,7 @@ export function useDragHandler<
 		} as DragSource
 	}, [])
 
-	useLayoutEffect(function registerHandler() {
+	useIsomorphicLayoutEffect(function registerHandler() {
 		const [handlerId, unregister] = registerSource(
 			spec.current.item.type,
 			handler,

--- a/packages/core/react-dnd/src/hooks/internal/drop.ts
+++ b/packages/core/react-dnd/src/hooks/internal/drop.ts
@@ -3,12 +3,13 @@ import {
 	DropTargetMonitor,
 	DropTargetHookSpec,
 } from '../../interfaces'
-import { useMemo, MutableRefObject, useLayoutEffect } from 'react'
+import { useMemo, MutableRefObject } from 'react'
 import { DropTarget } from 'dnd-core'
 import { registerTarget } from '../../common/registration'
 import { useDragDropManager } from './useDragDropManager'
 import { TargetConnector } from '../../common/TargetConnector'
 import { DropTargetMonitorImpl } from '../../common/DropTargetMonitorImpl'
+import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
 
 export function useDropTargetMonitor(): [DropTargetMonitor, TargetConnector] {
 	const manager = useDragDropManager()
@@ -52,7 +53,7 @@ export function useDropHandler<
 		} as DropTarget
 	}, [monitor])
 
-	useLayoutEffect(
+	useIsomorphicLayoutEffect(
 		function registerHandler() {
 			const [handlerId, unregister] = registerTarget(
 				spec.current.accept,

--- a/packages/core/react-dnd/src/hooks/internal/useCollector.ts
+++ b/packages/core/react-dnd/src/hooks/internal/useCollector.ts
@@ -1,5 +1,6 @@
 import shallowEqual from 'shallowequal'
-import { useState, useCallback, useLayoutEffect } from 'react'
+import { useState, useCallback } from 'react'
+import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
 
 /**
  *
@@ -26,7 +27,7 @@ export function useCollector<T, S>(
 
 	// update the collected properties after the first render
 	// and the components are attached to dnd-core
-	useLayoutEffect(updateCollected, [])
+	useIsomorphicLayoutEffect(updateCollected, [])
 
 	return [collected, updateCollected]
 }

--- a/packages/core/react-dnd/src/hooks/internal/useIsomorphicLayoutEffect.ts
+++ b/packages/core/react-dnd/src/hooks/internal/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,5 @@
+import { useLayoutEffect, useEffect } from 'react'
+
+// suppress the useLayoutEffect warning on server side.
+export const useIsomorphicLayoutEffect =
+	typeof window !== 'undefined' ? useLayoutEffect : useEffect

--- a/packages/core/react-dnd/src/hooks/internal/useMonitorOutput.ts
+++ b/packages/core/react-dnd/src/hooks/internal/useMonitorOutput.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect } from 'react'
+import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
 import { useCollector } from './useCollector'
 import { HandlerManager, MonitorEventEmitter } from '../../interfaces'
 
@@ -9,7 +9,7 @@ export function useMonitorOutput<Monitor extends HandlerManager, Collected>(
 ): Collected {
 	const [collected, updateCollected] = useCollector(monitor, collect, onCollect)
 
-	useLayoutEffect(
+	useIsomorphicLayoutEffect(
 		function subscribeToMonitorStateChange() {
 			const handlerId = monitor.getHandlerId()
 			if (handlerId == null) {

--- a/packages/core/react-dnd/src/hooks/useDrag.ts
+++ b/packages/core/react-dnd/src/hooks/useDrag.ts
@@ -1,4 +1,4 @@
-import { useRef, useMemo, useLayoutEffect } from 'react'
+import { useRef, useMemo } from 'react'
 import invariant from 'invariant'
 import {
 	DragSourceHookSpec,
@@ -7,6 +7,7 @@ import {
 	ConnectDragPreview,
 } from '../interfaces'
 import { useMonitorOutput } from './internal/useMonitorOutput'
+import { useIsomorphicLayoutEffect } from './internal/useIsomorphicLayoutEffect'
 import { useDragSourceMonitor, useDragHandler } from './internal/drag'
 
 /**
@@ -42,11 +43,11 @@ export function useDrag<
 	const connectDragPreview = useMemo(() => connector.hooks.dragPreview(), [
 		connector,
 	])
-	useLayoutEffect(() => {
+	useIsomorphicLayoutEffect(() => {
 		connector.dragSourceOptions = specRef.current.options || null
 		connector.reconnect()
 	}, [connector])
-	useLayoutEffect(() => {
+	useIsomorphicLayoutEffect(() => {
 		connector.dragPreviewOptions = specRef.current.previewOptions || null
 		connector.reconnect()
 	}, [connector])

--- a/packages/core/react-dnd/src/hooks/useDrop.ts
+++ b/packages/core/react-dnd/src/hooks/useDrop.ts
@@ -1,4 +1,4 @@
-import { useRef, useMemo, useLayoutEffect } from 'react'
+import { useRef, useMemo } from 'react'
 import invariant from 'invariant'
 import {
 	DropTargetHookSpec,
@@ -6,6 +6,7 @@ import {
 	DragObjectWithType,
 } from '../interfaces'
 import { useMonitorOutput } from './internal/useMonitorOutput'
+import { useIsomorphicLayoutEffect } from './internal/useIsomorphicLayoutEffect'
 import { useDropHandler, useDropTargetMonitor } from './internal/drop'
 
 /**
@@ -36,7 +37,7 @@ export function useDrop<
 		connector,
 	])
 
-	useLayoutEffect(() => {
+	useIsomorphicLayoutEffect(() => {
 		connector.dropTargetOptions = spec.options || null
 		connector.reconnect()
 	}, [spec.options])


### PR DESCRIPTION
> Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client.

Refs:
- https://github.com/facebookincubator/redux-react-hook/blob/master/src/create.ts#L15-L20
- https://github.com/reduxjs/react-redux/blob/master/src/hooks/useSelector.js#L14-L23