### PR TITLE
HTML5Backend Event Swallowing Updates

### DIFF
--- a/.yarn/versions/9c51b640.yml
+++ b/.yarn/versions/9c51b640.yml
@@ -1,8 +1,3 @@
 releases:
+  react-dnd: patch
   react-dnd-html5-backend: minor
-
-declined:
-  - react-dnd-documentation
-  - react-dnd-examples-decorators
-  - react-dnd-examples-hooks
-  - react-dnd-test-utils

--- a/.yarn/versions/9c51b640.yml
+++ b/.yarn/versions/9c51b640.yml
@@ -1,3 +1,9 @@
 releases:
   react-dnd: patch
   react-dnd-html5-backend: minor
+
+declined:
+  - react-dnd-documentation
+  - react-dnd-examples-decorators
+  - react-dnd-examples-hooks
+  - react-dnd-test-utils

--- a/.yarn/versions/9c51b640.yml
+++ b/.yarn/versions/9c51b640.yml
@@ -1,0 +1,8 @@
+releases:
+  react-dnd-html5-backend: minor
+
+declined:
+  - react-dnd-documentation
+  - react-dnd-examples-decorators
+  - react-dnd-examples-hooks
+  - react-dnd-test-utils

--- a/packages/backend-html5/src/HTML5BackendImpl.ts
+++ b/packages/backend-html5/src/HTML5BackendImpl.ts
@@ -569,8 +569,6 @@ export class HTML5BackendImpl implements Backend {
 		)
 
 		if (canDrop) {
-			// IE requires this to fire dragover events
-			e.preventDefault()
 			if (e.dataTransfer) {
 				e.dataTransfer.dropEffect = this.getCurrentDropEffect()
 			}

--- a/packages/backend-html5/src/HTML5BackendImpl.ts
+++ b/packages/backend-html5/src/HTML5BackendImpl.ts
@@ -90,7 +90,7 @@ export class HTML5BackendImpl implements Backend {
 	/**
 	 * Get the root element to use for event subscriptions
 	 */
-	public get rootElement(): Node | undefined {
+	private get rootElement(): Node | undefined {
 		return this.options.rootElement as Node
 	}
 
@@ -634,9 +634,7 @@ export class HTML5BackendImpl implements Backend {
 
 	public handleTopDragLeaveCapture = (e: DragEvent): void => {
 		if (this.isDraggingNativeItem()) {
-			if (!this.options.unblockNativeTypeEvents) {
-				e.preventDefault()
-			}
+			e.preventDefault()
 		}
 
 		const isLastLeave = this.enterLeaveCounter.leave(e.target)
@@ -653,9 +651,7 @@ export class HTML5BackendImpl implements Backend {
 		this.dropTargetIds = []
 
 		if (this.isDraggingNativeItem()) {
-			if (!this.options.unblockNativeTypeEvents) {
-				e.preventDefault()
-			}
+			e.preventDefault()
 			this.currentNativeSource?.loadDataTransfer(e.dataTransfer)
 		}
 

--- a/packages/backend-html5/src/HTML5BackendImpl.ts
+++ b/packages/backend-html5/src/HTML5BackendImpl.ts
@@ -611,9 +611,8 @@ export class HTML5BackendImpl implements Backend {
 	public handleTopDragLeaveCapture = (e: DragEvent): void => {
 		if (this.isDraggingNativeItem()) {
 			if (!this.options.unblockNativeTypeEvents) {
-				!this.options.unblockNativeTypeEvents
+				e.preventDefault()
 			}
-			e.preventDefault()
 		}
 
 		const isLastLeave = this.enterLeaveCounter.leave(e.target)

--- a/packages/backend-html5/src/HTML5BackendImpl.ts
+++ b/packages/backend-html5/src/HTML5BackendImpl.ts
@@ -571,6 +571,8 @@ export class HTML5BackendImpl implements Backend {
 		)
 
 		if (canDrop) {
+			// IE requires this to fire dragover events
+			e.preventDefault()
 			if (e.dataTransfer) {
 				e.dataTransfer.dropEffect = this.getCurrentDropEffect()
 			}
@@ -593,6 +595,9 @@ export class HTML5BackendImpl implements Backend {
 		this.dragOverTargetIds = []
 
 		if (!this.monitor.isDragging()) {
+			// This is probably a native item type we don't understand.
+			// Prevent default "drop and blow away the whole document" action.
+			e.preventDefault()
 			if (e.dataTransfer) {
 				e.dataTransfer.dropEffect = 'none'
 			}
@@ -615,7 +620,12 @@ export class HTML5BackendImpl implements Backend {
 			if (e.dataTransfer) {
 				e.dataTransfer.dropEffect = this.getCurrentDropEffect()
 			}
+		} else if (this.isDraggingNativeItem()) {
+			// Don't show a nice cursor but still prevent default
+			// "drop and blow away the whole document" action.
+			e.preventDefault()
 		} else {
+			e.preventDefault()
 			if (e.dataTransfer) {
 				e.dataTransfer.dropEffect = 'none'
 			}
@@ -624,9 +634,9 @@ export class HTML5BackendImpl implements Backend {
 
 	public handleTopDragLeaveCapture = (e: DragEvent): void => {
 		if (this.isDraggingNativeItem()) {
-			if (!this.options.unblockNativeTypeEvents) {
-				e.preventDefault()
-			}
+			// if (!this.options.unblockNativeTypeEvents) {
+			e.preventDefault()
+			// }
 		}
 
 		const isLastLeave = this.enterLeaveCounter.leave(e.target)
@@ -643,9 +653,9 @@ export class HTML5BackendImpl implements Backend {
 		this.dropTargetIds = []
 
 		if (this.isDraggingNativeItem()) {
-			if (!this.options.unblockNativeTypeEvents) {
-				e.preventDefault()
-			}
+			// if (!this.options.unblockNativeTypeEvents) {
+			e.preventDefault()
+			// }
 			this.currentNativeSource?.loadDataTransfer(e.dataTransfer)
 		}
 

--- a/packages/backend-html5/src/HTML5BackendImpl.ts
+++ b/packages/backend-html5/src/HTML5BackendImpl.ts
@@ -91,6 +91,12 @@ export class HTML5BackendImpl implements Backend {
 	public get document(): Document | undefined {
 		return this.options.document
 	}
+	/**
+	 * Get the root element to use for event subscriptions
+	 */
+	public get rootElement(): Node | undefined {
+		return this.options.rootElement as Node
+	}
 
 	public setup(): void {
 		if (this.window === undefined) {
@@ -101,7 +107,7 @@ export class HTML5BackendImpl implements Backend {
 			throw new Error('Cannot have two HTML5 backends at the same time.')
 		}
 		this.window.__isReactDndBackendSetUp = true
-		this.addEventListeners(this.window as Element)
+		this.addEventListeners(this.options.rootElement as Node)
 	}
 
 	public teardown(): void {
@@ -110,7 +116,7 @@ export class HTML5BackendImpl implements Backend {
 		}
 
 		this.window.__isReactDndBackendSetUp = false
-		this.removeEventListeners(this.window as Element)
+		this.removeEventListeners(this.rootElement as Element)
 		this.clearCurrentDragSourceNode()
 		if (this.asyncEndDragFrameId) {
 			this.window.cancelAnimationFrame(this.asyncEndDragFrameId)
@@ -357,13 +363,10 @@ export class HTML5BackendImpl implements Backend {
 		//   * https://github.com/react-dnd/react-dnd/issues/869
 		//
 		this.mouseMoveTimeoutTimer = (setTimeout(() => {
-			return (
-				this.window &&
-				this.window.addEventListener(
-					'mousemove',
-					this.endDragIfSourceWasRemovedFromDOM,
-					true,
-				)
+			return this.rootElement?.addEventListener(
+				'mousemove',
+				this.endDragIfSourceWasRemovedFromDOM,
+				true,
 			)
 		}, MOUSE_MOVE_TIMEOUT) as any) as number
 	}
@@ -372,9 +375,9 @@ export class HTML5BackendImpl implements Backend {
 		if (this.currentDragSourceNode) {
 			this.currentDragSourceNode = null
 
-			if (this.window) {
-				this.window.clearTimeout(this.mouseMoveTimeoutTimer || undefined)
-				this.window.removeEventListener(
+			if (this.rootElement) {
+				this.window?.clearTimeout(this.mouseMoveTimeoutTimer || undefined)
+				this.rootElement.removeEventListener(
 					'mousemove',
 					this.endDragIfSourceWasRemovedFromDOM,
 					true,

--- a/packages/backend-html5/src/HTML5BackendImpl.ts
+++ b/packages/backend-html5/src/HTML5BackendImpl.ts
@@ -693,9 +693,6 @@ export class HTML5BackendImpl implements Backend {
 			return
 		}
 
-		// For other targets, ask IE
-		// to enable drag and drop
-		e.preventDefault()
 		target.dragDrop()
 	}
 }

--- a/packages/backend-html5/src/HTML5BackendImpl.ts
+++ b/packages/backend-html5/src/HTML5BackendImpl.ts
@@ -329,11 +329,11 @@ export class HTML5BackendImpl implements Backend {
 
 	private endDragIfSourceWasRemovedFromDOM = (): void => {
 		const node = this.currentDragSourceNode
-		if (this.isNodeInDocument(node)) {
+		if (node == null || this.isNodeInDocument(node)) {
 			return
 		}
 
-		if (this.clearCurrentDragSourceNode()) {
+		if (this.clearCurrentDragSourceNode() && this.monitor.isDragging()) {
 			this.actions.endDrag()
 		}
 	}
@@ -517,7 +517,7 @@ export class HTML5BackendImpl implements Backend {
 	}
 
 	public handleTopDragEndCapture = (): void => {
-		if (this.clearCurrentDragSourceNode()) {
+		if (this.clearCurrentDragSourceNode() && this.monitor.isDragging()) {
 			// Firefox can dispatch this event in an infinite loop
 			// if dragend handler does something like showing an alert.
 			// Only proceed if we have not handled it already.
@@ -643,7 +643,7 @@ export class HTML5BackendImpl implements Backend {
 		}
 
 		if (this.isDraggingNativeItem()) {
-			this.endDragNativeItem()
+			setTimeout(() => this.endDragNativeItem(), 0)
 		}
 	}
 
@@ -673,7 +673,7 @@ export class HTML5BackendImpl implements Backend {
 
 		if (this.isDraggingNativeItem()) {
 			this.endDragNativeItem()
-		} else {
+		} else if (this.monitor.isDragging()) {
 			this.actions.endDrag()
 		}
 	}

--- a/packages/backend-html5/src/HTML5BackendImpl.ts
+++ b/packages/backend-html5/src/HTML5BackendImpl.ts
@@ -634,9 +634,9 @@ export class HTML5BackendImpl implements Backend {
 
 	public handleTopDragLeaveCapture = (e: DragEvent): void => {
 		if (this.isDraggingNativeItem()) {
-			// if (!this.options.unblockNativeTypeEvents) {
-			e.preventDefault()
-			// }
+			if (!this.options.unblockNativeTypeEvents) {
+				e.preventDefault()
+			}
 		}
 
 		const isLastLeave = this.enterLeaveCounter.leave(e.target)
@@ -653,9 +653,9 @@ export class HTML5BackendImpl implements Backend {
 		this.dropTargetIds = []
 
 		if (this.isDraggingNativeItem()) {
-			// if (!this.options.unblockNativeTypeEvents) {
-			e.preventDefault()
-			// }
+			if (!this.options.unblockNativeTypeEvents) {
+				e.preventDefault()
+			}
 			this.currentNativeSource?.loadDataTransfer(e.dataTransfer)
 		}
 
@@ -701,6 +701,9 @@ export class HTML5BackendImpl implements Backend {
 			return
 		}
 
+		// For other targets, ask IE
+		// to enable drag and drop
+		e.preventDefault()
 		target.dragDrop()
 	}
 }

--- a/packages/backend-html5/src/OptionsReader.ts
+++ b/packages/backend-html5/src/OptionsReader.ts
@@ -32,6 +32,10 @@ export class OptionsReader {
 		}
 	}
 
+	public get rootElement(): Node | undefined {
+		return this.optionsArgs?.rootElement || this.window
+	}
+
 	public get unblockNativeTypeEvents(): boolean {
 		return this.optionsArgs?.unblockNativeTypeEvents || false
 	}

--- a/packages/backend-html5/src/OptionsReader.ts
+++ b/packages/backend-html5/src/OptionsReader.ts
@@ -35,8 +35,4 @@ export class OptionsReader {
 	public get rootElement(): Node | undefined {
 		return this.optionsArgs?.rootElement || this.window
 	}
-
-	public get unblockNativeTypeEvents(): boolean {
-		return this.optionsArgs?.unblockNativeTypeEvents || false
-	}
 }

--- a/packages/backend-html5/src/OptionsReader.ts
+++ b/packages/backend-html5/src/OptionsReader.ts
@@ -1,11 +1,16 @@
-import { HTML5BackendContext } from './types'
+import { HTML5BackendContext, HTML5BackendOptions } from './types'
 
 export class OptionsReader {
 	public ownerDocument: Document | null = null
 	private globalContext: HTML5BackendContext
+	private optionsArgs?: HTML5BackendOptions
 
-	public constructor(globalContext: HTML5BackendContext) {
+	public constructor(
+		globalContext: HTML5BackendContext,
+		options?: HTML5BackendOptions,
+	) {
 		this.globalContext = globalContext
+		this.optionsArgs = options
 	}
 
 	public get window(): Window | undefined {
@@ -25,5 +30,9 @@ export class OptionsReader {
 		} else {
 			return undefined
 		}
+	}
+
+	public get unblockNativeTypeEvents(): boolean {
+		return this.optionsArgs?.unblockNativeTypeEvents || false
 	}
 }

--- a/packages/backend-html5/src/index.ts
+++ b/packages/backend-html5/src/index.ts
@@ -1,13 +1,14 @@
 import { HTML5BackendImpl } from './HTML5BackendImpl'
 import * as NativeTypes from './NativeTypes'
 import { DragDropManager, BackendFactory } from 'dnd-core'
-import { HTML5BackendContext } from './types'
+import { HTML5BackendContext, HTML5BackendOptions } from './types'
 export { getEmptyImage } from './getEmptyImage'
 export { NativeTypes }
 
 export const HTML5Backend: BackendFactory = function createBackend(
 	manager: DragDropManager,
 	context?: HTML5BackendContext,
+	options?: HTML5BackendOptions,
 ): HTML5BackendImpl {
-	return new HTML5BackendImpl(manager, context)
+	return new HTML5BackendImpl(manager, context, options)
 }

--- a/packages/backend-html5/src/types.ts
+++ b/packages/backend-html5/src/types.ts
@@ -5,6 +5,10 @@ export type HTML5BackendContext = Window | undefined
  */
 export interface HTML5BackendOptions {
 	/**
+	 * The root DOM node for subscribing to events
+	 */
+	rootElement: Node
+	/**
 	 * Unblocks processing of drag events for native types (e.g. files, etc..).
 	 * This may cause unexpected behavior in systems where these events are not
 	 * captured and handled by applications.

--- a/packages/backend-html5/src/types.ts
+++ b/packages/backend-html5/src/types.ts
@@ -1,1 +1,13 @@
 export type HTML5BackendContext = Window | undefined
+
+/**
+ * Configuration options for the HTML5Backend
+ */
+export interface HTML5BackendOptions {
+	/**
+	 * Unblocks processing of drag events for native types (e.g. files, etc..).
+	 * This may cause unexpected behavior in systems where these events are not
+	 * captured and handled by applications.
+	 */
+	unblockNativeTypeEvents?: boolean
+}

--- a/packages/backend-html5/src/types.ts
+++ b/packages/backend-html5/src/types.ts
@@ -5,13 +5,7 @@ export type HTML5BackendContext = Window | undefined
  */
 export interface HTML5BackendOptions {
 	/**
-	 * The root DOM node for subscribing to events
+	 * The root DOM node to use for subscribing to events. Default=Window
 	 */
 	rootElement: Node
-	/**
-	 * Unblocks processing of drag events for native types (e.g. files, etc..).
-	 * This may cause unexpected behavior in systems where these events are not
-	 * captured and handled by applications.
-	 */
-	unblockNativeTypeEvents?: boolean
 }

--- a/packages/docsite/src/components/layout.tsx
+++ b/packages/docsite/src/components/layout.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 declare const require: any
 
-import { FC, memo } from 'react'
+import { FC, memo, useMemo, useCallback, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import styled from 'styled-components'
 import { HTML5Backend } from 'react-dnd-html5-backend'
@@ -43,6 +43,9 @@ export const Layout: FC<LayoutProps> = memo(function Layout(props) {
 	const hideSidebar = props.hideSidebar || sitepath === '/about'
 	const debugMode = isDebugMode()
 	const touchBackend = isTouchBackend()
+	const [dndArea, setDndArea] = useState<HTMLDivElement | null>(null)
+	const html5Options = useMemo(() => ({ rootElement: dndArea }), [dndArea])
+
 	return (
 		<>
 			<Helmet title="React DnD" meta={HEADER_META} link={HEADER_LINK}>
@@ -53,25 +56,30 @@ export const Layout: FC<LayoutProps> = memo(function Layout(props) {
 				/>
 			</Helmet>
 			<Header debugMode={debugMode} touchBackend={touchBackend} />
-			<DndProvider
-				backend={touchBackend ? TouchBackend : HTML5Backend}
-				options={touchBackend ? touchBackendOptions : undefined}
-				debugMode={debugMode}
-			>
-				<ContentContainer>
-					<PageBody hasSidebar={sitepath !== '/about'}>
-						{hideSidebar ? null : (
-							<SidebarContainer>
-								<Sidebar
-									groups={sidebarItems}
-									location={location ? location.pathname : '/'}
-								/>
-							</SidebarContainer>
+
+			<ContentContainer>
+				<PageBody hasSidebar={sitepath !== '/about'}>
+					{hideSidebar ? null : (
+						<SidebarContainer>
+							<Sidebar
+								groups={sidebarItems}
+								location={location ? location.pathname : '/'}
+							/>
+						</SidebarContainer>
+					)}
+					<ChildrenContainer ref={useCallback((node) => setDndArea(node), [])}>
+						{dndArea == null ? null : (
+							<DndProvider
+								backend={touchBackend ? TouchBackend : HTML5Backend}
+								options={touchBackend ? touchBackendOptions : html5Options}
+								debugMode={debugMode}
+							>
+								{children}
+							</DndProvider>
 						)}
-						<ChildrenContainer>{children}</ChildrenContainer>
-					</PageBody>
-				</ContentContainer>
-			</DndProvider>
+					</ChildrenContainer>
+				</PageBody>
+			</ContentContainer>
 		</>
 	)
 })

--- a/packages/react-dnd/src/hooks/useDrop.ts
+++ b/packages/react-dnd/src/hooks/useDrop.ts
@@ -89,6 +89,14 @@ function useDropHandler<
 		} as DropTarget
 	}, [monitor])
 
+	/**
+	 * If we pass in spec.current.accept directly, the React hook will
+	 * re-fire when the array-instance changes. Instead, we pass the
+	 * accept items directly into the deps if it's an array
+	 */
+	const specDeps = Array.isArray(spec.current?.accept)
+		? spec.current?.accept
+		: [spec.current.accept]
 	useIsomorphicLayoutEffect(
 		function registerHandler() {
 			const [handlerId, unregister] = registerTarget(
@@ -100,6 +108,6 @@ function useDropHandler<
 			connector.receiveHandlerId(handlerId)
 			return unregister
 		},
-		[monitor, connector, spec.current.accept],
+		[monitor, connector, ...specDeps],
 	)
 }


### PR DESCRIPTION
This PR removes some events swallowing that was occurring in the HTML5Backend. Some of this may cause regressions in older browsers or edge case situtaions. The goal here is to minimize our interference with natural event patterns.

There are a few instances of `preventDefault()` that were either unavoidable or needed to be selectively disabled depending on the needs of clients. In the latter case we provide a configuration option in the HTML5Backend for `unblockNativeTypeEvents`

@tommoor related to #2852 
Usage:
```jsx
<DndProvider backend={HTML5Backend} options={{unblockNativeTypeEvents: true}}> 
{/* app *}
</DndProvider>
```

Fixes #3051 
