### PR TITLE
Small wording change for Tutorial.md

### DIFF
--- a/packages/docsite/markdown/docs/00 Quick Start/Tutorial.md
+++ b/packages/docsite/markdown/docs/00 Quick Start/Tutorial.md
@@ -36,7 +36,7 @@ Now let's build something!
 
 # Setup
 
-In this tutorial, the code examples are use function-components and modern JavaScript syntax. It's recommended to use a build-step to transpile these features into your target environment. We recommend using [create-react-app](https://github.com/facebook/create-react-app).
+In this tutorial, the code examples are using function-components and modern JavaScript syntax. It's recommended to use a build-step to transpile these features into your target environment. We recommend using [create-react-app](https://github.com/facebook/create-react-app).
 
 The app we're going to build is [available as an example on this website](/examples/tutorial).
 


### PR DESCRIPTION
I was going through the tutorial for React DnD and noticed that on line 39, it reads `are use function-components` instead of `are using function-components`.

Thank you so much for the in depth introduction to React DnD. I've gone through the whole tutorial now and have my first working example of the library that I'm planning to use a lot. Not only did it give great insight into how React DnD works, but you did an outstanding job of breaking down design decisions and linking to helpful articles to learn even more.