### PR TITLE
fix broken links (docs)

### DIFF
--- a/packages/docsite/markdown/docs/00 Quick Start/FAQ.md
+++ b/packages/docsite/markdown/docs/00 Quick Start/FAQ.md
@@ -58,7 +58,7 @@ export default flow(DragSource(/* ... */), DropTarget(/* ... */))(YourComponent)
 
 ### How do I register a drop target for the native files?
 
-If you are using the [HTML5 backend](/docs//backends/html5), you can register a drop target for one of the `NativeTypes` it exports:
+If you are using the [HTML5 backend](/docs/backends/html5), you can register a drop target for one of the `NativeTypes` it exports:
 
 ```jsx
 import React from 'react'

--- a/packages/docsite/markdown/docs/00 Quick Start/Overview.md
+++ b/packages/docsite/markdown/docs/00 Quick Start/Overview.md
@@ -95,7 +95,7 @@ Unfortunately, the HTML5 drag and drop API also has some downsides. It does not 
 
 This is why **the HTML5 drag and drop support is implemented in a pluggable way** in React DnD. You don't have to use it. You can write a different implementation, based on touch events, mouse events, or something else entirely. Such pluggable implementations are called the _backends_ in React DnD.
 
-The library currently ships with the [HTML backend](docs/backends/html5), which should be sufficient for most web applications. There is also a [Touch backend](/docs/backend/touch) that can be used for mobile web applications.
+The library currently ships with the [HTML backend](/docs/backends/html5), which should be sufficient for most web applications. There is also a [Touch backend](/docs/backends/touch) that can be used for mobile web applications.
 
 The backends perform a similar role to that of React's synthetic event system: **they abstract away the browser differences and process the native DOM events.** Despite the similarities, React DnD backends do not have a dependency on React or its synthetic event system. Under the hood, all the backends do is translate the DOM events into the internal Redux actions that React DnD can process.
 


### PR DESCRIPTION
This PR fixes two broken links. The other link which included "//", worked as expected and was only cleaned up.