### PR TITLE
Re-register DragSource when item.type changes

### DIFF
--- a/.yarn/versions/2ac2f9e7.yml
+++ b/.yarn/versions/2ac2f9e7.yml
@@ -1,0 +1,8 @@
+releases:
+  react-dnd: patch
+
+declined:
+  - react-dnd-documentation
+  - react-dnd-examples-decorators
+  - react-dnd-examples-hooks
+  - react-dnd-test-utils

--- a/packages/react-dnd/src/hooks/__tests__/useDrag.spec.tsx
+++ b/packages/react-dnd/src/hooks/__tests__/useDrag.spec.tsx
@@ -21,6 +21,42 @@ describe('The useDrag hook', () => {
 		}
 	})
 
+	it('throws if item is null', () => {
+		function Component() {
+			const [, drag] = useDrag(() => ({
+				item: null,
+			}))
+			return <div ref={drag} />
+		}
+
+		const err = console.error
+		try {
+			const errorMock = jest.fn()
+			console.error = errorMock
+			expect(() => render(<Component />)).toThrow(/item must be defined/)
+		} finally {
+			console.error = err
+		}
+	})
+
+	it('throws if item type is null', () => {
+		function Component() {
+			const [, drag] = useDrag(() => ({
+				item: { type: null },
+			}))
+			return <div ref={drag} />
+		}
+
+		const err = console.error
+		try {
+			const errorMock = jest.fn()
+			console.error = errorMock
+			expect(() => render(<Component />)).toThrow(/item type must be defined/)
+		} finally {
+			console.error = err
+		}
+	})
+
 	it('can be used inside of a React-DnD context', async () => {
 		const Wrapped = wrapWithBackend(function Component() {
 			const [, drag] = useDrag(() => ({

--- a/packages/react-dnd/src/hooks/__tests__/useDrop.spec.tsx
+++ b/packages/react-dnd/src/hooks/__tests__/useDrop.spec.tsx
@@ -21,6 +21,24 @@ describe('The useDrop hook', () => {
 		}
 	})
 
+	it('throws if accept is null', () => {
+		function Component() {
+			const [, drag] = useDrop(() => ({
+				accept: null,
+			}))
+			return <div ref={drag} />
+		}
+
+		const err = console.error
+		try {
+			const errorMock = jest.fn()
+			console.error = errorMock
+			expect(() => render(<Component />)).toThrow(/accept must be defined/)
+		} finally {
+			console.error = err
+		}
+	})
+
 	it('can be used inside of a React-DnD context', async () => {
 		const Wrapped = wrapWithBackend(function Component() {
 			const [, drag] = useDrop(() => ({

--- a/packages/react-dnd/src/hooks/types.ts
+++ b/packages/react-dnd/src/hooks/types.ts
@@ -4,6 +4,7 @@ import {
 	DragSourceMonitor,
 	DragSourceOptions,
 	DragPreviewOptions,
+	DropTargetOptions,
 } from '../types'
 
 export type FactoryOrInstance<T> = T | (() => T)
@@ -91,7 +92,7 @@ export interface DropTargetHookSpec<DragObject, DropResult, CollectedProps> {
 	/**
 	 * The drop target options
 	 */
-	options?: any
+	options?: DropTargetOptions
 
 	/**
 	 * Optional.

--- a/packages/react-dnd/src/hooks/useDrag/__tests__/DragSourceImpl.spec.ts
+++ b/packages/react-dnd/src/hooks/useDrag/__tests__/DragSourceImpl.spec.ts
@@ -1,0 +1,37 @@
+import { DragSourceMonitor } from '../../../types'
+import { DragSourceImpl } from '../DragSourceImpl'
+
+describe('The Hooks DragSourceImpl', () => {
+	it('can determine if a item can drag', () => {
+		const monitor = {} as DragSourceMonitor
+		let impl = new DragSourceImpl(
+			{
+				canDrag: true,
+			} as any,
+			monitor,
+			{} as any,
+		)
+		expect(impl.canDrag()).toEqual(true)
+
+		impl = new DragSourceImpl(
+			{
+				canDrag: false,
+			} as any,
+			monitor,
+			{} as any,
+		)
+		expect(impl.canDrag()).toEqual(false)
+
+		impl = new DragSourceImpl(
+			{
+				canDrag: (m) => {
+					expect(m).toEqual(monitor)
+					return true
+				},
+			} as any,
+			monitor,
+			{} as any,
+		)
+		expect(impl.canDrag()).toEqual(true)
+	})
+})

--- a/packages/react-dnd/src/hooks/useDrag/connectors.ts
+++ b/packages/react-dnd/src/hooks/useDrag/connectors.ts
@@ -1,0 +1,10 @@
+import { useMemo } from 'react'
+import { SourceConnector } from '../../internals'
+
+export function useConnectDragSource(connector: SourceConnector) {
+	return useMemo(() => connector.hooks.dragSource(), [connector])
+}
+
+export function useConnectDragPreview(connector: SourceConnector) {
+	return useMemo(() => connector.hooks.dragPreview(), [connector])
+}

--- a/packages/react-dnd/src/hooks/useDrag/useCollectedProps.ts
+++ b/packages/react-dnd/src/hooks/useDrag/useCollectedProps.ts
@@ -1,0 +1,13 @@
+import { SourceConnector } from '../../internals'
+import { DragSourceMonitor } from '../../types'
+import { useMonitorOutput } from '../useMonitorOutput'
+
+export function useCollectedProps<Collected>(
+	collector: ((monitor: DragSourceMonitor) => Collected) | undefined,
+	monitor: DragSourceMonitor,
+	connector: SourceConnector,
+) {
+	return useMonitorOutput(monitor, collector || (() => ({} as Collected)), () =>
+		connector.reconnect(),
+	)
+}

--- a/packages/react-dnd/src/hooks/useDrag/useDrag.ts
+++ b/packages/react-dnd/src/hooks/useDrag/useDrag.ts
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import { invariant } from '@react-dnd/invariant'
 import { ConnectDragSource, ConnectDragPreview } from '../../types'
 import {
@@ -6,10 +5,12 @@ import {
 	DragObjectWithType,
 	FactoryOrInstance,
 } from '../types'
-import { useMonitorOutput } from '../useMonitorOutput'
-import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect'
 import { useRegisteredDragSource } from './useRegisteredDragSource'
 import { useOptionalFactory } from '../useOptionalFactory'
+import { useDragSourceMonitor } from './useDragSourceMonitor'
+import { useDragSourceConnector } from './useDragSourceConnector'
+import { useCollectedProps } from './useCollectedProps'
+import { useConnectDragPreview, useConnectDragSource } from './connectors'
 
 /**
  * useDragSource hook
@@ -31,26 +32,13 @@ export function useDrag<
 	invariant(spec.item != null, 'item must be defined')
 	invariant(spec.item.type != null, 'item type must be defined')
 
-	const [monitor, connector] = useRegisteredDragSource(spec)
-	const collected: CollectedProps = useMonitorOutput(
-		monitor,
-		spec.collect || (() => ({} as CollectedProps)),
-		() => connector.reconnect(),
-	)
+	const monitor = useDragSourceMonitor()
+	const connector = useDragSourceConnector(spec.options, spec.previewOptions)
+	useRegisteredDragSource(spec, monitor, connector)
 
-	const connectDragSource = useMemo(() => connector.hooks.dragSource(), [
-		connector,
-	])
-	const connectDragPreview = useMemo(() => connector.hooks.dragPreview(), [
-		connector,
-	])
-	useIsomorphicLayoutEffect(() => {
-		connector.dragSourceOptions = spec.options || null
-		connector.reconnect()
-	}, [connector, spec.options])
-	useIsomorphicLayoutEffect(() => {
-		connector.dragPreviewOptions = spec.previewOptions || null
-		connector.reconnect()
-	}, [connector, spec.previewOptions])
-	return [collected, connectDragSource, connectDragPreview]
+	return [
+		useCollectedProps(spec.collect, monitor, connector),
+		useConnectDragSource(connector),
+		useConnectDragPreview(connector),
+	]
 }

--- a/packages/react-dnd/src/hooks/useDrag/useDrag.ts
+++ b/packages/react-dnd/src/hooks/useDrag/useDrag.ts
@@ -28,7 +28,6 @@ export function useDrag<
 	deps?: unknown[],
 ): [CollectedProps, ConnectDragSource, ConnectDragPreview] {
 	const spec = useOptionalFactory(specArg, deps)
-	// TODO: wire options into createSourceConnector
 	invariant(spec.item != null, 'item must be defined')
 	invariant(spec.item.type != null, 'item type must be defined')
 

--- a/packages/react-dnd/src/hooks/useDrag/useDragSourceConnector.ts
+++ b/packages/react-dnd/src/hooks/useDrag/useDragSourceConnector.ts
@@ -1,0 +1,9 @@
+import { DragDropManager } from 'dnd-core'
+import { useMemo } from 'react'
+import { SourceConnector } from '../../internals'
+
+export function useDragSourceConnector(
+	manager: DragDropManager,
+): SourceConnector {
+	return useMemo(() => new SourceConnector(manager.getBackend()), [manager])
+}

--- a/packages/react-dnd/src/hooks/useDrag/useDragSourceConnector.ts
+++ b/packages/react-dnd/src/hooks/useDrag/useDragSourceConnector.ts
@@ -1,9 +1,24 @@
-import { DragDropManager } from 'dnd-core'
 import { useMemo } from 'react'
 import { SourceConnector } from '../../internals'
+import { DragPreviewOptions, DragSourceOptions } from '../../types'
+import { useDragDropManager } from '../useDragDropManager'
+import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect'
 
 export function useDragSourceConnector(
-	manager: DragDropManager,
+	dragSourceOptions: DragSourceOptions | undefined,
+	dragPreviewOptions: DragPreviewOptions | undefined,
 ): SourceConnector {
-	return useMemo(() => new SourceConnector(manager.getBackend()), [manager])
+	const manager = useDragDropManager()
+	const connector = useMemo(() => new SourceConnector(manager.getBackend()), [
+		manager,
+	])
+	useIsomorphicLayoutEffect(() => {
+		connector.dragSourceOptions = dragSourceOptions || null
+		connector.reconnect()
+	}, [connector, dragSourceOptions])
+	useIsomorphicLayoutEffect(() => {
+		connector.dragPreviewOptions = dragPreviewOptions || null
+		connector.reconnect()
+	}, [connector, dragPreviewOptions])
+	return connector
 }

--- a/packages/react-dnd/src/hooks/useDrag/useDragSourceMonitor.ts
+++ b/packages/react-dnd/src/hooks/useDrag/useDragSourceMonitor.ts
@@ -1,14 +1,10 @@
 import { DragDropManager } from 'dnd-core'
 import { useMemo } from 'react'
-import { DragSourceMonitorImpl, SourceConnector } from '../../internals'
+import { DragSourceMonitorImpl } from '../../internals'
 import { DragSourceMonitor } from '../../types'
 
 export function useDragSourceMonitor(
 	manager: DragDropManager,
-): [DragSourceMonitor, SourceConnector] {
-	const monitor = useMemo(() => new DragSourceMonitorImpl(manager), [manager])
-	const connector = useMemo(() => new SourceConnector(manager.getBackend()), [
-		manager,
-	])
-	return [monitor, connector]
+): DragSourceMonitor {
+	return useMemo(() => new DragSourceMonitorImpl(manager), [manager])
 }

--- a/packages/react-dnd/src/hooks/useDrag/useDragSourceMonitor.ts
+++ b/packages/react-dnd/src/hooks/useDrag/useDragSourceMonitor.ts
@@ -1,10 +1,9 @@
-import { DragDropManager } from 'dnd-core'
 import { useMemo } from 'react'
 import { DragSourceMonitorImpl } from '../../internals'
 import { DragSourceMonitor } from '../../types'
+import { useDragDropManager } from '../useDragDropManager'
 
-export function useDragSourceMonitor(
-	manager: DragDropManager,
-): DragSourceMonitor {
+export function useDragSourceMonitor(): DragSourceMonitor {
+	const manager = useDragDropManager()
 	return useMemo(() => new DragSourceMonitorImpl(manager), [manager])
 }

--- a/packages/react-dnd/src/hooks/useDrag/useRegisteredDragSource.ts
+++ b/packages/react-dnd/src/hooks/useDrag/useRegisteredDragSource.ts
@@ -5,12 +5,14 @@ import { useDragDropManager } from '../useDragDropManager'
 import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect'
 import { useDragSource } from './useDragSource'
 import { useDragSourceMonitor } from './useDragSourceMonitor'
+import { useDragSourceConnector } from './useDragSourceConnector'
 
 export function useRegisteredDragSource<O extends DragObjectWithType, R, P>(
 	spec: DragSourceHookSpec<O, R, P>,
 ): [DragSourceMonitor, SourceConnector] {
 	const manager = useDragDropManager()
-	const [monitor, connector] = useDragSourceMonitor(manager)
+	const monitor = useDragSourceMonitor(manager)
+	const connector = useDragSourceConnector(manager)
 	const handler = useDragSource(spec, monitor, connector)
 
 	useIsomorphicLayoutEffect(

--- a/packages/react-dnd/src/hooks/useDrag/useRegisteredDragSource.ts
+++ b/packages/react-dnd/src/hooks/useDrag/useRegisteredDragSource.ts
@@ -14,19 +14,16 @@ export function useRegisteredDragSource<O extends DragObjectWithType, R, P>(
 	const monitor = useDragSourceMonitor(manager)
 	const connector = useDragSourceConnector(manager)
 	const handler = useDragSource(spec, monitor, connector)
+	const itemType = spec.item.type
 
 	useIsomorphicLayoutEffect(
-		function registerHandler() {
-			const [handlerId, unregister] = registerSource(
-				spec.item.type,
-				handler,
-				manager,
-			)
+		function registerDragSource() {
+			const [handlerId, unregister] = registerSource(itemType, handler, manager)
 			monitor.receiveHandlerId(handlerId)
 			connector.receiveHandlerId(handlerId)
 			return unregister
 		},
-		[manager, monitor, connector, handler],
+		[manager, monitor, connector, handler, itemType],
 	)
 	return [monitor, connector]
 }

--- a/packages/react-dnd/src/hooks/useDrag/useRegisteredDragSource.ts
+++ b/packages/react-dnd/src/hooks/useDrag/useRegisteredDragSource.ts
@@ -1,18 +1,16 @@
 import { DragSourceMonitor } from '../../types'
 import { registerSource, SourceConnector } from '../../internals'
 import { DragObjectWithType, DragSourceHookSpec } from '../types'
-import { useDragDropManager } from '../useDragDropManager'
 import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect'
 import { useDragSource } from './useDragSource'
-import { useDragSourceMonitor } from './useDragSourceMonitor'
-import { useDragSourceConnector } from './useDragSourceConnector'
+import { useDragDropManager } from '../useDragDropManager'
 
 export function useRegisteredDragSource<O extends DragObjectWithType, R, P>(
 	spec: DragSourceHookSpec<O, R, P>,
-): [DragSourceMonitor, SourceConnector] {
+	monitor: DragSourceMonitor,
+	connector: SourceConnector,
+): void {
 	const manager = useDragDropManager()
-	const monitor = useDragSourceMonitor(manager)
-	const connector = useDragSourceConnector(manager)
 	const handler = useDragSource(spec, monitor, connector)
 	const itemType = spec.item.type
 
@@ -25,5 +23,4 @@ export function useRegisteredDragSource<O extends DragObjectWithType, R, P>(
 		},
 		[manager, monitor, connector, handler, itemType],
 	)
-	return [monitor, connector]
 }

--- a/packages/react-dnd/src/hooks/useDrop/__tests__/DropTargetImpl.spec.ts
+++ b/packages/react-dnd/src/hooks/useDrop/__tests__/DropTargetImpl.spec.ts
@@ -1,0 +1,23 @@
+import { DropTargetMonitor } from '../../../types'
+import { DropTargetImpl } from '../DropTargetImpl'
+
+describe('The Hooks DropTargetImpl', () => {
+	it('can determine if a item can drag', () => {
+		const monitor = {
+			getItem: () => ({}),
+		} as DropTargetMonitor
+		let impl = new DropTargetImpl({} as any, monitor)
+		expect(impl.canDrop()).toEqual(true)
+
+		impl = new DropTargetImpl(
+			{
+				canDrop(item, mon) {
+					expect(mon).toEqual(monitor)
+					return false
+				},
+			} as any,
+			monitor,
+		)
+		expect(impl.canDrop()).toEqual(false)
+	})
+})

--- a/packages/react-dnd/src/hooks/useDrop/connectors.ts
+++ b/packages/react-dnd/src/hooks/useDrop/connectors.ts
@@ -1,0 +1,6 @@
+import { useMemo } from 'react'
+import { TargetConnector } from '../../internals'
+
+export function useConnectDropTarget(connector: TargetConnector) {
+	return useMemo(() => connector.hooks.dropTarget(), [connector])
+}

--- a/packages/react-dnd/src/hooks/useDrop/useCollectedProps.ts
+++ b/packages/react-dnd/src/hooks/useDrop/useCollectedProps.ts
@@ -1,0 +1,13 @@
+import { TargetConnector } from '../../internals'
+import { DropTargetMonitor } from '../../types'
+import { useMonitorOutput } from '../useMonitorOutput'
+
+export function useCollectedProps<Collected>(
+	collector: ((monitor: DropTargetMonitor) => Collected) | undefined,
+	monitor: DropTargetMonitor,
+	connector: TargetConnector,
+) {
+	return useMonitorOutput(monitor, collector || (() => ({} as Collected)), () =>
+		connector.reconnect(),
+	)
+}

--- a/packages/react-dnd/src/hooks/useDrop/useDropTargetConnector.ts
+++ b/packages/react-dnd/src/hooks/useDrop/useDropTargetConnector.ts
@@ -1,0 +1,9 @@
+import { DragDropManager } from 'dnd-core'
+import { useMemo } from 'react'
+import { TargetConnector } from '../../internals'
+
+export function useDropTargetConnector(
+	manager: DragDropManager,
+): TargetConnector {
+	return useMemo(() => new TargetConnector(manager.getBackend()), [manager])
+}

--- a/packages/react-dnd/src/hooks/useDrop/useDropTargetConnector.ts
+++ b/packages/react-dnd/src/hooks/useDrop/useDropTargetConnector.ts
@@ -1,9 +1,19 @@
-import { DragDropManager } from 'dnd-core'
 import { useMemo } from 'react'
 import { TargetConnector } from '../../internals'
+import { DropTargetOptions } from '../../types'
+import { useDragDropManager } from '../useDragDropManager'
+import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect'
 
 export function useDropTargetConnector(
-	manager: DragDropManager,
+	options: DropTargetOptions,
 ): TargetConnector {
-	return useMemo(() => new TargetConnector(manager.getBackend()), [manager])
+	const manager = useDragDropManager()
+	const connector = useMemo(() => new TargetConnector(manager.getBackend()), [
+		manager,
+	])
+	useIsomorphicLayoutEffect(() => {
+		connector.dropTargetOptions = options || null
+		connector.reconnect()
+	}, [options])
+	return connector
 }

--- a/packages/react-dnd/src/hooks/useDrop/useDropTargetMonitor.ts
+++ b/packages/react-dnd/src/hooks/useDrop/useDropTargetMonitor.ts
@@ -1,10 +1,9 @@
-import { DragDropManager } from 'dnd-core'
 import { useMemo } from 'react'
 import { DropTargetMonitorImpl } from '../../internals'
 import { DropTargetMonitor } from '../../types'
+import { useDragDropManager } from '../useDragDropManager'
 
-export function useDropTargetMonitor(
-	manager: DragDropManager,
-): DropTargetMonitor {
+export function useDropTargetMonitor(): DropTargetMonitor {
+	const manager = useDragDropManager()
 	return useMemo(() => new DropTargetMonitorImpl(manager), [manager])
 }

--- a/packages/react-dnd/src/hooks/useDrop/useDropTargetMonitor.ts
+++ b/packages/react-dnd/src/hooks/useDrop/useDropTargetMonitor.ts
@@ -1,14 +1,10 @@
 import { DragDropManager } from 'dnd-core'
 import { useMemo } from 'react'
-import { DropTargetMonitorImpl, TargetConnector } from '../../internals'
+import { DropTargetMonitorImpl } from '../../internals'
 import { DropTargetMonitor } from '../../types'
 
 export function useDropTargetMonitor(
 	manager: DragDropManager,
-): [DropTargetMonitor, TargetConnector] {
-	const monitor = useMemo(() => new DropTargetMonitorImpl(manager), [manager])
-	const connector = useMemo(() => new TargetConnector(manager.getBackend()), [
-		manager,
-	])
-	return [monitor, connector]
+): DropTargetMonitor {
+	return useMemo(() => new DropTargetMonitorImpl(manager), [manager])
 }

--- a/packages/react-dnd/src/hooks/useDrop/useRegisteredDropTarget.ts
+++ b/packages/react-dnd/src/hooks/useDrop/useRegisteredDropTarget.ts
@@ -5,15 +5,13 @@ import { useDragDropManager } from '../useDragDropManager'
 import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect'
 import { useAccept } from './useAccept'
 import { useDropTarget } from './useDropTarget'
-import { useDropTargetMonitor } from './useDropTargetMonitor'
-import { useDropTargetConnector } from './useDropTargetConnector'
 
 export function useRegisteredDropTarget<O extends DragObjectWithType, R, P>(
 	spec: DropTargetHookSpec<O, R, P>,
-): [DropTargetMonitor, TargetConnector] {
+	monitor: DropTargetMonitor,
+	connector: TargetConnector,
+): void {
 	const manager = useDragDropManager()
-	const monitor = useDropTargetMonitor(manager)
-	const connector = useDropTargetConnector(manager)
 	const dropTarget = useDropTarget(spec, monitor)
 	const accept = useAccept(spec)
 
@@ -30,5 +28,4 @@ export function useRegisteredDropTarget<O extends DragObjectWithType, R, P>(
 		},
 		[manager, monitor, dropTarget, connector, ...accept],
 	)
-	return [monitor, connector]
 }

--- a/packages/react-dnd/src/hooks/useDrop/useRegisteredDropTarget.ts
+++ b/packages/react-dnd/src/hooks/useDrop/useRegisteredDropTarget.ts
@@ -20,7 +20,7 @@ export function useRegisteredDropTarget<O extends DragObjectWithType, R, P>(
 	const accept = useAccept(spec)
 
 	useIsomorphicLayoutEffect(
-		function registerHandler() {
+		function registerDropTarget() {
 			const [handlerId, unregister] = registerTarget(
 				accept,
 				dropTarget,

--- a/packages/react-dnd/src/hooks/useDrop/useRegisteredDropTarget.ts
+++ b/packages/react-dnd/src/hooks/useDrop/useRegisteredDropTarget.ts
@@ -15,8 +15,6 @@ export function useRegisteredDropTarget<O extends DragObjectWithType, R, P>(
 	const monitor = useDropTargetMonitor(manager)
 	const connector = useDropTargetConnector(manager)
 	const dropTarget = useDropTarget(spec, monitor)
-
-	// Reconnect on accept change
 	const accept = useAccept(spec)
 
 	useIsomorphicLayoutEffect(

--- a/packages/react-dnd/src/hooks/useDrop/useRegisteredDropTarget.ts
+++ b/packages/react-dnd/src/hooks/useDrop/useRegisteredDropTarget.ts
@@ -6,13 +6,14 @@ import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect'
 import { useAccept } from './useAccept'
 import { useDropTarget } from './useDropTarget'
 import { useDropTargetMonitor } from './useDropTargetMonitor'
+import { useDropTargetConnector } from './useDropTargetConnector'
 
 export function useRegisteredDropTarget<O extends DragObjectWithType, R, P>(
 	spec: DropTargetHookSpec<O, R, P>,
 ): [DropTargetMonitor, TargetConnector] {
 	const manager = useDragDropManager()
-	const [monitor, connector] = useDropTargetMonitor(manager)
-
+	const monitor = useDropTargetMonitor(manager)
+	const connector = useDropTargetConnector(manager)
 	const dropTarget = useDropTarget(spec, monitor)
 
 	// Reconnect on accept change

--- a/packages/react-dnd/src/types/options.ts
+++ b/packages/react-dnd/src/types/options.ts
@@ -44,3 +44,5 @@ export interface DragPreviewOptions {
 	 */
 	offsetY?: number
 }
+
+export type DropTargetOptions = any


### PR DESCRIPTION
This PR also includes some internal cleanup/refactoring of the useDrag/useDrop hooks