### PR TITLE
Use event processing techniques to improve performance

### DIFF
--- a/.yarn/versions/01c379ac.yml
+++ b/.yarn/versions/01c379ac.yml
@@ -1,6 +1,3 @@
-releases:
-  react-dnd-html5-backend: patch
-
 declined:
   - react-dnd-documentation
   - react-dnd-examples-decorators

--- a/.yarn/versions/6b03c711.yml
+++ b/.yarn/versions/6b03c711.yml
@@ -1,7 +1,3 @@
-releases:
-  react-dnd-html5-backend: minor
-  react-dnd-touch-backend: minor
-
 declined:
   - react-dnd-documentation
   - react-dnd-examples-decorators

--- a/.yarn/versions/813706ed.yml
+++ b/.yarn/versions/813706ed.yml
@@ -1,6 +1,3 @@
-releases:
-  "@react-dnd/build": patch
-
 declined:
   - react-dnd-html5-backend
   - react-dnd-test-backend

--- a/.yarn/versions/9b1fb4e7.yml
+++ b/.yarn/versions/9b1fb4e7.yml
@@ -1,6 +1,3 @@
-releases:
-  react-dnd-html5-backend: patch
-
 declined:
   - react-dnd-documentation
   - react-dnd-examples-decorators

--- a/__tests__/umd-builds.spec.ts
+++ b/__tests__/umd-builds.spec.ts
@@ -1,6 +1,6 @@
 import * as rdnd from 'react-dnd'
 import * as html5 from 'react-dnd-html5-backend'
-import * as touch from 'react-dnd-touch-backend'
+import * as touch from '@pspdfkit/react-dnd-touch-backend'
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 describe('UMD Builds', () => {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "react-dnd-html5-backend": "workspace:packages/backend-html5",
     "react-dnd-test-backend": "workspace:packages/backend-test",
     "react-dnd-test-utils": "workspace:packages/test-utils",
-    "@pspdfkit/react-dnd-touch-backend": "workspace:packages/backend-touch",
+    "react-dnd-touch-backend": "workspace:packages/backend-touch",
     "rimraf": "^3.0.2",
     "typescript": "^4.0.5"
   },

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "react-dnd-html5-backend": "workspace:packages/backend-html5",
     "react-dnd-test-backend": "workspace:packages/backend-test",
     "react-dnd-test-utils": "workspace:packages/test-utils",
-    "react-dnd-touch-backend": "workspace:packages/backend-touch",
+    "@pspdfkit/react-dnd-touch-backend": "workspace:packages/backend-touch",
     "rimraf": "^3.0.2",
     "typescript": "^4.0.5"
   },

--- a/packages/backend-html5/package.json
+++ b/packages/backend-html5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pspdfkit-labs/react-dnd-html5-backend",
-  "version": "11.1.4",
+  "version": "11.1.5",
   "description": "HTML5 backend for React DnD",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/backend-html5/package.json
+++ b/packages/backend-html5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pspdfkit-labs/react-dnd-html5-backend",
-  "version": "11.1.6",
+  "version": "11.1.7",
   "description": "HTML5 backend for React DnD",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/backend-html5/package.json
+++ b/packages/backend-html5/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-dnd-html5-backend",
+  "name": "@pspdfkit-labs/react-dnd-html5-backend",
   "version": "11.1.8",
   "description": "HTML5 backend for React DnD",
   "main": "dist/cjs/index.js",

--- a/packages/backend-html5/package.json
+++ b/packages/backend-html5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pspdfkit-labs/react-dnd-html5-backend",
-  "version": "11.1.5",
+  "version": "11.1.6",
   "description": "HTML5 backend for React DnD",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/backend-html5/package.json
+++ b/packages/backend-html5/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-dnd-html5-backend",
-  "version": "11.1.3",
+  "name": "@pspdfkit-labs/react-dnd-html5-backend",
+  "version": "11.1.4",
   "description": "HTML5 backend for React DnD",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/backend-html5/package.json
