### PR TITLE
Fix link of callback ref

### DIFF
--- a/packages/docsite/markdown/docs/00 Quick Start/Overview.md
+++ b/packages/docsite/markdown/docs/00 Quick Start/Overview.md
@@ -85,7 +85,7 @@ render() {
 }
 ```
 
-The `connectDropTarget` call tells React DnD that the root DOM node of our component is a valid drop target, and that its hover and drop events should be handled by the backend. Internally it works by attaching a [callback ref](https://facebook.github.io/react/docs/more-about-refs.html#the-ref-callback-attribute) to the React element you gave it. The function returned by the connector is memoized, so it doesn't break the `shouldComponentUpdate` optimizations.
+The `connectDropTarget` call tells React DnD that the root DOM node of our component is a valid drop target, and that its hover and drop events should be handled by the backend. Internally it works by attaching a [callback ref](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs) to the React element you gave it. The function returned by the connector is memoized, so it doesn't break the `shouldComponentUpdate` optimizations.
 
 ### Drag Sources and Drop Targets
 

--- a/packages/react-dnd/src/utils/cloneWithRef.ts
+++ b/packages/react-dnd/src/utils/cloneWithRef.ts
@@ -18,7 +18,7 @@ export function cloneWithRef(
 		typeof previousRef !== 'string',
 		'Cannot connect React DnD to an element with an existing string ref. ' +
 			'Please convert it to use a callback ref instead, or wrap it into a <span> or <div>. ' +
-			'Read more: https://facebook.github.io/react/docs/more-about-refs.html#the-ref-callback-attribute',
+			'Read more: https://reactjs.org/docs/refs-and-the-dom.html#callback-refs',
 	)
 
 	if (!previousRef) {


### PR DESCRIPTION
It seems that links to the description of callback ref in React doc is outdated.
So I fixed them.