### PR TITLE
Wrong type in end function

### DIFF
--- a/packages/core/react-dnd/src/interfaces/hooksApi.ts
+++ b/packages/core/react-dnd/src/interfaces/hooksApi.ts
@@ -43,7 +43,7 @@ export interface DragSourceHookSpec<
 	 * monitor.getDropResult(). This method is a good place to fire a Flux action. Note: If the component is unmounted while dragging,
 	 * component parameter is set to be null.
 	 */
-	end?: (dropResult: DropResult | undefined, monitor: DragSourceMonitor) => void
+	end?: (draggedItem: DragObject | undefined, monitor: DragSourceMonitor) => void
 
 	/**
 	 * Optional.

--- a/packages/documentation/examples-hooks/src/01-dustbin/copy-or-move/Box.tsx
+++ b/packages/documentation/examples-hooks/src/01-dustbin/copy-or-move/Box.tsx
@@ -21,11 +21,16 @@ interface DropResult {
 	name: string
 }
 
+interface DragItem {
+	name: string
+	type: string
+}
+
 const Box: React.FC<BoxProps> = ({ name }) => {
 	const item = { name, type: ItemTypes.BOX }
 	const [{ opacity }, drag] = useDrag({
 		item,
-		end(item: { name: string } | undefined, monitor: DragSourceMonitor) {
+		end(item: DragItem | undefined, monitor: DragSourceMonitor) {
 			const dropResult: DropResult = monitor.getDropResult()
 			if (item && dropResult) {
 				let alertMessage = ''


### PR DESCRIPTION
In the end function the first argument is actually a monitor.getItem(), so the type in the interface should be DragObject, and not DropResult