### PR TITLE
Don't swallow drop events

### DIFF
--- a/.yarn/versions/01c379ac.yml
+++ b/.yarn/versions/01c379ac.yml
@@ -1,0 +1,7 @@
+releases:
+  react-dnd-html5-backend: patch
+
+declined:
+  - react-dnd-documentation
+  - react-dnd-examples-decorators
+  - react-dnd-examples-hooks

--- a/packages/backend-html5/src/HTML5BackendImpl.ts
+++ b/packages/backend-html5/src/HTML5BackendImpl.ts
@@ -649,7 +649,6 @@ export class HTML5BackendImpl implements Backend {
 
 	public handleTopDropCapture = (e: DragEvent): void => {
 		this.dropTargetIds = []
-		e.preventDefault()
 
 		if (this.isDraggingNativeItem()) {
 			this.currentNativeSource?.loadDataTransfer(e.dataTransfer)


### PR DESCRIPTION
Hey! First time contributor here so not really sure what the exprectations of PR:s are. 

This is an attempt to fix this issue, where other libs using html dnd breaks because react-dnd swallows drop events: https://github.com/react-dnd/react-dnd/issues/2752

The fix is simple to not call `e.preventDefault()`. I'm not sure if it's there for a very good reason – it was hard to tell why it was added by looking at the git blame. Anyway, it solves the problem for us and haven't noticed any other issues so far.