### PR TITLE
Add types property to test-utils package.json

### DIFF
--- a/packages/testing/test-utils/package.json
+++ b/packages/testing/test-utils/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "./dist/esm/index.js",
   "module": "./dist/esm/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
     "clean": "../../../scripts/clean_package.sh",
     "build": "../../../scripts/build_package.sh",


### PR DESCRIPTION
This PR fixes the `react-dnd-test-utils` types not being picked up correctly e.g.

![ts-example](https://user-images.githubusercontent.com/7240988/68662887-02203d80-053e-11ea-8a87-905f09aeb10a.png)
