### PR TITLE
Fix name mismatch in DndProvider example

### DIFF
--- a/packages/documentation/docsite/markdown/docs/01 Top Level API/DndProvider.md
+++ b/packages/documentation/docsite/markdown/docs/01 Top Level API/DndProvider.md
@@ -19,7 +19,7 @@ import { DndProvider } from 'react-dnd'
 export default class YourApp {
   render() {
     return (
-      <DndProvider backend={HTML5Backend}>
+      <DndProvider backend={Backend}>
         /* Your Drag-and-Drop Application */
       </DndProvider>
     )


### PR DESCRIPTION
In the DndProvider example, an import is named `Backend` and later used as `HTML5Backend`. This seems to have slipped through in https://github.com/react-dnd/react-dnd/pull/1683/files#diff-5ce06c996535249b437e40d20021c66aR16.

(No big deal but maybe annoying when copying the code.)