### PR TITLE
Fix babelEsmConfig path

### DIFF
--- a/packages/build/src/tasks/babel.ts
+++ b/packages/build/src/tasks/babel.ts
@@ -8,7 +8,7 @@ import plumber = require('gulp-plumber')
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 const babelCjsConfig = require('../../config/babel.config.cjs')
-const babelEsmConfig = require('../../config/babel.config.cjs')
+const babelEsmConfig = require('../../config/babel.config')
 /* eslint-enable  @typescript-eslint/no-var-requires */
 
 const BABEL_GLOBS = ['lib/**/*.js']


### PR DESCRIPTION
While looking through the `react-dnd` build process I noticed that the path to the config file for the ESM builds was the same as the path to the config file for the CJS builds, so both `dist/esm` and `dist/cjs` get the same contents. 

No releases have been affected by this, as the last release (11.1.3) predates this build configuration.

This sets the correct path for the ESM Babel config file.