### PR TITLE
Fix UMD build issue 

### DIFF
--- a/packages/core/dnd-core/package.json
+++ b/packages/core/dnd-core/package.json
@@ -17,7 +17,8 @@
     "url": "https://github.com/react-dnd/react-dnd.git"
   },
   "dependencies": {
-    "@react-dnd/asap": "^3.0.0",
+    "@types/asap": "^2.0.0",
+    "asap": "^2.0.6",
     "@react-dnd/invariant": "^2.0.0",
     "redux": "^4.0.4"
   }

--- a/packages/core/dnd-core/src/HandlerRegistryImpl.ts
+++ b/packages/core/dnd-core/src/HandlerRegistryImpl.ts
@@ -1,5 +1,4 @@
 import { Store } from 'redux'
-import { asap } from '@react-dnd/asap'
 import { invariant } from '@react-dnd/invariant'
 import {
 	addSource,
@@ -23,6 +22,7 @@ import {
 	validateTargetContract,
 	validateType,
 } from './contracts'
+import asap from 'asap'
 
 function getNextHandlerId(role: HandlerRole): string {
 	const id = getNextUniqueId().toString()

--- a/packages/core/dnd-core/tsconfig.json
+++ b/packages/core/dnd-core/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "lib",
-    "baseUrl": "./src"
+    "baseUrl": "./src",
+    "allowSyntheticDefaultImports": true
   },
   "include": ["src/index.ts"]
 }

--- a/packages/core/html5-backend/rollup.config.js
+++ b/packages/core/html5-backend/rollup.config.js
@@ -42,5 +42,5 @@ export default {
 		},
 	],
 	external: ['react', 'react-dom', 'react-dnd'],
-	plugins: [resolve(), commonjs()],
+	plugins: [resolve({ browser: true }), commonjs()],
 }

--- a/packages/core/react-dnd/rollup.config.js
+++ b/packages/core/react-dnd/rollup.config.js
@@ -40,5 +40,5 @@ export default {
 		},
 	],
 	external: ['react', 'react-dom'],
-	plugins: [resolve(), commonjs()],
+	plugins: [resolve({ browser: true }), commonjs()],
 }

--- a/packages/core/touch-backend/rollup.config.js
+++ b/packages/core/touch-backend/rollup.config.js
@@ -42,5 +42,5 @@ export default {
 		},
 	],
 	external: ['react', 'react-dom', 'react-dnd'],
-	plugins: [resolve(), commonjs()],
+	plugins: [resolve({ browser: true }), commonjs()],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2470,11 +2470,6 @@
     react-lifecycles-compat "^3.0.4"
     warning "^3.0.0"
 
-"@react-dnd/asap@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@react-dnd/asap/-/asap-3.0.0.tgz#18febff4a27d4e4a72735d5f5521f08b7a5a0258"
-  integrity sha512-6kinmeCdN0JbvmFRnay+U2+YJoxAwb2qUmbCtdCbhcoZ24XVK3RXIXTBkUsnKg41RBFM/bY1W47w7lvyHfY63g==
-
 "@react-dnd/invariant@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@react-dnd/invariant/-/invariant-2.0.0.tgz#09d2e81cd39e0e767d7da62df9325860f24e517e"
@@ -2615,6 +2610,11 @@
   integrity sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==
   dependencies:
     defer-to-connect "^1.0.1"
+
+"@types/asap@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/asap/-/asap-2.0.0.tgz#d529e9608c83499a62ae08c871c5e62271aa2963"
+  integrity sha512-upIS0Gt9Mc8eEpCbYMZ1K8rhNosfKUtimNcINce+zLwJF5UpM3Vv7yz3S5l/1IX+DxTa8lTkUjqynvjRXyJzsg==
 
 "@types/babel__core@^7.1.0":
   version "7.1.3"
@@ -3605,7 +3605,7 @@ arrify@^2.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
 
-asap@^2.0.0, asap@~2.0.3, asap@~2.0.6:
+asap@^2.0.0, asap@^2.0.6, asap@~2.0.3, asap@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=


### PR DESCRIPTION
The rollup config needed to be updated to respect the `package.json::browser` field, which is used by asap. Using the upstream ASAP for now until we can update our fork of it.

fixes #1652