+++ b/packages/backend-html5/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pspdfkit-labs/react-dnd-html5-backend",
+  "name": "react-dnd-html5-backend",
   "version": "11.1.8",
   "description": "HTML5 backend for React DnD",
   "main": "dist/cjs/index.js",

--- a/packages/backend-html5/package.json
+++ b/packages/backend-html5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pspdfkit-labs/react-dnd-html5-backend",
-  "version": "11.1.7",
+  "version": "11.1.8",
   "description": "HTML5 backend for React DnD",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/backend-html5/src/HTML5BackendImpl.ts
+++ b/packages/backend-html5/src/HTML5BackendImpl.ts
@@ -29,11 +29,6 @@ declare global {
 	}
 }
 
-// To avoid overloading react - how much should we we wait before sending
-// a new update
-// 
-const UPDATE_INTERVAL = 50 // in ms
-
 export class HTML5BackendImpl implements Backend {
 	private options: OptionsReader
 
@@ -623,7 +618,7 @@ export class HTML5BackendImpl implements Backend {
 		if (this.hoverUpdateTimer === null) {
 
 
-			this.hoverUpdateTimer = setTimeout(() => {
+			this.hoverUpdateTimer = requestAnimationFrame(() => {
 
 				this.actions.hover(dragOverTargetIds || [], {
 					clientOffset: this.lastClientOffset,
@@ -631,7 +626,7 @@ export class HTML5BackendImpl implements Backend {
 
 				this.hoverUpdateTimer = null
 
-			}, UPDATE_INTERVAL)
+			})
 		}
 
 		const canDrop = (dragOverTargetIds || []).some((targetId) =>

--- a/packages/backend-html5/src/HTML5BackendImpl.ts
+++ b/packages/backend-html5/src/HTML5BackendImpl.ts
@@ -96,6 +96,7 @@ export class HTML5BackendImpl implements Backend {
 	}
 
 	public setup(): void {
+
 		if (this.window === undefined) {
 			return
 		}
@@ -103,8 +104,8 @@ export class HTML5BackendImpl implements Backend {
 		if (this.window.__isReactDndBackendSetUp) {
 			throw new Error('Cannot have twL5 backends at the same time.')
 		}
-		this.window.__isReactDndBackendSetUp = true
 
+		this.window.__isReactDndBackendSetUp = true
 		this.addEventListeners(this.document as Node)
 	}
 
@@ -114,7 +115,7 @@ export class HTML5BackendImpl implements Backend {
 		}
 
 		this.window.__isReactDndBackendSetUp = false
-		this.removeEventListeners(this.window as Element)
+		this.removeEventListeners(this.document as Node)
 		this.clearCurrentDragSourceNode()
 		if (this.asyncEndDragFrameId) {
 			this.window.cancelAnimationFrame(this.asyncEndDragFrameId)

--- a/packages/backend-html5/src/HTML5BackendImpl.ts
+++ b/packages/backend-html5/src/HTML5BackendImpl.ts
@@ -21,7 +21,7 @@ import {
 import * as NativeTypes from './NativeTypes'
 import { NativeDragSource } from './NativeDragSources/NativeDragSource'
 import { OptionsReader } from './OptionsReader'
-import { HTML5BackendContext } from './types'
+import { HTML5BackendContext, HTML5BackendOptions } from './types'
 
 declare global {
 	interface Window {
@@ -58,9 +58,10 @@ export class HTML5BackendImpl implements Backend {
 
 	public constructor(
 		manager: DragDropManager,
-		globalContext?: HTML5BackendContext,
+		context?: HTML5BackendContext,
+		options: HTML5BackendOptions = {},
 	) {
-		this.options = new OptionsReader(globalContext)
+		this.options = new OptionsReader(options, context)
 		this.actions = manager.getActions()
 		this.monitor = manager.getMonitor()
 		this.registry = manager.getRegistry()
@@ -97,10 +98,11 @@ export class HTML5BackendImpl implements Backend {
 		}
 
 		if (this.window.__isReactDndBackendSetUp) {
-			throw new Error('Cannot have two HTML5 backends at the same time.')
+			throw new Error('Cannot have twL5 backends at the same time.')
 		}
 		this.window.__isReactDndBackendSetUp = true
-		this.addEventListeners(this.window as Element)
+
+		this.addEventListeners(this.document as Node)
 	}
 
 	public teardown(): void {
@@ -173,6 +175,7 @@ export class HTML5BackendImpl implements Backend {
 
 	private addEventListeners(target: Node) {
 		// SSR Fix (https://github.com/react-dnd/react-dnd/pull/813
+
 		if (!target.addEventListener) {
 			return
 		}
@@ -393,6 +396,7 @@ export class HTML5BackendImpl implements Backend {
 	}
 
 	public handleDragStart(e: DragEvent, sourceId: string): void {
+		
 		if (e.defaultPrevented) {
 			return
 		}
@@ -404,6 +408,7 @@ export class HTML5BackendImpl implements Backend {
 	}
 
 	public handleTopDragStart = (e: DragEvent): void => {
+
 		if (e.defaultPrevented) {
 			return
 		}
@@ -475,6 +480,7 @@ export class HTML5BackendImpl implements Backend {
 
 			// Now we are ready to publish the drag source.. or are we not?
 			const { captureDraggingState } = this.getCurrentSourcePreviewNodeOptions()
+			
 			if (!captureDraggingState) {
 				// Usually we want to publish it in the next tick so that browser
 				// is able to screenshot the current (not yet dragging) state.
@@ -515,6 +521,7 @@ export class HTML5BackendImpl implements Backend {
 	}
 
 	public handleTopDragEndCapture = (): void => {
+
 		if (this.clearCurrentDragSourceNode()) {
 			// Firefox can dispatch this event in an infinite loop
 			// if dragend handler does something like showing an alert.

--- a/packages/backend-html5/src/OptionsReader.ts
+++ b/packages/backend-html5/src/OptionsReader.ts
@@ -1,11 +1,20 @@
-import { HTML5BackendContext } from './types'
+import { HTML5BackendContext, HTML5BackendOptions } from './types'
 
 export class OptionsReader {
 	public ownerDocument: Document | null = null
 	private globalContext: HTML5BackendContext
 
-	public constructor(globalContext: HTML5BackendContext) {
+	public constructor(
+		incoming: HTML5BackendOptions,
+		globalContext: HTML5BackendContext) {
+
 		this.globalContext = globalContext
+
+		Object.keys(incoming).forEach((key) => {
+			if ((incoming as any)[key] != null) {
+				;(this as any)[key] = (incoming as any)[key]
+			}
+		})
 	}
 
 	public get window(): Window | undefined {
@@ -18,7 +27,10 @@ export class OptionsReader {
 	}
 
 	public get document(): Document | undefined {
-		if (this.globalContext?.document) {
+
+		if (this.ownerDocument) {
+			return this.ownerDocument
+		} else if (this.globalContext?.document) {
 			return this.globalContext.document
 		} else if (this.window) {
 			return this.window.document

--- a/packages/backend-html5/src/index.ts
+++ b/packages/backend-html5/src/index.ts
@@ -1,13 +1,14 @@
 import { HTML5BackendImpl } from './HTML5BackendImpl'
 import * as NativeTypes from './NativeTypes'
 import { DragDropManager, BackendFactory } from 'dnd-core'
-import { HTML5BackendContext } from './types'
+import { HTML5BackendContext, HTML5BackendOptions } from './types'
 export { getEmptyImage } from './getEmptyImage'
 export { NativeTypes }
 
 export const HTML5Backend: BackendFactory = function createBackend(
 	manager: DragDropManager,
 	context?: HTML5BackendContext,
+	options?: HTML5BackendOptions
 ): HTML5BackendImpl {
-	return new HTML5BackendImpl(manager, context)
+	return new HTML5BackendImpl(manager, context, options)
 }

--- a/packages/backend-html5/src/types.ts
+++ b/packages/backend-html5/src/types.ts
@@ -1,1 +1,5 @@
 export type HTML5BackendContext = Window | undefined
+
+export interface HTML5BackendOptions {
+	ownerDocument?: Document | null
+}

--- a/packages/backend-touch/backend-touch
+++ b/packages/backend-touch/backend-touch
@@ -1,0 +1,1 @@
+../../../../react-dnd/packages/backend-touch/

--- a/packages/backend-touch/package.json
+++ b/packages/backend-touch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pspdfkit-labs/react-dnd-touch-backend",
-  "version": "11.1.5",
+  "version": "11.1.6",
   "description": "Touch backend for react-dnd",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/backend-touch/package.json
+++ b/packages/backend-touch/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-dnd-touch-backend",
-  "version": "11.2.0",
+  "name": "@pspdfkit/react-dnd-touch-backend",
+  "version": "11.3.0",
   "description": "Touch backend for react-dnd",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/backend-touch/package.json
+++ b/packages/backend-touch/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pspdfkit-labs/react-dnd-touch-backend",
+  "name": "react-dnd-touch-backend",
   "version": "11.1.6",
   "description": "Touch backend for react-dnd",
   "main": "dist/cjs/index.js",

--- a/packages/backend-touch/package.json
+++ b/packages/backend-touch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pspdfkit-labs/react-dnd-touch-backend",
-  "version": "11.1.7",
+  "version": "11.1.8",
   "description": "Touch backend for react-dnd",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/backend-touch/package.json
+++ b/packages/backend-touch/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-dnd-touch-backend",
-  "version": "11.1.6",
+  "name": "@pspdfkit-labs/react-dnd-touch-backend",
+  "version": "11.1.7",
   "description": "Touch backend for react-dnd",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/backend-touch/package.json
+++ b/packages/backend-touch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pspdfkit-labs/react-dnd-touch-backend",
-  "version": "11.2.1",
+  "version": "11.1.5",
   "description": "Touch backend for react-dnd",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/backend-touch/package.json
+++ b/packages/backend-touch/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@pspdfkit/react-dnd-touch-backend",
-  "version": "11.3.0",
+  "name": "@pspdfkit-labs/react-dnd-touch-backend",
+  "version": "11.2.1",
   "description": "Touch backend for react-dnd",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/backend-touch/package.json
+++ b/packages/backend-touch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pspdfkit-labs/react-dnd-touch-backend",
-  "version": "11.1.8",
+  "version": "11.1.9",
   "description": "Touch backend for react-dnd",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/backend-touch/package.json
+++ b/packages/backend-touch/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pspdfkit/react-dnd-touch-backend",
+  "name": "react-dnd-touch-backend",
   "version": "11.2.0",
   "description": "Touch backend for react-dnd",
   "main": "dist/cjs/index.js",

--- a/packages/backend-touch/package.json
+++ b/packages/backend-touch/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-dnd-touch-backend",
-  "version": "11.1.3",
+  "name": "@pspdfkit/react-dnd-touch-backend",
+  "version": "11.2.0",
   "description": "Touch backend for react-dnd",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/backend-touch/src/TouchBackendImpl.ts
+++ b/packages/backend-touch/src/TouchBackendImpl.ts
@@ -385,9 +385,14 @@ export class TouchBackendImpl implements Backend {
 				this.lastTargetTouchFallback = e.targetTouches[0]
 			}
 			this._mouseClientOffset = clientOffset
+			
+			const delay =
+			e.type === eventNames.touch.start
+				? this.options.delayTouchStart
+				: this.options.delayMouseStart
 
 			if (
-				!this.monitor.isDragging() && this.waitingForDelay) {
+				!this.monitor.isDragging() && this.waitingForDelay && delay > 0) {
 
 					const { moveStartSourceIds } = this
 
@@ -411,6 +416,7 @@ export class TouchBackendImpl implements Backend {
 			e.type === eventNames.touch.start
 				? this.options.delayTouchStart
 				: this.options.delayMouseStart
+
 		this.timeout = (setTimeout(
 			this.handleTopMoveStart.bind(this, e as any),
 			delay,

--- a/packages/backend-touch/src/TouchBackendImpl.ts
+++ b/packages/backend-touch/src/TouchBackendImpl.ts
@@ -369,6 +369,7 @@ export class TouchBackendImpl implements Backend {
 	}
 
 	public handleTopMoveStart = (e: MouseEvent | TouchEvent): void => {
+		
 		if (!eventShouldStartDrag(e as MouseEvent)) {
 			return
 		}
@@ -384,11 +385,24 @@ export class TouchBackendImpl implements Backend {
 				this.lastTargetTouchFallback = e.targetTouches[0]
 			}
 			this._mouseClientOffset = clientOffset
+
+			if (
+				!this.monitor.isDragging() && this.waitingForDelay) {
+
+					const { moveStartSourceIds } = this
+
+					this.actions.beginDrag(moveStartSourceIds, {
+						clientOffset: this._mouseClientOffset,
+						getSourceClientOffset: this.getSourceClientOffset,
+						publishSource: false,
+					})
+				}
 		}
 		this.waitingForDelay = false
 	}
 
 	public handleTopMoveStartDelay = (e: Event): void => {
+		
 		if (!eventShouldStartDrag(e as MouseEvent)) {
 			return
 		}

--- a/packages/backend-touch/src/TouchBackendImpl.ts
+++ b/packages/backend-touch/src/TouchBackendImpl.ts
@@ -116,6 +116,7 @@ export class TouchBackendImpl implements Backend {
 	}
 
 	public setup(): void {
+
 		if (!this.document) {
 			return
 		}
@@ -396,6 +397,7 @@ export class TouchBackendImpl implements Backend {
 
 					const { moveStartSourceIds } = this
 
+
 					this.actions.beginDrag(moveStartSourceIds, {
 						clientOffset: this._mouseClientOffset,
 						getSourceClientOffset: this.getSourceClientOffset,
@@ -421,6 +423,7 @@ export class TouchBackendImpl implements Backend {
 			this.handleTopMoveStart.bind(this, e as any),
 			delay,
 		) as any) as ReturnType<typeof setTimeout>
+
 		this.waitingForDelay = true
 	}
 
@@ -438,16 +441,20 @@ export class TouchBackendImpl implements Backend {
 	}
 
 	public handleTopMove = (e: TouchEvent | MouseEvent): void => {
-		if (this.timeout) {
-			clearTimeout(this.timeout)
-		}
+
 		if (!this.document || this.waitingForDelay) {
 			return
 		}
+
+		if (this.timeout) {
+			clearTimeout(this.timeout)
+		}
+
 		const { moveStartSourceIds, dragOverTargetIds } = this
 		const enableHoverOutsideTarget = this.options.enableHoverOutsideTarget
 
 		const clientOffset = getEventClientOffset(e, this.lastTargetTouchFallback)
+
 
 		if (!clientOffset) {
 			return

--- a/packages/docsite/package.json
+++ b/packages/docsite/package.json
@@ -29,7 +29,7 @@
     "react-dnd-examples-hooks": "workspace:packages/examples-hooks",
     "react-dnd-html5-backend": "workspace:packages/backend-html5",
     "react-dnd-test-backend": "workspace:packages/backend-test",
-    "react-dnd-touch-backend": "workspace:packages/backend-touch",
+    "@pspdfkit/react-dnd-touch-backend": "workspace:packages/backend-touch",
     "react-dom": "^16.14.0",
     "react-error-overlay": "^6.0.8",
     "react-helmet": "^6.1.0",


### PR DESCRIPTION
During testing of our SDK it appears that some browsers can emit screen tearing on lower end devices. Potentially this is sue to slow event handling during screen renders.

During profiling I found some event handlers could take as much as 3 seconds to fire on a VM with very low memory and low core counts. Which goes over our frame budget.

I've tried the following techniques which seem to result in event handlers taking 20 - 50ms to fire which should allow for more timely updates during repaints.

- We throttle mouse/touch events to only handle them every 50 milliseconds as most move updates only translate to a very minor move.
- Instead of requesting an animation update on every move we start an animation frame update loop when we detect the first move which means we will get regular frame updates when the browser is ready to handle them.

I also attempted to make all event handlers passive but it appears in a few places events are cancelled. Potentially this is another optimisation that can be done if needed.