### PR TITLE
Change renderSquare's second argument to [knightX, knightY] in Tutorial

### DIFF
--- a/packages/documentation/docsite/markdown/docs/00 Quick Start/Tutorial.md
+++ b/packages/documentation/docsite/markdown/docs/00 Quick Start/Tutorial.md
@@ -361,7 +361,7 @@ import { moveKnight } from './Game'
 
 /* ... */
 
-function renderSquare(i, knightPosition) {
+function renderSquare(i, [knightX, knightY]) {
   /* ... */
   return <div onClick={() => handleSquareClick(x, y)}>{/* ... */}</div>
 }


### PR DESCRIPTION
In [Adding Game State](https://react-dnd.github.io/react-dnd/docs/tutorial#make-the-board-squares-droppable) section, `renderSquare` function's second argument changes to `knightsPosition` which breaks `isKnightHere`'s logic inside the function at that point.

I think we can change the function's second argument to `[knightX, knightY]` as previous sections and change it in [Make the Board Squares Droppable](https://react-dnd.github.io/react-dnd/docs/tutorial#make-the-board-squares-droppable) where `renderSquare` function is refactored with `renderPiece` function.