### PR TITLE
Correct DragPreview connection logic

### DIFF
--- a/packages/core/react-dnd/src/common/SourceConnector.ts
+++ b/packages/core/react-dnd/src/common/SourceConnector.ts
@@ -139,9 +139,7 @@ export class SourceConnector implements Connector {
 
 		if (!this.handlerId) {
 			this.disconnectDragPreview()
-		}
-
-		if (this.handlerId && this.dragPreview && didChange) {
+		} else if (this.dragPreview && didChange) {
 			this.lastConnectedHandlerId = this.handlerId
 			this.lastConnectedDragPreview = dragPreview
 			this.lastConnectedDragPreviewOptions = this.dragPreviewOptions

--- a/packages/core/react-dnd/src/common/SourceConnector.ts
+++ b/packages/core/react-dnd/src/common/SourceConnector.ts
@@ -136,6 +136,10 @@ export class SourceConnector implements Connector {
 			this.didConnectedDragPreviewChange() ||
 			this.didDragPreviewOptionsChange()
 
+		if (!this.handlerId) {
+			this.disconnectDragPreview()
+		}
+
 		if (this.handlerId && this.dragPreview && didChange) {
 			this.lastConnectedHandlerId = this.handlerId
 			this.lastConnectedDragPreview = this.dragPreview

--- a/packages/core/react-dnd/src/common/SourceConnector.ts
+++ b/packages/core/react-dnd/src/common/SourceConnector.ts
@@ -18,6 +18,7 @@ export class SourceConnector implements Connector {
 			node: Element | React.ReactElement | React.Ref<any>,
 			options?: DragSourceOptions,
 		) => {
+			this.clearDragSource()
 			this.dragSourceOptions = options || null
 			if (isRef(node)) {
 				this.dragSourceRef = node as React.RefObject<any>
@@ -27,6 +28,7 @@ export class SourceConnector implements Connector {
 			this.reconnectDragSource()
 		},
 		dragPreview: (node: any, options?: DragPreviewOptions) => {
+			this.clearDragPreview()
 			this.dragPreviewOptions = options || null
 			if (isRef(node)) {
 				this.dragPreviewRef = node
@@ -208,5 +210,15 @@ export class SourceConnector implements Connector {
 			this.dragPreviewNode ||
 			(this.dragPreviewRef && this.dragPreviewRef.current)
 		)
+	}
+
+	private clearDragSource() {
+		this.dragSourceNode = null
+		this.dragSourceRef = null
+	}
+
+	private clearDragPreview() {
+		this.dragPreviewNode = null
+		this.dragPreviewRef = null
 	}
 }

--- a/packages/core/react-dnd/src/common/SourceConnector.ts
+++ b/packages/core/react-dnd/src/common/SourceConnector.ts
@@ -98,6 +98,7 @@ export class SourceConnector implements Connector {
 	}
 
 	private reconnectDragSource() {
+		const dragSource = this.dragSource
 		// if nothing has changed then don't resubscribe
 		const didChange =
 			this.didHandlerIdChange() ||
@@ -108,7 +109,6 @@ export class SourceConnector implements Connector {
 			this.disconnectDragSource()
 		}
 
-		const dragSource = this.dragSource
 		if (!this.handlerId) {
 			return
 		}
@@ -136,22 +136,14 @@ export class SourceConnector implements Connector {
 			this.didConnectedDragPreviewChange() ||
 			this.didDragPreviewOptionsChange()
 
-		if (didChange) {
-			this.disconnectDragPreview()
-		}
-
-		const dragPreview = this.dragPreview
-		if (!this.handlerId || !dragPreview) {
-			return
-		}
-
-		if (didChange) {
+		if (this.handlerId && this.dragPreview && didChange) {
 			this.lastConnectedHandlerId = this.handlerId
-			this.lastConnectedDragPreview = dragPreview
+			this.lastConnectedDragPreview = this.dragPreview
 			this.lastConnectedDragPreviewOptions = this.dragPreviewOptions
+			this.disconnectDragPreview()
 			this.dragPreviewUnsubscribe = this.backend.connectDragPreview(
 				this.handlerId,
-				dragPreview,
+				this.dragPreview,
 				this.dragPreviewOptions,
 			)
 		}

--- a/packages/core/react-dnd/src/common/SourceConnector.ts
+++ b/packages/core/react-dnd/src/common/SourceConnector.ts
@@ -130,6 +130,7 @@ export class SourceConnector implements Connector {
 	}
 
 	private reconnectDragPreview() {
+		const dragPreview = this.dragPreview
 		// if nothing has changed then don't resubscribe
 		const didChange =
 			this.didHandlerIdChange() ||
@@ -142,12 +143,12 @@ export class SourceConnector implements Connector {
 
 		if (this.handlerId && this.dragPreview && didChange) {
 			this.lastConnectedHandlerId = this.handlerId
-			this.lastConnectedDragPreview = this.dragPreview
+			this.lastConnectedDragPreview = dragPreview
 			this.lastConnectedDragPreviewOptions = this.dragPreviewOptions
 			this.disconnectDragPreview()
 			this.dragPreviewUnsubscribe = this.backend.connectDragPreview(
 				this.handlerId,
-				this.dragPreview,
+				dragPreview,
 				this.dragPreviewOptions,
 			)
 		}

--- a/packages/core/react-dnd/src/common/SourceConnector.ts
+++ b/packages/core/react-dnd/src/common/SourceConnector.ts
@@ -96,6 +96,7 @@ export class SourceConnector implements Connector {
 	}
 
 	private reconnectDragSource() {
+		const dragSource = this.dragSource
 		// if nothing has changed then don't resubscribe
 		const didChange =
 			this.didHandlerIdChange() ||
@@ -104,30 +105,21 @@ export class SourceConnector implements Connector {
 
 		if (didChange) {
 			this.disconnectDragSource()
-		}
-
-		const dragSource = this.dragSource
-		if (!this.handlerId) {
-			return
-		}
-		if (!dragSource) {
-			this.lastConnectedDragSource = dragSource
-			return
-		}
-
-		if (didChange) {
 			this.lastConnectedHandlerId = this.handlerId
 			this.lastConnectedDragSource = dragSource
 			this.lastConnectedDragSourceOptions = this.dragSourceOptions
-			this.dragSourceUnsubscribe = this.backend.connectDragSource(
-				this.handlerId,
-				dragSource,
-				this.dragSourceOptions,
-			)
+			if (dragSource) {
+				this.dragSourceUnsubscribe = this.backend.connectDragSource(
+					this.handlerId,
+					dragSource,
+					this.dragSourceOptions,
+				)
+			}
 		}
 	}
 
 	private reconnectDragPreview() {
+		const dragPreview = this.dragPreview
 		// if nothing has changed then don't resubscribe
 		const didChange =
 			this.didHandlerIdChange() ||
@@ -136,22 +128,17 @@ export class SourceConnector implements Connector {
 
 		if (didChange) {
 			this.disconnectDragPreview()
-		}
-
-		const dragPreview = this.dragPreview
-		if (!this.handlerId || !dragPreview) {
-			return
-		}
-
-		if (didChange) {
 			this.lastConnectedHandlerId = this.handlerId
 			this.lastConnectedDragPreview = dragPreview
 			this.lastConnectedDragPreviewOptions = this.dragPreviewOptions
-			this.dragPreviewUnsubscribe = this.backend.connectDragPreview(
-				this.handlerId,
-				dragPreview,
-				this.dragPreviewOptions,
-			)
+
+			if (dragPreview) {
+				this.dragPreviewUnsubscribe = this.backend.connectDragPreview(
+					this.handlerId,
+					dragPreview,
+					this.dragPreviewOptions,
+				)
+			}
 		}
 	}
 

--- a/packages/core/react-dnd/src/common/SourceConnector.ts
+++ b/packages/core/react-dnd/src/common/SourceConnector.ts
@@ -96,7 +96,6 @@ export class SourceConnector implements Connector {
 	}
 
 	private reconnectDragSource() {
-		const dragSource = this.dragSource
 		// if nothing has changed then don't resubscribe
 		const didChange =
 			this.didHandlerIdChange() ||
@@ -105,21 +104,30 @@ export class SourceConnector implements Connector {
 
 		if (didChange) {
 			this.disconnectDragSource()
+		}
+
+		const dragSource = this.dragSource
+		if (!this.handlerId) {
+			return
+		}
+		if (!dragSource) {
+			this.lastConnectedDragSource = dragSource
+			return
+		}
+
+		if (didChange) {
 			this.lastConnectedHandlerId = this.handlerId
 			this.lastConnectedDragSource = dragSource
 			this.lastConnectedDragSourceOptions = this.dragSourceOptions
-			if (dragSource) {
-				this.dragSourceUnsubscribe = this.backend.connectDragSource(
-					this.handlerId,
-					dragSource,
-					this.dragSourceOptions,
-				)
-			}
+			this.dragSourceUnsubscribe = this.backend.connectDragSource(
+				this.handlerId,
+				dragSource,
+				this.dragSourceOptions,
+			)
 		}
 	}
 
 	private reconnectDragPreview() {
-		const dragPreview = this.dragPreview
 		// if nothing has changed then don't resubscribe
 		const didChange =
 			this.didHandlerIdChange() ||
@@ -128,17 +136,22 @@ export class SourceConnector implements Connector {
 
 		if (didChange) {
 			this.disconnectDragPreview()
+		}
+
+		const dragPreview = this.dragPreview
+		if (!this.handlerId || !dragPreview) {
+			return
+		}
+
+		if (didChange) {
 			this.lastConnectedHandlerId = this.handlerId
 			this.lastConnectedDragPreview = dragPreview
 			this.lastConnectedDragPreviewOptions = this.dragPreviewOptions
-
-			if (dragPreview) {
-				this.dragPreviewUnsubscribe = this.backend.connectDragPreview(
-					this.handlerId,
-					dragPreview,
-					this.dragPreviewOptions,
-				)
-			}
+			this.dragPreviewUnsubscribe = this.backend.connectDragPreview(
+				this.handlerId,
+				dragPreview,
+				this.dragPreviewOptions,
+			)
 		}
 	}
 

--- a/packages/core/react-dnd/src/common/TargetConnector.ts
+++ b/packages/core/react-dnd/src/common/TargetConnector.ts
@@ -8,6 +8,7 @@ import { Connector } from './SourceConnector'
 export class TargetConnector implements Connector {
 	public hooks = wrapConnectorHooks({
 		dropTarget: (node: any, options: any) => {
+			this.clearDropTarget()
 			this.dropTargetOptions = options
 			if (isRef(node)) {
 				this.dropTargetRef = node
@@ -113,5 +114,10 @@ export class TargetConnector implements Connector {
 		return (
 			this.dropTargetNode || (this.dropTargetRef && this.dropTargetRef.current)
 		)
+	}
+
+	private clearDropTarget() {
+		this.dropTargetRef = null
+		this.dropTargetNode = null
 	}
 }

--- a/packages/core/react-dnd/src/common/TargetConnector.ts
+++ b/packages/core/react-dnd/src/common/TargetConnector.ts
@@ -39,7 +39,6 @@ export class TargetConnector implements Connector {
 	}
 
 	public reconnect() {
-		const dropTarget = this.dropTarget
 		// if nothing has changed then don't resubscribe
 		const didChange =
 			this.didHandlerIdChange() ||
@@ -48,17 +47,27 @@ export class TargetConnector implements Connector {
 
 		if (didChange) {
 			this.disconnectDropTarget()
+		}
+
+		const dropTarget = this.dropTarget
+		if (!this.handlerId) {
+			return
+		}
+		if (!dropTarget) {
+			this.lastConnectedDropTarget = dropTarget
+			return
+		}
+
+		if (didChange) {
 			this.lastConnectedHandlerId = this.handlerId
 			this.lastConnectedDropTarget = dropTarget
 			this.lastConnectedDropTargetOptions = this.dropTargetOptions
 
-			if (dropTarget) {
-				this.unsubscribeDropTarget = this.backend.connectDropTarget(
-					this.handlerId,
-					dropTarget,
-					this.dropTargetOptions,
-				)
-			}
+			this.unsubscribeDropTarget = this.backend.connectDropTarget(
+				this.handlerId,
+				dropTarget,
+				this.dropTargetOptions,
+			)
 		}
 	}
 

--- a/packages/core/react-dnd/src/common/TargetConnector.ts
+++ b/packages/core/react-dnd/src/common/TargetConnector.ts
@@ -39,6 +39,7 @@ export class TargetConnector implements Connector {
 	}
 
 	public reconnect() {
+		const dropTarget = this.dropTarget
 		// if nothing has changed then don't resubscribe
 		const didChange =
 			this.didHandlerIdChange() ||
@@ -47,27 +48,17 @@ export class TargetConnector implements Connector {
 
 		if (didChange) {
 			this.disconnectDropTarget()
-		}
-
-		const dropTarget = this.dropTarget
-		if (!this.handlerId) {
-			return
-		}
-		if (!dropTarget) {
-			this.lastConnectedDropTarget = dropTarget
-			return
-		}
-
-		if (didChange) {
 			this.lastConnectedHandlerId = this.handlerId
 			this.lastConnectedDropTarget = dropTarget
 			this.lastConnectedDropTargetOptions = this.dropTargetOptions
 
-			this.unsubscribeDropTarget = this.backend.connectDropTarget(
-				this.handlerId,
-				dropTarget,
-				this.dropTargetOptions,
-			)
+			if (dropTarget) {
+				this.unsubscribeDropTarget = this.backend.connectDropTarget(
+					this.handlerId,
+					dropTarget,
+					this.dropTargetOptions,
+				)
+			}
 		}
 	}
 

--- a/packages/core/react-dnd/src/utils/cloneWithRef.ts
+++ b/packages/core/react-dnd/src/utils/cloneWithRef.ts
@@ -26,14 +26,12 @@ export function cloneWithRef(
 		return cloneElement(element, {
 			ref: newRef,
 		})
-	}
-
-	return cloneElement(element, {
-		ref: (node: any) => {
-			setRef(newRef, node)
-			if (previousRef) {
+	} else {
+		return cloneElement(element, {
+			ref: (node: any) => {
 				setRef(previousRef, node)
-			}
-		},
-	})
+				setRef(newRef, node)
+			},
+		})
+	}
 }

--- a/packages/documentation/docsite/markdown/examples/other/chained-connectors.md
+++ b/packages/documentation/docsite/markdown/examples/other/chained-connectors.md
@@ -3,7 +3,7 @@ path: '/examples/other/chained-connectors'
 title: 'Chained Connecors'
 ---
 
-Example using chained connector functions.
+Example using chained connector functions. Regression example of [#1465](https://github.com/react-dnd/react-dnd/pull/1465)
 
 <view-source name="06-other/chained-connectors" component="other-chained-connectors">
 </view-source>

--- a/packages/documentation/docsite/markdown/examples/other/chained-connectors.md
+++ b/packages/documentation/docsite/markdown/examples/other/chained-connectors.md
@@ -1,0 +1,9 @@
+---
+path: '/examples/other/chained-connectors'
+title: 'Chained Connecors'
+---
+
+Example using chained connector functions.
+
+<view-source name="06-other/chained-connectors" component="other-chained-connectors">
+</view-source>

--- a/packages/documentation/docsite/markdown/examples/other/chained-connectors.md
+++ b/packages/documentation/docsite/markdown/examples/other/chained-connectors.md
@@ -1,6 +1,6 @@
 ---
 path: '/examples/other/chained-connectors'
-title: 'Chained Connecors'
+title: 'Chained Connectors'
 ---
 
 Example using chained connector functions. Regression example of [#1465](https://github.com/react-dnd/react-dnd/pull/1465)

--- a/packages/documentation/docsite/markdown/examples/other/drag-source-remount.md
+++ b/packages/documentation/docsite/markdown/examples/other/drag-source-remount.md
@@ -5,5 +5,7 @@ title: 'Drag Source Remounts with Correct Props'
 
 Regression example based on [#1429](https://github.com/react-dnd/react-dnd/pull/1429) that verifies that as drag-sources are remounted, they receive their correct props from React-DnD.
 
+The box at the drag-source location should flash red while the item is being dragged around.
+
 <view-source name="06-other/remount-with-correct-props" component="other-remount-with-correct-props">
 </view-source>

--- a/packages/documentation/docsite/src/constants.ts
+++ b/packages/documentation/docsite/src/constants.ts
@@ -241,6 +241,10 @@ export const ExamplePages: PageGroup[] = [
 				location: '/examples/other/native-files',
 				title: 'Native Files',
 			},
+			OTHER_CHAINED_CONNECTORS: {
+				location: '/examples/other/chained-connectors',
+				title: 'Chained Connectors',
+			},
 		},
 	},
 ]

--- a/packages/documentation/examples-decorators/src/06-other/chained-connectors/BoxWithHandle.tsx
+++ b/packages/documentation/examples-decorators/src/06-other/chained-connectors/BoxWithHandle.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import {
+	DragSource,
+	DropTarget,
+	ConnectDragSource,
+	ConnectDragPreview,
+	ConnectDropTarget,
+} from 'react-dnd'
+import ItemTypes from './ItemTypes'
+
+const style = {
+	border: '1px dashed gray',
+	padding: '0.5rem 1rem',
+	marginBottom: '.5rem',
+	backgroundColor: 'white',
+	width: '20rem',
+}
+const handleStyle = {
+	backgroundColor: 'green',
+	width: '1rem',
+	height: '1rem',
+	display: 'inline-block',
+	marginRight: '0.75rem',
+	cursor: 'move',
+}
+
+export interface BoxWithHandleProps {
+	isDragging: boolean
+	connectDragSource: ConnectDragSource
+	connectDragPreview: ConnectDragPreview
+	connectDropTarget: ConnectDropTarget
+}
+
+const BoxWithHandleRaw: React.FC<BoxWithHandleProps> = ({
+	isDragging,
+	connectDragSource,
+	connectDragPreview,
+	connectDropTarget,
+}: BoxWithHandleProps) => {
+	const opacity = isDragging ? 0.4 : 1
+	return connectDropTarget(
+		connectDragPreview(
+			<div style={{ ...style, opacity }}>
+				{connectDragSource(<div style={handleStyle} />)}
+				Drag me by the handle BAD
+			</div>,
+		),
+	)
+}
+
+export const BoxWithHandle = DragSource(
+	ItemTypes.BOX,
+	{
+		beginDrag: () => ({}),
+	},
+	(connect, monitor) => ({
+		connectDragSource: connect.dragSource(),
+		connectDragPreview: connect.dragPreview(),
+		isDragging: monitor.isDragging(),
+	}),
+)(
+	DropTarget(ItemTypes.BOX, {}, (connect, monitor) => ({
+		connectDropTarget: connect.dropTarget(),
+		isDraggingHover: monitor.isOver({ shallow: true }),
+		isOver: monitor.isOver(),
+	}))(BoxWithHandleRaw),
+)

--- a/packages/documentation/examples-decorators/src/06-other/chained-connectors/BoxWithHandle.tsx
+++ b/packages/documentation/examples-decorators/src/06-other/chained-connectors/BoxWithHandle.tsx
@@ -42,7 +42,7 @@ const BoxWithHandleRaw: React.FC<BoxWithHandleProps> = ({
 		connectDragPreview(
 			<div style={{ ...style, opacity }}>
 				{connectDragSource(<div style={handleStyle} />)}
-				Drag me by the handle BAD
+				Drag me by the handle, the whole box should drag
 			</div>,
 		),
 	)

--- a/packages/documentation/examples-decorators/src/06-other/chained-connectors/ItemTypes.ts
+++ b/packages/documentation/examples-decorators/src/06-other/chained-connectors/ItemTypes.ts
@@ -1,0 +1,3 @@
+export default {
+	BOX: 'box',
+}

--- a/packages/documentation/examples-decorators/src/06-other/chained-connectors/index.tsx
+++ b/packages/documentation/examples-decorators/src/06-other/chained-connectors/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { BoxWithHandle } from './BoxWithHandle'
+
+const style = {
+	width: 400,
+}
+
+export interface Item {
+	id: number
+	text: string
+}
+export interface ContainerState {
+	cards: Item[]
+}
+
+const Container: React.FC = () => {
+	{
+		return (
+			<div style={style}>
+				<BoxWithHandle />
+			</div>
+		)
+	}
+}
+
+export default Container

--- a/packages/documentation/examples-decorators/src/index.ts
+++ b/packages/documentation/examples-decorators/src/index.ts
@@ -17,6 +17,7 @@ import customizeHandlesAndPreviews from './05-customize/handles-and-previews'
 import dragSourceRerender from './06-other/drag-source-rerender'
 import remountWithCorrectProps from './06-other/remount-with-correct-props'
 import otherNativeFiles from './06-other/native-files'
+import otherChainedConnectors from './06-other/chained-connectors'
 
 export const componentIndex: {
 	[key: string]: React.ComponentClass<any> | React.FunctionComponent<any>
@@ -39,4 +40,5 @@ export const componentIndex: {
 	'other-drag-source-rerender': dragSourceRerender,
 	'other-remount-with-correct-props': remountWithCorrectProps,
 	'other-native-files': otherNativeFiles,
+	'other-chained-connectors': otherChainedConnectors,
 }

--- a/packages/documentation/examples-hooks/src/06-other/chained-connectors/BoxWithHandle.tsx
+++ b/packages/documentation/examples-hooks/src/06-other/chained-connectors/BoxWithHandle.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import { DragSource, DropTarget, useDrop, useDrag } from 'react-dnd'
+import ItemTypes from './ItemTypes'
+
+const style = {
+	border: '1px dashed gray',
+	padding: '0.5rem 1rem',
+	marginBottom: '.5rem',
+	backgroundColor: 'white',
+	width: '20rem',
+}
+const handleStyle = {
+	backgroundColor: 'green',
+	width: '1rem',
+	height: '1rem',
+	display: 'inline-block',
+	marginRight: '0.75rem',
+	cursor: 'move',
+}
+
+const BoxWithHandleRaw: React.FC = () => {
+	const [, drop] = useDrop({
+		accept: ItemTypes.BOX,
+	})
+	const [{ isDragging }, drag, preview] = useDrag({
+		item: {
+			type: ItemTypes.BOX,
+		},
+		collect: monitor => ({
+			isDragging: monitor.isDragging(),
+		}),
+	})
+	const opacity = isDragging ? 0.4 : 1
+	return drop(
+		preview(
+			<div style={{ ...style, opacity }}>
+				{drag(<div style={handleStyle} />)}
+				Drag me by the handle
+			</div>,
+		),
+	)
+}
+
+export const BoxWithHandle = DragSource(
+	ItemTypes.BOX,
+	{
+		beginDrag: () => ({}),
+	},
+	(connect, monitor) => ({
+		connectDragSource: connect.dragSource(),
+		connectDragPreview: connect.dragPreview(),
+		isDragging: monitor.isDragging(),
+	}),
+)(
+	DropTarget(ItemTypes.BOX, {}, (connect, monitor) => ({
+		connectDropTarget: connect.dropTarget(),
+		isDraggingHover: monitor.isOver({ shallow: true }),
+		isOver: monitor.isOver(),
+	}))(BoxWithHandleRaw),
+)

--- a/packages/documentation/examples-hooks/src/06-other/chained-connectors/BoxWithHandle.tsx
+++ b/packages/documentation/examples-hooks/src/06-other/chained-connectors/BoxWithHandle.tsx
@@ -35,7 +35,7 @@ const BoxWithHandleRaw: React.FC = () => {
 		preview(
 			<div style={{ ...style, opacity }}>
 				{drag(<div style={handleStyle} />)}
-				Drag me by the handle
+				Drag me by the handle, the whole box should drag
 			</div>,
 		),
 	)

--- a/packages/documentation/examples-hooks/src/06-other/chained-connectors/ItemTypes.ts
+++ b/packages/documentation/examples-hooks/src/06-other/chained-connectors/ItemTypes.ts
@@ -1,0 +1,3 @@
+export default {
+	BOX: 'box',
+}

--- a/packages/documentation/examples-hooks/src/06-other/chained-connectors/index.tsx
+++ b/packages/documentation/examples-hooks/src/06-other/chained-connectors/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { BoxWithHandle } from './BoxWithHandle'
+
+const style = {
+	width: 400,
+}
+
+export interface Item {
+	id: number
+	text: string
+}
+export interface ContainerState {
+	cards: Item[]
+}
+
+const Container: React.FC = () => {
+	{
+		return (
+			<div style={style}>
+				<BoxWithHandle />
+			</div>
+		)
+	}
+}
+
+export default Container

--- a/packages/documentation/examples-hooks/src/index.ts
+++ b/packages/documentation/examples-hooks/src/index.ts
@@ -17,6 +17,7 @@ import customizeHandlesAndPreviews from './05-customize/handles-and-previews'
 import dragSourceRerender from './06-other/drag-source-rerender'
 import remountWithCorrectProps from './06-other/remount-with-correct-props'
 import otherNativeFiles from './06-other/native-files'
+import otherChainedConnectors from './06-other/chained-connectors'
 
 export const componentIndex: {
 	[key: string]: React.ComponentClass<any> | React.FunctionComponent<any>
@@ -39,4 +40,5 @@ export const componentIndex: {
 	'other-drag-source-rerender': dragSourceRerender,
 	'other-remount-with-correct-props': remountWithCorrectProps,
 	'other-native-files': otherNativeFiles,
+	'other-chained-connectors': otherChainedConnectors,
 }


### PR DESCRIPTION
This PR refactors the reconnection logic between the dragsource, droptarget, and dragPreview. The conditional nature of the previous version was hard to follow and led to subtle errors. 

Fixes #1465