### PR TITLE
Add missing DropTargetMoniter type arguments

### DIFF
--- a/packages/react-dnd/src/hooks/types.ts
+++ b/packages/react-dnd/src/hooks/types.ts
@@ -134,5 +134,7 @@ export interface DropTargetHookSpec<DragObject, DropResult, CollectedProps> {
 	/**
 	 * A function to collect rendering properties
 	 */
-	collect?: (monitor: DropTargetMonitor) => CollectedProps
+	collect?: (
+		monitor: DropTargetMonitor<DragObject, DropResult>,
+	) => CollectedProps
 }


### PR DESCRIPTION
This should allow cases like

https://github.com/react-dnd/react-dnd/blob/e8bd6436548d96f6d6594f763752f424c2e0834b/packages/examples-hooks/src/01-dustbin/copy-or-move/Dustbin.tsx#L40

to have type inference.