### PR TITLE
Fix touch backend bug in _getDropTargetId

### DIFF
--- a/packages/core/touch-backend/src/TouchBackendImpl.ts
+++ b/packages/core/touch-backend/src/TouchBackendImpl.ts
@@ -563,8 +563,8 @@ export class TouchBackendImpl implements Backend {
 	public _getDropTargetId = (node: Element): Identifier | undefined => {
 		const keys = this.targetNodes.keys()
 		let next = keys.next()
-		const targetId = next.value
 		while (next.done === false) {
+			const targetId = next.value
 			if (node === this.targetNodes.get(targetId)) {
 				return targetId
 			} else {

--- a/packages/core/touch-backend/src/__tests__/TouchBackend.spec.ts
+++ b/packages/core/touch-backend/src/__tests__/TouchBackend.spec.ts
@@ -19,11 +19,14 @@ describe('TouchBackend', () => {
 	})
 
 	it('can determine target ids', () => {
-		const mockNode = {} as HTMLElement
+		const mockNode1 = {} as HTMLElement
+		const mockNode2 = {} as HTMLElement
 		const backend = TouchBackend(mockManager(), {}, {}) as TouchBackendImpl
-		backend.targetNodes.set('abc', mockNode)
+		backend.targetNodes.set('abc', mockNode1)
+		backend.targetNodes.set('def', mockNode2)
 
-		expect(backend._getDropTargetId(mockNode)).toEqual('abc')
+		expect(backend._getDropTargetId(mockNode1)).toEqual('abc')
+		expect(backend._getDropTargetId(mockNode2)).toEqual('def')
 		expect(backend._getDropTargetId({} as Element)).toEqual(undefined)
 	})
 })


### PR DESCRIPTION
This is a fix of an issue missed in yesterday`s touch backend fix. Now only the first node in a map can be found.