### PR TITLE
Update utils.tsx

### DIFF
--- a/packages/testing/test-utils/src/utils.tsx
+++ b/packages/testing/test-utils/src/utils.tsx
@@ -15,7 +15,7 @@ interface RefType {
  * @param DecoratedComponent The component to decorate
  */
 export function wrapInTestContext(
-	DecoratedComponent: React.ComponentType,
+	DecoratedComponent: React.ComponentType<any>,
 ): any {
 	const forwardedRefFunc = (props: any, ref: React.Ref<RefType>) => {
 		const dragDropManager = React.useRef<any>(undefined)


### PR DESCRIPTION
example:
```
interface MyComponentProps {
    ...
}
const MyComponent: FC<MyComponentProps> = (props: MyComponentProps) => {
    ...
}

/**
* error. TS2345: Argument of Type FC<MyComponentProps> is not assignable
* to parameter of type ComponentType<{}>
**/
const DndWrapper = wrapInTestContext(MyComponent);
```


This error happens because of this type definition in @types/react:

```
// from @types/react
type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
```

The default props type is empty object (`<P = {}>`). My patch fixes this error