### PR TITLE
TouchBackend - impossible to drop item 

### DIFF
--- a/packages/core/touch-backend/src/TouchBackendImpl.ts
+++ b/packages/core/touch-backend/src/TouchBackendImpl.ts
@@ -528,7 +528,7 @@ export class TouchBackendImpl implements Backend {
 			.filter((node) => dragOverTargetNodes.indexOf(node as HTMLElement) > -1)
 			// Map back the nodes elements to targetIds
 			.map((node) => {
-				for (const targetId in this.targetNodes) {
+				for (const targetId of this.targetNodes.keys()) {
 					if (node === this.targetNodes.get(targetId)) {
 						return targetId
 					}

--- a/packages/core/touch-backend/src/TouchBackendImpl.ts
+++ b/packages/core/touch-backend/src/TouchBackendImpl.ts
@@ -560,7 +560,7 @@ export class TouchBackendImpl implements Backend {
 	 *
 	 * visible for testing
 	 */
-	public _getDropTargetId(node: Element): Identifier | undefined {
+	public _getDropTargetId = (node: Element): Identifier | undefined => {
 		const keys = this.targetNodes.keys()
 		let next = keys.next()
 		const targetId = next.value

--- a/packages/core/touch-backend/src/TouchBackendImpl.ts
+++ b/packages/core/touch-backend/src/TouchBackendImpl.ts
@@ -50,10 +50,10 @@ export class TouchBackendImpl implements Backend {
 
 	// Internal State
 	private static isSetUp: boolean
-	private sourceNodes: Map<Identifier, HTMLElement>
-	private sourcePreviewNodes: Map<string, HTMLElement>
-	private sourcePreviewNodeOptions: Map<string, any>
-	private targetNodes: Map<string, HTMLElement>
+	public sourceNodes: Map<Identifier, HTMLElement>
+	public sourcePreviewNodes: Map<string, HTMLElement>
+	public sourcePreviewNodeOptions: Map<string, any>
+	public targetNodes: Map<string, HTMLElement>
 	private _mouseClientOffset: Partial<XYCoord>
 	private _isScrolling: boolean
 	private listenerTypes: ListenerType[]
@@ -527,19 +527,7 @@ export class TouchBackendImpl implements Backend {
 			// Filter off nodes that arent a hovered DropTargets nodes
 			.filter((node) => dragOverTargetNodes.indexOf(node as HTMLElement) > -1)
 			// Map back the nodes elements to targetIds
-			.map((node) => {
-				const keys = this.targetNodes.keys()
-				let next = keys.next()
-				const targetId = next.value
-				while (next.done === false) {
-					if (node === this.targetNodes.get(targetId)) {
-						return targetId
-					} else {
-						next = keys.next()
-					}
-				}
-				return undefined
-			})
+			.map((node) => this._getDropTargetId(node))
 			// Filter off possible null rows
 			.filter((node) => !!node)
 			.filter((id, index, ids) => ids.indexOf(id) === index) as string[]
@@ -566,6 +554,24 @@ export class TouchBackendImpl implements Backend {
 		this.actions.hover(orderedDragOverTargetIds, {
 			clientOffset: clientOffset,
 		})
+	}
+
+	/**
+	 *
+	 * visible for testing
+	 */
+	public _getDropTargetId(node: Element): Identifier | undefined {
+		const keys = this.targetNodes.keys()
+		let next = keys.next()
+		const targetId = next.value
+		while (next.done === false) {
+			if (node === this.targetNodes.get(targetId)) {
+				return targetId
+			} else {
+				next = keys.next()
+			}
+		}
+		return undefined
 	}
 
 	public handleTopMoveEndCapture = (e: Event): void => {

--- a/packages/core/touch-backend/src/TouchBackendImpl.ts
+++ b/packages/core/touch-backend/src/TouchBackendImpl.ts
@@ -528,9 +528,14 @@ export class TouchBackendImpl implements Backend {
 			.filter((node) => dragOverTargetNodes.indexOf(node as HTMLElement) > -1)
 			// Map back the nodes elements to targetIds
 			.map((node) => {
-				for (const targetId of this.targetNodes.keys()) {
+				const keys = this.targetNodes.keys()
+				let next = keys.next()
+				const targetId = next.value
+				while (next.done === false) {
 					if (node === this.targetNodes.get(targetId)) {
 						return targetId
+					} else {
+						next = keys.next()
 					}
 				}
 				return undefined

--- a/packages/core/touch-backend/src/__tests__/TouchBackend.spec.ts
+++ b/packages/core/touch-backend/src/__tests__/TouchBackend.spec.ts
@@ -1,5 +1,6 @@
 import { TouchBackend } from '../index'
 import { DragDropManager } from 'dnd-core'
+import { TouchBackendImpl } from '../TouchBackendImpl'
 
 describe('TouchBackend', () => {
 	it('can be constructed', () => {
@@ -15,6 +16,15 @@ describe('TouchBackend', () => {
 		Object.keys(profile).forEach((profilingKey) =>
 			expect(profile[profilingKey]).toEqual(0),
 		)
+	})
+
+	it('can determine target ids', () => {
+		const mockNode = {} as HTMLElement
+		const backend = TouchBackend(mockManager(), {}, {}) as TouchBackendImpl
+		backend.targetNodes.set('abc', mockNode)
+
+		expect(backend._getDropTargetId(mockNode)).toEqual('abc')
+		expect(backend._getDropTargetId({} as Element)).toEqual(undefined)
 	})
 })
 


### PR DESCRIPTION
https://github.com/react-dnd/react-dnd/blob/55957e32b57998de02f3ef9621a1d4d2c47546d1/packages/core/touch-backend/src/TouchBackendImpl.ts#L531
this.targetNodes is a Map. It's not possible to iterate over map keys using for (... in ...). As a result, orderedDragOverTargetIds array is always empty.
Because of that drop callback from useDrop is never being called (when an item is dropped to drop zone).
Changing this line to 
`for (const targetId of this.targetNodes.keys()) {`
do the trick and drop became possible after that. 