### PR TITLE
Node 8 Deprecation 

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
 
     steps:
       - uses: actions/checkout@v1

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "hoc"
   ],
   "engines": {
-    "node": ">= 8.0"
+    "node": ">= 10.0"
   },
   "author": "Dan Abramov <dan.abramov@me.com> (http://github.com/gaearon)",
   "contributors": [


### PR DESCRIPTION
According to the NodeJS release cycle, Node 8.x has fallen out of LTS support. This removes official support for Node 8.