### PR TITLE
Update useDrag(), useDrop() to accept a spec-creating function instead of a spec

### DIFF
--- a/packages/dnd-core/src/classes/DragDropMonitorImpl.ts
+++ b/packages/dnd-core/src/classes/DragDropMonitorImpl.ts
@@ -79,7 +79,7 @@ export class DragDropMonitorImpl implements DragDropMonitor {
 			return false
 		}
 		const source = this.registry.getSource(sourceId)
-		invariant(source, 'Expected to find a valid source.')
+		invariant(source, `Expected to find a valid source. sourceId=${sourceId}`)
 
 		if (this.isDragging()) {
 			return false
@@ -94,7 +94,7 @@ export class DragDropMonitorImpl implements DragDropMonitor {
 			return false
 		}
 		const target = this.registry.getTarget(targetId)
-		invariant(target, 'Expected to find a valid target.')
+		invariant(target, `Expected to find a valid target. targetId=${targetId}`)
 
 		if (!this.isDragging() || this.didDrop()) {
 			return false
@@ -117,7 +117,7 @@ export class DragDropMonitorImpl implements DragDropMonitor {
 			return false
 		}
 		const source = this.registry.getSource(sourceId, true)
-		invariant(source, 'Expected to find a valid source.')
+		invariant(source, `Expected to find a valid source. sourceId=${sourceId}`)
 
 		if (!this.isDragging() || !this.isSourcePublic()) {
 			return false

--- a/packages/docsite/markdown/docs/03 Using Hooks/HooksOverview.md
+++ b/packages/docsite/markdown/docs/03 Using Hooks/HooksOverview.md
@@ -26,7 +26,7 @@ To start using hooks, let's make a box draggable.
 import { useDrag } from 'react-dnd'
 
 function Box() {
-  const [{ isDragging }, drag, dragPreview] = useDrag({
+  const [{ isDragging }, drag, dragPreview] = useDrag(() => ({
 		// "type" is required. It is used by the "accept" specification of drop targets.
     item: { type: 'BOX' },
 		// The collect function utilizes a "monitor" instance (see the Overview for what this is)
@@ -34,15 +34,15 @@ function Box() {
     collect: (monitor) => ({
       isDragging: monitor.isDragging()
     })
+  }))
 
-		return (
-			{/* This is optional. The dragPreview will be attached to the dragSource by default */}
-			<div ref={dragPreview} style={{ opacity: isDragging ? 0.5 : 1}}>
-			   {/* The drag ref marks this node as being the "pick-up" node */}
-				 <div role="Handle" ref={drag}>
-			</div>
-		)
-  })
+  return (
+    {/* This is optional. The dragPreview will be attached to the dragSource by default */}
+    <div ref={dragPreview} style={{ opacity: isDragging ? 0.5 : 1}}>
+        {/* The drag ref marks this node as being the "pick-up" node */}
+        <div role="Handle" ref={drag}>
+    </div>
+  )
 }
 ```
 
@@ -50,7 +50,7 @@ Now, let's make something for this to drag into.
 
 ```jsx
 function Bucket() {
-  const [{ canDrop, isOver }, drop] = useDrop({
+  const [{ canDrop, isOver }, drop] = useDrop(() => ({
     // The type (or types) to accept - strings or symbols
     accept: 'BOX',
     // Props to collect
@@ -58,7 +58,7 @@ function Bucket() {
       isOver: monitor.isOver(),
       canDrop: monitor.canDrop()
     })
-  })
+  }))
 
   return (
     <div

--- a/packages/docsite/markdown/docs/03 Using Hooks/useDrag.md
+++ b/packages/docsite/markdown/docs/03 Using Hooks/useDrag.md
@@ -15,9 +15,9 @@ The `useDrag`hook provides a way to wire your component into the DnD system as a
 import { useDrag } from 'react-dnd'
 
 function DraggableComponent(props) {
-  const [collected, drag, dragPreview] = useDrag({
+  const [collected, drag, dragPreview] = useDrag(() => ({
     item: { id, type }
-  })
+  }))
   return collected.isDragging ?
     <div ref={dragPreview> : (
     <div ref={drag} {...collected}>
@@ -29,7 +29,8 @@ function DraggableComponent(props) {
 
 #### Parameters
 
-- **`spec`** A specification object, see below for details on how to construct this
+- **`spec`** A function that creates a specification object (recommended), or a specification object. See below for details on how to construct this
+- **`deps`** A dependency array used for memoization. This behaves like the built-in `useMemo` React hook. The default value is an empty array for function spec, and an array containing the spec for an object spec.
 
 #### Return Value Array
 

--- a/packages/docsite/markdown/docs/03 Using Hooks/useDrop.md
+++ b/packages/docsite/markdown/docs/03 Using Hooks/useDrop.md
@@ -15,9 +15,9 @@ The `useDrop` hook provides a way for you to wire in your component into the DnD
 import { useDrop } from 'react-dnd'
 
 function myDropTarget(props) {
-  const [collectedProps, drop] = useDrop({
+  const [collectedProps, drop] = useDrop(() => ({
     accept
-  })
+  }))
 
   return <div ref={drop}>Drop Target</div>
 }
@@ -25,7 +25,8 @@ function myDropTarget(props) {
 
 #### Parameters
 
-- **`spec`** A specification object, see below for details on how to construct this
+- **`spec`** A function that creates a specification object (recommended), or a specification object. See below for details on how to construct this
+- **`deps`** A dependency array used for memoization. This behaves like the built-in `useMemo` React hook. The default value is an empty array for function spec, and an array containing the spec for an object spec.
 
 #### Return Value Array
 

--- a/packages/docsite/markdown/docs/docsRoot.md
+++ b/packages/docsite/markdown/docs/docsRoot.md
@@ -26,12 +26,15 @@ import { ItemTypes } from './Constants'
  * Your Component
  */
 export default function Card({ isDragging, text }) {
-  const [{ opacity }, dragRef] = useDrag({
-    item: { type: ItemTypes.CARD, text },
-    collect: (monitor) => ({
-      opacity: monitor.isDragging() ? 0.5 : 1
-    })
-  })
+  const [{ opacity }, dragRef] = useDrag(
+    () => ({
+      item: { type: ItemTypes.CARD, text },
+      collect: (monitor) => ({
+        opacity: monitor.isDragging() ? 0.5 : 1
+      })
+    }),
+    []
+  )
   return (
     <div ref={dragRef} style={{ opacity }}>
       {text}

--- a/packages/examples-hooks/src/00-chessboard/BoardSquare.tsx
+++ b/packages/examples-hooks/src/00-chessboard/BoardSquare.tsx
@@ -17,15 +17,18 @@ export const BoardSquare: FC<BoardSquareProps> = ({
 	children,
 	game,
 }: BoardSquareProps) => {
-	const [{ isOver, canDrop }, drop] = useDrop({
-		accept: ItemTypes.KNIGHT,
-		canDrop: () => game.canMoveKnight(x, y),
-		drop: () => game.moveKnight(x, y),
-		collect: (monitor) => ({
-			isOver: !!monitor.isOver(),
-			canDrop: !!monitor.canDrop(),
+	const [{ isOver, canDrop }, drop] = useDrop(
+		() => ({
+			accept: ItemTypes.KNIGHT,
+			canDrop: () => game.canMoveKnight(x, y),
+			drop: () => game.moveKnight(x, y),
+			collect: (monitor) => ({
+				isOver: !!monitor.isOver(),
+				canDrop: !!monitor.canDrop(),
+			}),
 		}),
-	})
+		[game],
+	)
 	const black = (x + y) % 2 === 1
 
 	return (

--- a/packages/examples-hooks/src/00-chessboard/Knight.tsx
+++ b/packages/examples-hooks/src/00-chessboard/Knight.tsx
@@ -10,12 +10,15 @@ const knightStyle: CSSProperties = {
 }
 
 export const Knight: FC = () => {
-	const [{ isDragging }, drag, preview] = useDrag({
-		item: { type: ItemTypes.KNIGHT },
-		collect: (monitor) => ({
-			isDragging: !!monitor.isDragging(),
+	const [{ isDragging }, drag, preview] = useDrag(
+		() => ({
+			item: { type: ItemTypes.KNIGHT },
+			collect: (monitor) => ({
+				isDragging: !!monitor.isDragging(),
+			}),
 		}),
-	})
+		[],
+	)
 
 	return (
 		<>

--- a/packages/examples-hooks/src/01-dustbin/copy-or-move/Box.tsx
+++ b/packages/examples-hooks/src/01-dustbin/copy-or-move/Box.tsx
@@ -27,31 +27,33 @@ interface DragItem {
 }
 
 export const Box: FC<BoxProps> = ({ name }) => {
-	const item = { name, type: ItemTypes.BOX }
-	const [{ opacity }, drag] = useDrag({
-		item,
-		end(item: DragItem | undefined, monitor: DragSourceMonitor) {
-			const dropResult: DropResult = monitor.getDropResult()
-			if (item && dropResult) {
-				let alertMessage = ''
-				const isDropAllowed =
-					dropResult.allowedDropEffect === 'any' ||
-					dropResult.allowedDropEffect === dropResult.dropEffect
+	const [{ opacity }, drag] = useDrag(
+		() => ({
+			item: { name, type: ItemTypes.BOX },
+			end(item: DragItem | undefined, monitor: DragSourceMonitor) {
+				const dropResult: DropResult = monitor.getDropResult()
+				if (item && dropResult) {
+					let alertMessage = ''
+					const isDropAllowed =
+						dropResult.allowedDropEffect === 'any' ||
+						dropResult.allowedDropEffect === dropResult.dropEffect
 
-				if (isDropAllowed) {
-					const isCopyAction = dropResult.dropEffect === 'copy'
-					const actionName = isCopyAction ? 'copied' : 'moved'
-					alertMessage = `You ${actionName} ${item.name} into ${dropResult.name}!`
-				} else {
-					alertMessage = `You cannot ${dropResult.dropEffect} an item into the ${dropResult.name}`
+					if (isDropAllowed) {
+						const isCopyAction = dropResult.dropEffect === 'copy'
+						const actionName = isCopyAction ? 'copied' : 'moved'
+						alertMessage = `You ${actionName} ${item.name} into ${dropResult.name}!`
+					} else {
+						alertMessage = `You cannot ${dropResult.dropEffect} an item into the ${dropResult.name}`
+					}
+					alert(alertMessage)
 				}
-				alert(alertMessage)
-			}
-		},
-		collect: (monitor: any) => ({
-			opacity: monitor.isDragging() ? 0.4 : 1,
+			},
+			collect: (monitor: any) => ({
+				opacity: monitor.isDragging() ? 0.4 : 1,
+			}),
 		}),
-	})
+		[name],
+	)
 
 	return (
 		<div ref={drag} style={{ ...style, opacity }}>

--- a/packages/examples-hooks/src/01-dustbin/copy-or-move/Dustbin.tsx
+++ b/packages/examples-hooks/src/01-dustbin/copy-or-move/Dustbin.tsx
@@ -30,17 +30,20 @@ function selectBackgroundColor(isActive: boolean, canDrop: boolean) {
 }
 
 export const Dustbin: FC<DustbinProps> = ({ allowedDropEffect }) => {
-	const [{ canDrop, isOver }, drop] = useDrop({
-		accept: ItemTypes.BOX,
-		drop: () => ({
-			name: `${allowedDropEffect} Dustbin`,
-			allowedDropEffect,
+	const [{ canDrop, isOver }, drop] = useDrop(
+		() => ({
+			accept: ItemTypes.BOX,
+			drop: () => ({
+				name: `${allowedDropEffect} Dustbin`,
+				allowedDropEffect,
+			}),
+			collect: (monitor: any) => ({
+				isOver: monitor.isOver(),
+				canDrop: monitor.canDrop(),
+			}),
 		}),
-		collect: (monitor: any) => ({
-			isOver: monitor.isOver(),
-			canDrop: monitor.canDrop(),
-		}),
-	})
+		[allowedDropEffect],
+	)
 
 	const isActive = canDrop && isOver
 	const backgroundColor = selectBackgroundColor(isActive, canDrop)

--- a/packages/examples-hooks/src/01-dustbin/multiple-targets/Box.tsx
+++ b/packages/examples-hooks/src/01-dustbin/multiple-targets/Box.tsx
@@ -18,12 +18,15 @@ export interface BoxProps {
 }
 
 export const Box: FC<BoxProps> = memo(function Box({ name, type, isDropped }) {
-	const [{ opacity }, drag] = useDrag({
-		item: { name, type },
-		collect: (monitor) => ({
-			opacity: monitor.isDragging() ? 0.4 : 1,
+	const [{ opacity }, drag] = useDrag(
+		() => ({
+			item: { name, type },
+			collect: (monitor) => ({
+				opacity: monitor.isDragging() ? 0.4 : 1,
+			}),
 		}),
-	})
+		[name, type],
+	)
 
 	return (
 		<div ref={drag} role="Box" style={{ ...style, opacity }}>

--- a/packages/examples-hooks/src/01-dustbin/multiple-targets/Dustbin.tsx
+++ b/packages/examples-hooks/src/01-dustbin/multiple-targets/Dustbin.tsx
@@ -25,14 +25,17 @@ export const Dustbin: FC<DustbinProps> = memo(function Dustbin({
 	lastDroppedItem,
 	onDrop,
 }) {
-	const [{ isOver, canDrop }, drop] = useDrop({
-		accept,
-		drop: onDrop,
-		collect: (monitor) => ({
-			isOver: monitor.isOver(),
-			canDrop: monitor.canDrop(),
+	const [{ isOver, canDrop }, drop] = useDrop(
+		() => ({
+			accept,
+			drop: onDrop,
+			collect: (monitor) => ({
+				isOver: monitor.isOver(),
+				canDrop: monitor.canDrop(),
+			}),
 		}),
-	})
+		[accept, onDrop],
+	)
 
 	const isActive = isOver && canDrop
 	let backgroundColor = '#222'

--- a/packages/examples-hooks/src/01-dustbin/single-target-in-iframe/Box.tsx
+++ b/packages/examples-hooks/src/01-dustbin/single-target-in-iframe/Box.tsx
@@ -17,18 +17,21 @@ interface BoxProps {
 }
 
 export const Box: FC<BoxProps> = ({ name }) => {
-	const [{ isDragging }, drag] = useDrag({
-		item: { name, type: ItemTypes.BOX },
-		end: (item: { name: string } | undefined, monitor: DragSourceMonitor) => {
-			const dropResult = monitor.getDropResult()
-			if (item && dropResult) {
-				alert(`You dropped ${item.name} into ${dropResult.name}!`)
-			}
-		},
-		collect: (monitor) => ({
-			isDragging: monitor.isDragging(),
+	const [{ isDragging }, drag] = useDrag(
+		() => ({
+			item: { name, type: ItemTypes.BOX },
+			end: (item: { name: string } | undefined, monitor: DragSourceMonitor) => {
+				const dropResult = monitor.getDropResult()
+				if (item && dropResult) {
+					alert(`You dropped ${item.name} into ${dropResult.name}!`)
+				}
+			},
+			collect: (monitor) => ({
+				isDragging: monitor.isDragging(),
+			}),
 		}),
-	})
+		[name],
+	)
 	const opacity = isDragging ? 0.4 : 1
 
 	return (

--- a/packages/examples-hooks/src/01-dustbin/single-target-in-iframe/Dustbin.tsx
+++ b/packages/examples-hooks/src/01-dustbin/single-target-in-iframe/Dustbin.tsx
@@ -16,14 +16,14 @@ const style: CSSProperties = {
 }
 
 export const Dustbin: FC = () => {
-	const [{ canDrop, isOver }, drop] = useDrop({
+	const [{ canDrop, isOver }, drop] = useDrop(() => ({
 		accept: ItemTypes.BOX,
 		drop: () => ({ name: 'Dustbin' }),
 		collect: (monitor) => ({
 			isOver: monitor.isOver(),
 			canDrop: monitor.canDrop(),
 		}),
-	})
+	}))
 
 	const isActive = canDrop && isOver
 	let backgroundColor = '#222'

--- a/packages/examples-hooks/src/01-dustbin/single-target/Box.tsx
+++ b/packages/examples-hooks/src/01-dustbin/single-target/Box.tsx
@@ -17,7 +17,7 @@ export interface BoxProps {
 }
 
 export const Box: FC<BoxProps> = function Box({ name }) {
-	const [{ isDragging }, drag] = useDrag({
+	const [{ isDragging }, drag] = useDrag(() => ({
 		item: { name, type: ItemTypes.BOX },
 		end: (item: { name: string } | undefined, monitor: DragSourceMonitor) => {
 			const dropResult = monitor.getDropResult()
@@ -29,7 +29,7 @@ export const Box: FC<BoxProps> = function Box({ name }) {
 			isDragging: monitor.isDragging(),
 			handlerId: monitor.getHandlerId(),
 		}),
-	})
+	}))
 
 	const opacity = isDragging ? 0.4 : 1
 	return (

--- a/packages/examples-hooks/src/01-dustbin/single-target/Dustbin.tsx
+++ b/packages/examples-hooks/src/01-dustbin/single-target/Dustbin.tsx
@@ -16,14 +16,14 @@ const style: CSSProperties = {
 }
 
 export const Dustbin: FC = () => {
-	const [{ canDrop, isOver }, drop] = useDrop({
+	const [{ canDrop, isOver }, drop] = useDrop(() => ({
 		accept: ItemTypes.BOX,
 		drop: () => ({ name: 'Dustbin' }),
 		collect: (monitor) => ({
 			isOver: monitor.isOver(),
 			canDrop: monitor.canDrop(),
 		}),
-	})
+	}))
 
 	const isActive = canDrop && isOver
 	let backgroundColor = '#222'

--- a/packages/examples-hooks/src/01-dustbin/stress-test/Box.tsx
+++ b/packages/examples-hooks/src/01-dustbin/stress-test/Box.tsx
@@ -18,16 +18,19 @@ export interface BoxProps {
 }
 
 export const Box: FC<BoxProps> = ({ name, type, isDropped }) => {
-	const [{ isDragging }, drag] = useDrag({
-		item: { name, type },
-		isDragging(monitor) {
-			const item = monitor.getItem()
-			return name === item.name
-		},
-		collect: (monitor) => ({
-			isDragging: monitor.isDragging(),
+	const [{ isDragging }, drag] = useDrag(
+		() => ({
+			item: { name, type },
+			isDragging(monitor) {
+				const item = monitor.getItem()
+				return name === item.name
+			},
+			collect: (monitor) => ({
+				isDragging: monitor.isDragging(),
+			}),
 		}),
-	})
+		[name, type],
+	)
 
 	const opacity = isDragging ? 0.4 : 1
 

--- a/packages/examples-hooks/src/01-dustbin/stress-test/Dustbin.tsx
+++ b/packages/examples-hooks/src/01-dustbin/stress-test/Dustbin.tsx
@@ -25,14 +25,14 @@ export const Dustbin: FC<DustbinProps> = ({
 	accepts: accept,
 	onDrop,
 }) => {
-	const [{ isOver, canDrop }, drop] = useDrop({
+	const [{ isOver, canDrop }, drop] = useDrop(() => ({
 		accept,
 		collect: (monitor) => ({
 			isOver: monitor.isOver(),
 			canDrop: monitor.canDrop(),
 		}),
-		drop: (item) => onDrop(item),
-	})
+		drop: (item: unknown) => onDrop(item),
+	}))
 
 	const isActive = isOver && canDrop
 	let backgroundColor = '#222'

--- a/packages/examples-hooks/src/02-drag-around/custom-drag-layer/Container.tsx
+++ b/packages/examples-hooks/src/02-drag-around/custom-drag-layer/Container.tsx
@@ -40,24 +40,27 @@ export const Container: FC<ContainerProps> = ({ snapToGrid }) => {
 		[boxes],
 	)
 
-	const [, drop] = useDrop({
-		accept: ItemTypes.BOX,
-		drop(item: DragItem, monitor) {
-			const delta = monitor.getDifferenceFromInitialOffset() as {
-				x: number
-				y: number
-			}
+	const [, drop] = useDrop(
+		() => ({
+			accept: ItemTypes.BOX,
+			drop(item: DragItem, monitor) {
+				const delta = monitor.getDifferenceFromInitialOffset() as {
+					x: number
+					y: number
+				}
 
-			let left = Math.round(item.left + delta.x)
-			let top = Math.round(item.top + delta.y)
-			if (snapToGrid) {
-				;[left, top] = doSnapToGrid(left, top)
-			}
+				let left = Math.round(item.left + delta.x)
+				let top = Math.round(item.top + delta.y)
+				if (snapToGrid) {
+					;[left, top] = doSnapToGrid(left, top)
+				}
 
-			moveBox(item.id, left, top)
-			return undefined
-		},
-	})
+				moveBox(item.id, left, top)
+				return undefined
+			},
+		}),
+		[moveBox],
+	)
 
 	return (
 		<div ref={drop} style={styles}>

--- a/packages/examples-hooks/src/02-drag-around/custom-drag-layer/DraggableBox.tsx
+++ b/packages/examples-hooks/src/02-drag-around/custom-drag-layer/DraggableBox.tsx
@@ -30,12 +30,15 @@ export interface DraggableBoxProps {
 
 export const DraggableBox: FC<DraggableBoxProps> = (props) => {
 	const { id, title, left, top } = props
-	const [{ isDragging }, drag, preview] = useDrag({
-		item: { type: ItemTypes.BOX, id, left, top, title },
-		collect: (monitor: DragSourceMonitor) => ({
-			isDragging: monitor.isDragging(),
+	const [{ isDragging }, drag, preview] = useDrag(
+		() => ({
+			item: { type: ItemTypes.BOX, id, left, top, title },
+			collect: (monitor: DragSourceMonitor) => ({
+				isDragging: monitor.isDragging(),
+			}),
 		}),
-	})
+		[id, left, top, title],
+	)
 
 	useEffect(() => {
 		preview(getEmptyImage(), { captureDraggingState: true })

--- a/packages/examples-hooks/src/02-drag-around/naive/Box.tsx
+++ b/packages/examples-hooks/src/02-drag-around/naive/Box.tsx
@@ -24,12 +24,15 @@ export const Box: FC<BoxProps> = ({
 	hideSourceOnDrag,
 	children,
 }) => {
-	const [{ isDragging }, drag] = useDrag({
-		item: { id, left, top, type: ItemTypes.BOX },
-		collect: (monitor) => ({
-			isDragging: monitor.isDragging(),
+	const [{ isDragging }, drag] = useDrag(
+		() => ({
+			item: { id, left, top, type: ItemTypes.BOX },
+			collect: (monitor) => ({
+				isDragging: monitor.isDragging(),
+			}),
 		}),
-	})
+		[id, left, top],
+	)
 
 	if (isDragging && hideSourceOnDrag) {
 		return <div ref={drag} />

--- a/packages/examples-hooks/src/02-drag-around/naive/Container.tsx
+++ b/packages/examples-hooks/src/02-drag-around/naive/Container.tsx
@@ -32,7 +32,7 @@ export const Container: FC<ContainerProps> = ({ hideSourceOnDrag }) => {
 		b: { top: 180, left: 20, title: 'Drag me too' },
 	})
 
-	const [, drop] = useDrop({
+	const [, drop] = useDrop(() => ({
 		accept: ItemTypes.BOX,
 		drop(item: DragItem, monitor) {
 			const delta = monitor.getDifferenceFromInitialOffset() as XYCoord
@@ -41,7 +41,7 @@ export const Container: FC<ContainerProps> = ({ hideSourceOnDrag }) => {
 			moveBox(item.id, left, top)
 			return undefined
 		},
-	})
+	}))
 
 	const moveBox = (id: string, left: number, top: number) => {
 		setBoxes(

--- a/packages/examples-hooks/src/03-nesting/drag-sources/SourceBox.tsx
+++ b/packages/examples-hooks/src/03-nesting/drag-sources/SourceBox.tsx
@@ -15,17 +15,20 @@ export interface SourceBoxProps {
 
 export const SourceBox: FC<SourceBoxProps> = ({ color, children }) => {
 	const [forbidDrag, setForbidDrag] = useState(false)
-	const [{ isDragging }, drag] = useDrag({
-		item: { type: `${color}` },
-		canDrag: !forbidDrag,
-		collect: (monitor: DragSourceMonitor) => ({
-			isDragging: monitor.isDragging(),
+	const [{ isDragging }, drag] = useDrag(
+		() => ({
+			item: { type: `${color}` },
+			canDrag: !forbidDrag,
+			collect: (monitor: DragSourceMonitor) => ({
+				isDragging: monitor.isDragging(),
+			}),
 		}),
-	})
+		[forbidDrag, color],
+	)
 
 	const onToggleForbidDrag = useCallback(() => {
 		setForbidDrag(!forbidDrag)
-	}, [forbidDrag])
+	}, [forbidDrag, setForbidDrag])
 
 	const backgroundColor = useMemo(() => {
 		switch (color) {

--- a/packages/examples-hooks/src/03-nesting/drag-sources/TargetBox.tsx
+++ b/packages/examples-hooks/src/03-nesting/drag-sources/TargetBox.tsx
@@ -1,5 +1,5 @@
 import { CSSProperties, FC, useState, useCallback } from 'react'
-import { useDrop } from 'react-dnd'
+import { useDrop, DropTargetMonitor } from 'react-dnd'
 import { Colors } from './Colors'
 import { DragItem } from './interfaces'
 
@@ -17,18 +17,21 @@ export interface TargetBoxProps {
 }
 
 const TargetBox: FC<TargetBoxProps> = ({ onDrop, lastDroppedColor }) => {
-	const [{ isOver, draggingColor, canDrop }, drop] = useDrop({
-		accept: [Colors.YELLOW, Colors.BLUE],
-		drop(item: DragItem) {
-			onDrop(item.type)
-			return undefined
-		},
-		collect: (monitor) => ({
-			isOver: monitor.isOver(),
-			canDrop: monitor.canDrop(),
-			draggingColor: monitor.getItemType() as string,
+	const [{ isOver, draggingColor, canDrop }, drop] = useDrop(
+		() => ({
+			accept: [Colors.YELLOW, Colors.BLUE],
+			drop(item: DragItem) {
+				onDrop(item.type)
+				return undefined
+			},
+			collect: (monitor: DropTargetMonitor) => ({
+				isOver: monitor.isOver(),
+				canDrop: monitor.canDrop(),
+				draggingColor: monitor.getItemType() as string,
+			}),
 		}),
-	})
+		[onDrop],
+	)
 
 	const opacity = isOver ? 1 : 0.7
 	let backgroundColor = '#fff'

--- a/packages/examples-hooks/src/03-nesting/drop-targets/Box.tsx
+++ b/packages/examples-hooks/src/03-nesting/drop-targets/Box.tsx
@@ -11,7 +11,7 @@ const style = {
 }
 
 export const Box: FC = () => {
-	const [, drag] = useDrag({ item: { type: ItemTypes.BOX } })
+	const [, drag] = useDrag(() => ({ item: { type: ItemTypes.BOX } }))
 	return (
 		<div ref={drag} style={style}>
 			Drag me

--- a/packages/examples-hooks/src/03-nesting/drop-targets/Dustbin.tsx
+++ b/packages/examples-hooks/src/03-nesting/drop-targets/Dustbin.tsx
@@ -31,21 +31,24 @@ export const Dustbin: FC<DustbinProps> = ({ greedy, children }) => {
 	const [hasDropped, setHasDropped] = useState(false)
 	const [hasDroppedOnChild, setHasDroppedOnChild] = useState(false)
 
-	const [{ isOver, isOverCurrent }, drop] = useDrop({
-		accept: ItemTypes.BOX,
-		drop(item, monitor) {
-			const didDrop = monitor.didDrop()
-			if (didDrop && !greedy) {
-				return
-			}
-			setHasDropped(true)
-			setHasDroppedOnChild(didDrop)
-		},
-		collect: (monitor) => ({
-			isOver: monitor.isOver(),
-			isOverCurrent: monitor.isOver({ shallow: true }),
+	const [{ isOver, isOverCurrent }, drop] = useDrop(
+		() => ({
+			accept: ItemTypes.BOX,
+			drop(item: unknown, monitor) {
+				const didDrop = monitor.didDrop()
+				if (didDrop && !greedy) {
+					return
+				}
+				setHasDropped(true)
+				setHasDroppedOnChild(didDrop)
+			},
+			collect: (monitor) => ({
+				isOver: monitor.isOver(),
+				isOverCurrent: monitor.isOver({ shallow: true }),
+			}),
 		}),
-	})
+		[greedy, setHasDropped, setHasDroppedOnChild],
+	)
 
 	const text = greedy ? 'greedy' : 'not greedy'
 	let backgroundColor = 'rgba(0, 0, 0, .5)'

--- a/packages/examples-hooks/src/04-sortable/cancel-on-drop-outside/Card.tsx
+++ b/packages/examples-hooks/src/04-sortable/cancel-on-drop-outside/Card.tsx
@@ -25,21 +25,24 @@ interface Item {
 
 export const Card: FC<CardProps> = ({ id, text, moveCard, findCard }) => {
 	const originalIndex = findCard(id).index
-	const [{ isDragging }, drag] = useDrag({
-		item: { type: ItemTypes.CARD, id, originalIndex },
-		collect: (monitor) => ({
-			isDragging: monitor.isDragging(),
+	const [{ isDragging }, drag] = useDrag(
+		() => ({
+			item: { type: ItemTypes.CARD, id, originalIndex },
+			collect: (monitor) => ({
+				isDragging: monitor.isDragging(),
+			}),
+			end: (dropResult: unknown, monitor) => {
+				const { id: droppedId, originalIndex } = monitor.getItem()
+				const didDrop = monitor.didDrop()
+				if (!didDrop) {
+					moveCard(droppedId, originalIndex)
+				}
+			},
 		}),
-		end: (dropResult, monitor) => {
-			const { id: droppedId, originalIndex } = monitor.getItem()
-			const didDrop = monitor.didDrop()
-			if (!didDrop) {
-				moveCard(droppedId, originalIndex)
-			}
-		},
-	})
+		[id, originalIndex],
+	)
 
-	const [, drop] = useDrop({
+	const [, drop] = useDrop(() => ({
 		accept: ItemTypes.CARD,
 		canDrop: () => false,
 		hover({ id: draggedId }: Item) {
@@ -48,7 +51,7 @@ export const Card: FC<CardProps> = ({ id, text, moveCard, findCard }) => {
 				moveCard(draggedId, overIndex)
 			}
 		},
-	})
+	}))
 
 	const opacity = isDragging ? 0 : 1
 	return (

--- a/packages/examples-hooks/src/04-sortable/cancel-on-drop-outside/Container.tsx
+++ b/packages/examples-hooks/src/04-sortable/cancel-on-drop-outside/Container.tsx
@@ -65,7 +65,7 @@ export const Container: FC = () => {
 		}
 	}
 
-	const [, drop] = useDrop({ accept: ItemTypes.CARD })
+	const [, drop] = useDrop(() => ({ accept: ItemTypes.CARD }))
 	return (
 		<>
 			<div ref={drop} style={style}>

--- a/packages/examples-hooks/src/04-sortable/simple/Card.tsx
+++ b/packages/examples-hooks/src/04-sortable/simple/Card.tsx
@@ -25,64 +25,70 @@ interface DragItem {
 }
 export const Card: FC<CardProps> = ({ id, text, index, moveCard }) => {
 	const ref = useRef<HTMLDivElement>(null)
-	const [, drop] = useDrop({
-		accept: ItemTypes.CARD,
-		hover(item: DragItem, monitor: DropTargetMonitor) {
-			if (!ref.current) {
-				return
-			}
-			const dragIndex = item.index
-			const hoverIndex = index
+	const [, drop] = useDrop(
+		() => ({
+			accept: ItemTypes.CARD,
+			hover(item: DragItem, monitor: DropTargetMonitor) {
+				if (!ref.current) {
+					return
+				}
+				const dragIndex = item.index
+				const hoverIndex = index
 
-			// Don't replace items with themselves
-			if (dragIndex === hoverIndex) {
-				return
-			}
+				// Don't replace items with themselves
+				if (dragIndex === hoverIndex) {
+					return
+				}
 
-			// Determine rectangle on screen
-			const hoverBoundingRect = ref.current?.getBoundingClientRect()
+				// Determine rectangle on screen
+				const hoverBoundingRect = ref.current?.getBoundingClientRect()
 
-			// Get vertical middle
-			const hoverMiddleY =
-				(hoverBoundingRect.bottom - hoverBoundingRect.top) / 2
+				// Get vertical middle
+				const hoverMiddleY =
+					(hoverBoundingRect.bottom - hoverBoundingRect.top) / 2
 
-			// Determine mouse position
-			const clientOffset = monitor.getClientOffset()
+				// Determine mouse position
+				const clientOffset = monitor.getClientOffset()
 
-			// Get pixels to the top
-			const hoverClientY = (clientOffset as XYCoord).y - hoverBoundingRect.top
+				// Get pixels to the top
+				const hoverClientY = (clientOffset as XYCoord).y - hoverBoundingRect.top
 
-			// Only perform the move when the mouse has crossed half of the items height
-			// When dragging downwards, only move when the cursor is below 50%
-			// When dragging upwards, only move when the cursor is above 50%
+				// Only perform the move when the mouse has crossed half of the items height
+				// When dragging downwards, only move when the cursor is below 50%
+				// When dragging upwards, only move when the cursor is above 50%
 
-			// Dragging downwards
-			if (dragIndex < hoverIndex && hoverClientY < hoverMiddleY) {
-				return
-			}
+				// Dragging downwards
+				if (dragIndex < hoverIndex && hoverClientY < hoverMiddleY) {
+					return
+				}
 
-			// Dragging upwards
-			if (dragIndex > hoverIndex && hoverClientY > hoverMiddleY) {
-				return
-			}
+				// Dragging upwards
+				if (dragIndex > hoverIndex && hoverClientY > hoverMiddleY) {
+					return
+				}
 
-			// Time to actually perform the action
-			moveCard(dragIndex, hoverIndex)
+				// Time to actually perform the action
+				moveCard(dragIndex, hoverIndex)
 
-			// Note: we're mutating the monitor item here!
-			// Generally it's better to avoid mutations,
-			// but it's good here for the sake of performance
-			// to avoid expensive index searches.
-			item.index = hoverIndex
-		},
-	})
-
-	const [{ isDragging }, drag] = useDrag({
-		item: { type: ItemTypes.CARD, id, index },
-		collect: (monitor: any) => ({
-			isDragging: monitor.isDragging(),
+				// Note: we're mutating the monitor item here!
+				// Generally it's better to avoid mutations,
+				// but it's good here for the sake of performance
+				// to avoid expensive index searches.
+				item.index = hoverIndex
+			},
 		}),
-	})
+		[index, moveCard],
+	)
+
+	const [{ isDragging }, drag] = useDrag(
+		() => ({
+			item: { type: ItemTypes.CARD, id, index },
+			collect: (monitor: any) => ({
+				isDragging: monitor.isDragging(),
+			}),
+		}),
+		[id, index],
+	)
 
 	const opacity = isDragging ? 0 : 1
 	drag(drop(ref))

--- a/packages/examples-hooks/src/04-sortable/stress-test/Card.tsx
+++ b/packages/examples-hooks/src/04-sortable/stress-test/Card.tsx
@@ -18,7 +18,7 @@ export interface CardProps {
 
 export const Card: FC<CardProps> = memo(({ id, text, moveCard }) => {
 	const ref = useRef(null)
-	const [{ isDragging }, connectDrag] = useDrag({
+	const [{ isDragging }, connectDrag] = useDrag(() => ({
 		item: { id, type: ItemTypes.CARD },
 		collect: (monitor: any) => {
 			const result = {
@@ -26,16 +26,19 @@ export const Card: FC<CardProps> = memo(({ id, text, moveCard }) => {
 			}
 			return result
 		},
-	})
+	}))
 
-	const [, connectDrop] = useDrop({
-		accept: ItemTypes.CARD,
-		hover({ id: draggedId }: { id: string; type: string }) {
-			if (draggedId !== id) {
-				moveCard(draggedId, id)
-			}
-		},
-	})
+	const [, connectDrop] = useDrop(
+		() => ({
+			accept: ItemTypes.CARD,
+			hover({ id: draggedId }: { id: string; type: string }) {
+				if (draggedId !== id) {
+					moveCard(draggedId, id)
+				}
+			},
+		}),
+		[id, moveCard],
+	)
 
 	connectDrag(ref)
 	connectDrop(ref)

--- a/packages/examples-hooks/src/05-customize/drop-effects/SourceBox.tsx
+++ b/packages/examples-hooks/src/05-customize/drop-effects/SourceBox.tsx
@@ -16,15 +16,18 @@ export interface SourceBoxProps {
 }
 
 export const SourceBox: FC<SourceBoxProps> = ({ showCopyIcon }) => {
-	const [{ opacity }, drag] = useDrag({
-		item: { type: ItemTypes.BOX },
-		options: {
-			dropEffect: showCopyIcon ? 'copy' : 'move',
-		},
-		collect: (monitor) => ({
-			opacity: monitor.isDragging() ? 0.4 : 1,
+	const [{ opacity }, drag] = useDrag(
+		() => ({
+			item: { type: ItemTypes.BOX },
+			options: {
+				dropEffect: showCopyIcon ? 'copy' : 'move',
+			},
+			collect: (monitor) => ({
+				opacity: monitor.isDragging() ? 0.4 : 1,
+			}),
 		}),
-	})
+		[showCopyIcon],
+	)
 
 	return (
 		<div ref={drag} style={{ ...style, opacity }}>

--- a/packages/examples-hooks/src/05-customize/drop-effects/TargetBox.tsx
+++ b/packages/examples-hooks/src/05-customize/drop-effects/TargetBox.tsx
@@ -11,12 +11,12 @@ const style: CSSProperties = {
 }
 
 export const TargetBox: FC = () => {
-	const [{ isActive }, drop] = useDrop({
+	const [{ isActive }, drop] = useDrop(() => ({
 		accept: ItemTypes.BOX,
 		collect: (monitor) => ({
 			isActive: monitor.canDrop() && monitor.isOver(),
 		}),
-	})
+	}))
 
 	return (
 		<div ref={drop} style={style}>

--- a/packages/examples-hooks/src/05-customize/handles-and-previews/BoxWithHandle.tsx
+++ b/packages/examples-hooks/src/05-customize/handles-and-previews/BoxWithHandle.tsx
@@ -20,12 +20,12 @@ const handleStyle: CSSProperties = {
 }
 
 export const BoxWithHandle: FC = () => {
-	const [{ opacity }, drag, preview] = useDrag({
+	const [{ opacity }, drag, preview] = useDrag(() => ({
 		item: { type: ItemTypes.BOX },
 		collect: (monitor) => ({
 			opacity: monitor.isDragging() ? 0.4 : 1,
 		}),
-	})
+	}))
 
 	return (
 		<div ref={preview} style={{ ...style, opacity }}>

--- a/packages/examples-hooks/src/05-customize/handles-and-previews/BoxWithImage.tsx
+++ b/packages/examples-hooks/src/05-customize/handles-and-previews/BoxWithImage.tsx
@@ -13,12 +13,12 @@ const style: CSSProperties = {
 }
 
 export const BoxWithImage: FC = () => {
-	const [{ opacity }, drag, preview] = useDrag({
+	const [{ opacity }, drag, preview] = useDrag(() => ({
 		item: { type: ItemTypes.BOX },
 		collect: (monitor) => ({
 			opacity: monitor.isDragging() ? 0.4 : 1,
 		}),
-	})
+	}))
 
 	return (
 		<>

--- a/packages/examples-hooks/src/06-other/native-files/TargetBox.tsx
+++ b/packages/examples-hooks/src/06-other/native-files/TargetBox.tsx
@@ -16,18 +16,21 @@ export interface TargetBoxProps {
 
 export const TargetBox: FC<TargetBoxProps> = (props) => {
 	const { onDrop } = props
-	const [{ canDrop, isOver }, drop] = useDrop({
-		accept: [NativeTypes.FILE],
-		drop(item, monitor) {
-			if (onDrop) {
-				onDrop(props, monitor)
-			}
-		},
-		collect: (monitor) => ({
-			isOver: monitor.isOver(),
-			canDrop: monitor.canDrop(),
+	const [{ canDrop, isOver }, drop] = useDrop(
+		() => ({
+			accept: [NativeTypes.FILE],
+			drop(item: unknown, monitor: DropTargetMonitor) {
+				if (onDrop) {
+					onDrop(props, monitor)
+				}
+			},
+			collect: (monitor: DropTargetMonitor) => ({
+				isOver: monitor.isOver(),
+				canDrop: monitor.canDrop(),
+			}),
 		}),
-	})
+		[props],
+	)
 
 	const isActive = canDrop && isOver
 	return (

--- a/packages/examples-hooks/src/06-other/native-html/TargetBox.tsx
+++ b/packages/examples-hooks/src/06-other/native-html/TargetBox.tsx
@@ -16,18 +16,21 @@ export interface TargetBoxProps {
 
 export const TargetBox: FC<TargetBoxProps> = (props) => {
 	const { onDrop } = props
-	const [{ canDrop, isOver }, drop] = useDrop({
-		accept: [NativeTypes.HTML],
-		drop(item, monitor) {
-			if (onDrop) {
-				onDrop(props, monitor)
-			}
-		},
-		collect: (monitor) => ({
-			isOver: monitor.isOver(),
-			canDrop: monitor.canDrop(),
+	const [{ canDrop, isOver }, drop] = useDrop(
+		() => ({
+			accept: [NativeTypes.HTML],
+			drop(item: unknown, monitor: DropTargetMonitor) {
+				if (onDrop) {
+					onDrop(props, monitor)
+				}
+			},
+			collect: (monitor: DropTargetMonitor) => ({
+				isOver: monitor.isOver(),
+				canDrop: monitor.canDrop(),
+			}),
 		}),
-	})
+		[props],
+	)
 
 	const isActive = canDrop && isOver
 	return (

--- a/packages/examples-hooks/src/07-regression/chained-connectors/BoxWithHandle.tsx
+++ b/packages/examples-hooks/src/07-regression/chained-connectors/BoxWithHandle.tsx
@@ -19,17 +19,17 @@ const handleStyle: CSSProperties = {
 }
 
 export const BoxWithHandle: FC = () => {
-	const [, drop] = useDrop({
+	const [, drop] = useDrop(() => ({
 		accept: ItemTypes.BOX,
-	})
-	const [{ isDragging }, drag, preview] = useDrag({
+	}))
+	const [{ isDragging }, drag, preview] = useDrag(() => ({
 		item: {
 			type: ItemTypes.BOX,
 		},
 		collect: (monitor) => ({
 			isDragging: monitor.isDragging(),
 		}),
-	})
+	}))
 	const opacity = isDragging ? 0.4 : 1
 	return drop(
 		preview(

--- a/packages/examples-hooks/src/07-regression/drag-source-rerender/Example.tsx
+++ b/packages/examples-hooks/src/07-regression/drag-source-rerender/Example.tsx
@@ -2,12 +2,12 @@ import { FC, useState, useCallback } from 'react'
 import { useDrag, ConnectDragSource } from 'react-dnd'
 
 export const Example: FC = () => {
-	const [{ isDragging }, drag] = useDrag({
+	const [{ isDragging }, drag] = useDrag(() => ({
 		item: { type: 'KNIGHT' },
 		collect: (monitor) => ({
 			isDragging: monitor.isDragging(),
 		}),
-	})
+	}))
 
 	return <Child drag={drag}>{isDragging ? 'Dragging' : 'Drag me'}</Child>
 }

--- a/packages/examples-hooks/src/07-regression/previews-memory-leak/BoxWithHandle.tsx
+++ b/packages/examples-hooks/src/07-regression/previews-memory-leak/BoxWithHandle.tsx
@@ -18,12 +18,12 @@ const handleStyle: CSSProperties = {
 	cursor: 'move',
 }
 export const BoxWithHandle: FC = () => {
-	const [{ opacity }, drag, preview] = useDrag({
+	const [{ opacity }, drag, preview] = useDrag(() => ({
 		item: { type: ItemTypes.BOX },
 		collect: (monitor) => ({
 			opacity: monitor.isDragging() ? 0.4 : 1,
 		}),
-	})
+	}))
 	return (
 		<div ref={preview} style={{ ...style, opacity }}>
 			<div ref={drag} style={handleStyle} />

--- a/packages/examples-hooks/src/07-regression/previews-memory-leak/BoxWithImage.tsx
+++ b/packages/examples-hooks/src/07-regression/previews-memory-leak/BoxWithImage.tsx
@@ -12,12 +12,12 @@ const style: CSSProperties = {
 	width: '20rem',
 }
 export const BoxWithImage: FC = () => {
-	const [{ opacity }, drag, preview] = useDrag({
+	const [{ opacity }, drag, preview] = useDrag(() => ({
 		item: { type: ItemTypes.BOX },
 		collect: (monitor) => ({
 			opacity: monitor.isDragging() ? 0.4 : 1,
 		}),
-	})
+	}))
 	return (
 		<>
 			<DragPreviewImage connect={preview} src={boxImage} />

--- a/packages/examples-hooks/src/07-regression/remount-with-correct-props/SourceBox.tsx
+++ b/packages/examples-hooks/src/07-regression/remount-with-correct-props/SourceBox.tsx
@@ -21,13 +21,13 @@ export const SourceBox: FC<SourceBoxProps> = ({
 	onBeginDrag,
 	onEndDrag,
 }) => {
-	const [{ isDragging }, drag] = useDrag({
+	const [{ isDragging }, drag] = useDrag(() => ({
 		item: { type: ItemTypes.BOX, id },
 		isDragging: (monitor) => monitor.getItem().id === id,
 		collect: (monitor) => ({ isDragging: monitor.isDragging() }),
 		begin: onBeginDrag,
 		end: onEndDrag,
-	})
+	}))
 
 	return (
 		<div ref={drag} style={getStyle(isDragging)}>

--- a/packages/examples-hooks/src/07-regression/remount-with-correct-props/TargetBox.tsx
+++ b/packages/examples-hooks/src/07-regression/remount-with-correct-props/TargetBox.tsx
@@ -11,12 +11,12 @@ const style: CSSProperties = {
 }
 
 export const TargetBox: FC = () => {
-	const [{ isActive }, drop] = useDrop({
+	const [{ isActive }, drop] = useDrop(() => ({
 		accept: ItemTypes.BOX,
 		collect: (monitor) => ({
 			isActive: monitor.canDrop() && monitor.isOver(),
 		}),
-	})
+	}))
 	return (
 		<div ref={drop} style={style}>
 			{isActive ? 'Release to drop' : 'Drag item here'}

--- a/packages/react-dnd/src/hooks/useDrop.ts
+++ b/packages/react-dnd/src/hooks/useDrop.ts
@@ -1,4 +1,4 @@
-import { useRef, useMemo, MutableRefObject } from 'react'
+import { useMemo } from 'react'
 import { invariant } from '@react-dnd/invariant'
 import { DropTarget } from 'dnd-core'
 import { ConnectDropTarget, DropTargetMonitor } from '../types'
@@ -14,25 +14,26 @@ import { useDragDropManager } from './useDragDropManager'
 
 /**
  * useDropTarget Hook
- * @param spec The drop target specification
+ * @param spec The drop target specification (object or function, function preferred)
+ * @param deps The memoization deps array to use when evaluating spec changes
  */
 export function useDrop<
 	DragObject extends DragObjectWithType,
 	DropResult,
 	CollectedProps
 >(
-	spec: DropTargetHookSpec<DragObject, DropResult, CollectedProps>,
+	specFn: () => DropTargetHookSpec<DragObject, DropResult, CollectedProps>,
+	deps?: unknown[],
 ): [CollectedProps, ConnectDropTarget] {
-	const specRef = useRef(spec)
-	specRef.current = spec
+	const spec = useMemo(specFn, deps || [])
 	invariant(spec.accept != null, 'accept must be defined')
 
 	const [monitor, connector] = useDropTargetMonitor()
-	useDropHandler(specRef, monitor, connector)
+	useDropHandler(spec, monitor, connector)
 
 	const result: CollectedProps = useMonitorOutput(
 		monitor,
-		specRef.current.collect || (() => ({} as CollectedProps)),
+		spec.collect || (() => ({} as CollectedProps)),
 		() => connector.reconnect(),
 	)
 
@@ -61,9 +62,7 @@ function useDropHandler<
 	DropResult,
 	CustomProps
 >(
-	spec: MutableRefObject<
-		DropTargetHookSpec<DragObject, DropResult, CustomProps>
-	>,
+	spec: DropTargetHookSpec<DragObject, DropResult, CustomProps>,
 	monitor: DropTargetMonitor,
 	connector: any,
 ) {
@@ -71,28 +70,35 @@ function useDropHandler<
 	const handler = useMemo(() => {
 		return {
 			canDrop() {
-				const { canDrop } = spec.current
+				const { canDrop } = spec
 				return canDrop ? canDrop(monitor.getItem(), monitor) : true
 			},
 			hover() {
-				const { hover } = spec.current
+				const { hover } = spec
 				if (hover) {
 					hover(monitor.getItem(), monitor)
 				}
 			},
 			drop() {
-				const { drop } = spec.current
+				const { drop } = spec
 				if (drop) {
 					return drop(monitor.getItem(), monitor)
 				}
 			},
 		} as DropTarget
-	}, [monitor])
+	}, [monitor, spec])
+
+	/**
+	 * If we pass in spec.current.accept directly, the React hook will
+	 * re-fire when the array-instance changes. Instead, we pass the
+	 * accept items directly into the deps if it's an array
+	 */
+	const specAccept = Array.isArray(spec.accept) ? spec.accept : [spec.accept]
 
 	useIsomorphicLayoutEffect(
 		function registerHandler() {
 			const [handlerId, unregister] = registerTarget(
-				spec.current.accept,
+				spec.accept,
 				handler,
 				manager,
 			)
@@ -100,6 +106,6 @@ function useDropHandler<
 			connector.receiveHandlerId(handlerId)
 			return unregister
 		},
-		[monitor, connector, spec.current.accept],
+		[manager, monitor, handler, connector, ...specAccept],
 	)
 }


### PR DESCRIPTION
Major Semver Impact on React-DnD

Some of the bugs I've been chasing down today have been really brittle, ephemeral issues in dealing with the workarounds of not having used spec-functions in the first place. These are all resolve by using `useMemo`

e.g. `useDrag(useMemo(() => /* spec */, []))`

However, this brings in a lot of structural complexity to what should be a simple hook. Instead of trying to work around a polymorphic hook design or recommend that everyone switch to including `useMemo` in their DnD hooks, we're going to rip the band-aid off and switch to passing functions to our hooks:

e.g. `useDrag(() => /* spec */, [/* optional deps */)`

Internally this just uses useMemo, and it buys us a nice way out of weird bugs that crop up with the hooks API if you don't use it _in such and such a way_. 