### PR TITLE
Add manager to test backend

### DIFF
--- a/packages/documentation/docsite/markdown/docs/00 Quick Start/Testing.md
+++ b/packages/documentation/docsite/markdown/docs/00 Quick Start/Testing.md
@@ -134,14 +134,14 @@ it('can be tested with the testing backend', () => {
 To use it with react-dnd, you'll need to call `.instance()` on `mount`-ed nodes to access the react-dnd helper methods:
 
 ```jsx
+import { getBackendFromInstance } from 'react-dnd-test-utils';
+
 var root = Enzyme.mount(<BoxContext name="test" />)
 
 // ...
 
-var backend = root
-  .instance()
-  .getManager()
-  .getBackend()
+var backend = getBackendFromInstance(root);
+var manager = backend.manager;
 
 // ...
 

--- a/packages/testing/test-backend/src/TestBackend.ts
+++ b/packages/testing/test-backend/src/TestBackend.ts
@@ -24,9 +24,11 @@ export interface TestBackend extends Backend {
 export default class TestBackendImpl implements Backend, TestBackend {
 	public didCallSetup = false
 	public didCallTeardown = false
+	public manager: DragDropManager;
 	private actions: DragDropActions
 
 	public constructor(manager: DragDropManager) {
+		this.manager = manager;
 		this.actions = manager.getActions()
 	}
 


### PR DESCRIPTION
I need to access manager in my tests.
The `wrapInTestContext` is now functional HOC, where enzyme `.instance() => null` so I can't get a manager from the component, so I would like to get it from the backend, what is global.