### PR TITLE
Add document owner property to touch backend

### DIFF
--- a/packages/backend-touch/package.json
+++ b/packages/backend-touch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dnd-touch-backend",
-  "version": "11.1.3",
+  "version": "11.1.4",
   "description": "Touch backend for react-dnd",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/backend-touch/src/OptionsReader.ts
+++ b/packages/backend-touch/src/OptionsReader.ts
@@ -5,6 +5,7 @@ import {
 } from './interfaces'
 
 export class OptionsReader implements TouchBackendOptions {
+	public ownerDocument: Document | null = null
 	public enableTouchEvents = true
 	public enableMouseEvents = false
 	public enableKeyboardEvents = false
@@ -46,9 +47,15 @@ export class OptionsReader implements TouchBackendOptions {
 	}
 
 	public get document(): Document | undefined {
+		
 		if (this.window) {
 			return this.window.document
 		}
+
+		if (this.ownerDocument) {
+			return this.ownerDocument
+		}
+
 		return undefined
 	}
 }

--- a/packages/backend-touch/src/OptionsReader.ts
+++ b/packages/backend-touch/src/OptionsReader.ts
@@ -38,6 +38,7 @@ export class OptionsReader implements TouchBackendOptions {
 	}
 
 	public get window(): Window | undefined {
+
 		if (this.context && this.context.window) {
 			return this.context.window
 		} else if (typeof window !== 'undefined') {
@@ -51,7 +52,7 @@ export class OptionsReader implements TouchBackendOptions {
 		if (this.ownerDocument) {
 			return this.ownerDocument
 		}
-		
+
 		if (this.window) {
 			return this.window.document
 		}

--- a/packages/backend-touch/src/OptionsReader.ts
+++ b/packages/backend-touch/src/OptionsReader.ts
@@ -47,13 +47,13 @@ export class OptionsReader implements TouchBackendOptions {
 	}
 
 	public get document(): Document | undefined {
-		
-		if (this.window) {
-			return this.window.document
-		}
 
 		if (this.ownerDocument) {
 			return this.ownerDocument
+		}
+		
+		if (this.window) {
+			return this.window.document
 		}
 
 		return undefined

--- a/packages/backend-touch/src/TouchBackendImpl.ts
+++ b/packages/backend-touch/src/TouchBackendImpl.ts
@@ -124,7 +124,7 @@ export class TouchBackendImpl implements Backend {
 	}
 
 	public setup(): void {
-		if (!this.window) {
+		if (!this.document) {
 			return
 		}
 
@@ -135,20 +135,20 @@ export class TouchBackendImpl implements Backend {
 		TouchBackendImpl.isSetUp = true
 
 		this.addEventListener(
-			this.window,
+			this.document,
 			'start',
 			this.getTopMoveStartHandler() as any,
 		)
 		this.addEventListener(
-			this.window,
+			this.document,
 			'start',
 			this.handleTopMoveStartCapture as any,
 			true,
 		)
-		this.addEventListener(this.window, 'move', this.handleTopMove as any)
-		this.addEventListener(this.window, 'move', this.handleTopMoveCapture, true)
+		this.addEventListener(this.document, 'move', this.handleTopMove as any)
+		this.addEventListener(this.document, 'move', this.handleTopMoveCapture, true)
 		this.addEventListener(
-			this.window,
+			this.document,
 			'end',
 			this.handleTopMoveEndCapture as any,
 			true,
@@ -156,7 +156,7 @@ export class TouchBackendImpl implements Backend {
 
 		if (this.options.enableMouseEvents && !this.options.ignoreContextMenu) {
 			this.addEventListener(
-				this.window,
+				this.document,
 				'contextmenu',
 				this.handleTopMoveEndCapture as any,
 			)
@@ -164,7 +164,7 @@ export class TouchBackendImpl implements Backend {
 
 		if (this.options.enableKeyboardEvents) {
 			this.addEventListener(
-				this.window,
+				this.document,
 				'keydown',
 				this.handleCancelOnEscape as any,
 				true,
@@ -173,7 +173,7 @@ export class TouchBackendImpl implements Backend {
 	}
 
 	public teardown(): void {
-		if (!this.window) {
+		if (!this.document) {
 			return
 		}
 
@@ -181,25 +181,25 @@ export class TouchBackendImpl implements Backend {
 		this._mouseClientOffset = {}
 
 		this.removeEventListener(
-			this.window,
+			this.document,
 			'start',
 			this.handleTopMoveStartCapture as any,
 			true,
 		)
 		this.removeEventListener(
-			this.window,
+			this.document,
 			'start',
 			this.handleTopMoveStart as any,
 		)
 		this.removeEventListener(
-			this.window,
+			this.document,
 			'move',
 			this.handleTopMoveCapture,
 			true,
 		)
-		this.removeEventListener(this.window, 'move', this.handleTopMove as any)
+		this.removeEventListener(this.document, 'move', this.handleTopMove as any)
 		this.removeEventListener(
-			this.window,
+			this.document,
 			'end',
 			this.handleTopMoveEndCapture as any,
 			true,
@@ -207,7 +207,7 @@ export class TouchBackendImpl implements Backend {
 
 		if (this.options.enableMouseEvents && !this.options.ignoreContextMenu) {
 			this.removeEventListener(
-				this.window,
+				this.document,
 				'contextmenu',
 				this.handleTopMoveEndCapture as any,
 			)
@@ -215,7 +215,7 @@ export class TouchBackendImpl implements Backend {
 
 		if (this.options.enableKeyboardEvents) {
 			this.removeEventListener(
-				this.window,
+				this.document,
 				'keydown',
 				this.handleCancelOnEscape as any,
 				true,
@@ -226,7 +226,7 @@ export class TouchBackendImpl implements Backend {
 	}
 
 	private addEventListener<K extends keyof EventName>(
-		subject: HTMLElement | Window,
+		subject: HTMLElement | Window | Document,
 		event: K,
 		handler: (e: any) => void,
 		capture?: boolean,
@@ -243,7 +243,7 @@ export class TouchBackendImpl implements Backend {
 	}
 
 	private removeEventListener<K extends keyof EventName>(
-		subject: HTMLElement | Window,
+		subject: HTMLElement | Window | Document,
 		event: K,
 		handler: (e: any) => void,
 		capture?: boolean,

--- a/packages/backend-touch/src/TouchBackendImpl.ts
+++ b/packages/backend-touch/src/TouchBackendImpl.ts
@@ -117,9 +117,11 @@ export class TouchBackendImpl implements Backend {
 
 	// public for test
 	public get document(): Document | undefined {
+		
 		if (this.window) {
 			return this.window.document
 		}
+
 		return undefined
 	}
 

--- a/packages/backend-touch/src/TouchBackendImpl.ts
+++ b/packages/backend-touch/src/TouchBackendImpl.ts
@@ -111,18 +111,8 @@ export class TouchBackendImpl implements Backend {
 	}
 
 	// public for test
-	public get window(): Window | undefined {
-		return this.options.window
-	}
-
-	// public for test
 	public get document(): Document | undefined {
-		
-		if (this.window) {
-			return this.window.document
-		}
-
-		return undefined
+		return this.options.document
 	}
 
 	public setup(): void {


### PR DESCRIPTION
In certain projects such as the one I am working on elements are encapsulated so that they are in their own sandbox. In modern browsers you would do this with the ShadowDOM but since we have to support IE 11 we cannot use that API.

We could use a Polyfill but as we are an SDK that would add unneeded weight. Instead we encapsulate by mounting our element within an iframe. 

Unfortunately that breaks some assumptions this library makes. The element is now owned by the document of the iframe and not the root document object meaning events can only be listened to from the document object for the iframe.

The library assumes that it will always be able to get these events from the global document for the window. In this PR I provide an ownerDocument option which allows the consuming project to provide it's own document object for the touch backend to attach its events to.

So within the encapsulated component you can pass in a ref to a `div` element's ownerDocument to the backend, like so:

```js
const collection = () => {
    const container = useRef(null)
    return <div ref={container}>
         <DNDContext options={{ ownerDocument: container.current.ownerDocument} }/>
    <./div>
}
```

Similar changes will need to be made for the HTML5 backend but I wanted to keep this PR focused on one backend.