### PR TITLE
Update utils.tsx

### DIFF
--- a/packages/testing/test-utils/src/utils.tsx
+++ b/packages/testing/test-utils/src/utils.tsx
@@ -6,7 +6,8 @@ import { Backend, DragDropManager } from 'dnd-core'
 import { act } from 'react-dom/test-utils'
 
 interface RefType {
-	getManager: () => DragDropManager | undefined
+	getManager: () => DragDropManager | undefined,
+	getDecoratedComponent<T>(): T
 }
 
 /**
@@ -19,9 +20,11 @@ export function wrapInTestContext(
 ): any {
 	const forwardedRefFunc = (props: any, ref: React.Ref<RefType>) => {
 		const dragDropManager = React.useRef<any>(undefined)
+		const decoratedComponentRef = React.useRef<any>(undefined)
 
 		React.useImperativeHandle(ref, () => ({
 			getManager: () => dragDropManager.current,
+			getDecoratedComponent: () => decoratedComponentRef.current
 		}))
 
 		return (
@@ -32,7 +35,7 @@ export function wrapInTestContext(
 						return null
 					}}
 				</DndContext.Consumer>
-				<DecoratedComponent {...props} />
+				<DecoratedComponent ref={decoratedComponentRef} {...props} />
 			</DndProvider>
 		)
 	}


### PR DESCRIPTION
We need to get ref to DecoratedComponent. For example if we want to get drag or drop source ID. Like in [documenation](https://react-dnd.github.io/react-dnd/docs/testing):

```
// Find the drag source ID and use it to simulate the dragging operation
const box = TestUtils.findRenderedComponentWithType(root, Box)
backend.simulateBeginDrag([box.getHandlerId()])
```

TestUtils.findRenderedComponentWithType works with class components. But what if I use functional components? I suggest using React.forwardRef and useImperativeHandle:

```
interface BoxRef {
  getDragHandlerId(): Identifier | null;
  getDropHandlerId(): Identifier | null;
}

const Box = forwardRef<BoxRef, BoxProps>(props: BoxProps) => {
  const [{ dropHandlerId }, dropRef] = useDrop({
    collect(monitor) {
      return {
        dropHandlerId: monitor.getHandlerId()
      };
    },
  });
  const [{ dragHandlerId }, dragRef] = useDrag({
    collect(monitor) {
      return {
        dropHandlerId: monitor.getHandlerId()
      };
    },
  });

  useImperativeHandle(ref, () => ({
    getDragHandlerId: () => dragHandlerId,
    getDropHandlerId: () => dropHandlerId,
  }));
}
```

`TestUtils.findRenderedComponentWithType(root, Box)` works only with class components. So I suggest adding getDecoratedComponent() method to wrapInTestContext. And we could get sourceId like that:
```
const sourceId: Identifier = root.getDecoratedComponent<BoxRef>().getDragHandlerId();
```