### PR TITLE
Remove early reference and rename 'mon' for consistency

### DIFF
--- a/packages/documentation/docsite/markdown/docs/00 Quick Start/Tutorial.md
+++ b/packages/documentation/docsite/markdown/docs/00 Quick Start/Tutorial.md
@@ -567,12 +567,11 @@ See? The `drop` method has the `props` of the `BoardSquare` in scope, so it know
 In my collecting function I'm going to ask the monitor whether the pointer is currently over the `BoardSquare` so I can highlight it:
 
 ```jsx
-const [{ isOver, canDrop }, drop] = useDrop({
+const [{ isOver }, drop] = useDrop({
   accept: ItemTypes.KNIGHT,
   drop: () => moveKnight(x, y),
-  collect: (mon) => ({
-    isOver: !!mon.isOver(),
-    canDrop: !!mon.canDrop()
+  collect: monitor => ({
+    isOver: !!monitor.isOver(),
   })
 })
 ```


### PR DESCRIPTION
* remove reference to canDrop before it is talked about

* replace 'mon' with 'monitor' for document consistency