### PR TITLE
Improve readability of the documentation

### DIFF
--- a/packages/documentation/docsite/src/components/doc.tsx
+++ b/packages/documentation/docsite/src/components/doc.tsx
@@ -20,7 +20,8 @@ export const Doc: React.FC<DocProps> = memo(function Doc({ docPage }) {
 })
 
 const HtmlContainer = styled.div`
-	width: 75%;
+	width: 100%;
+	max-width: 34rem;
 `
 
 const Container = styled.div`


### PR DESCRIPTION
As the content container of the documentation fills 75% of the available space, the text becomes really uncomfortable to read with larger browser window sizes.

I set a maximum width to the content container to improve the readability on "larger" browser window sizes.
The definend maximum width results in an approximate 75 characters per line.

I also set the `width` to `100%` to use as much space as possible on smaller screens.