### PR TITLE
Fix wrapInTestContext type signature

### DIFF
--- a/packages/testing/test-utils/src/utils.tsx
+++ b/packages/testing/test-utils/src/utils.tsx
@@ -15,9 +15,9 @@ interface RefType {
  *
  * @param DecoratedComponent The component to decorate
  */
-export function wrapInTestContext(
-	DecoratedComponent: React.ComponentType<any>,
-): any {
+export function wrapInTestContext<T>(
+	DecoratedComponent: React.ComponentType<T>,
+): React.ComponentType<T> {
 	const forwardedRefFunc = (props: any, ref: React.Ref<RefType>) => {
 		const dragDropManager = React.useRef<any>(undefined)
 		const decoratedComponentRef = React.useRef<any>(undefined)


### PR DESCRIPTION
Closes https://github.com/react-dnd/react-dnd/issues/2635

This fixes the type error you get when using `wrapInTestContext` on class components with `getDerivedStateFromProps`. It is possible that this change would break builds since the type is more specific compared to what it was before.