### PR TITLE
Always clear mousemove timer before setting new one

### DIFF
--- a/packages/backend-html5/src/HTML5BackendImpl.ts
+++ b/packages/backend-html5/src/HTML5BackendImpl.ts
@@ -371,8 +371,8 @@ export class HTML5BackendImpl implements Backend {
 
 	private resetMouseMoveTimer() {
 		if (this.rootElement) {
-			this.window?.clearTimeout(this.mouseMoveTimeoutTimer || undefined)
-			this.rootElement.removeEventListener(
+			this.window?.clearTimeout?.(this.mouseMoveTimeoutTimer || undefined)
+			this.rootElement.removeEventListener?.(
 				'mousemove',
 				this.endDragIfSourceWasRemovedFromDOM,
 				true,

--- a/packages/backend-html5/src/HTML5BackendImpl.ts
+++ b/packages/backend-html5/src/HTML5BackendImpl.ts
@@ -369,20 +369,24 @@ export class HTML5BackendImpl implements Backend {
 		}, MOUSE_MOVE_TIMEOUT) as any) as number
 	}
 
+	private resetMouseMoveTimer() {
+		if (this.rootElement) {
+			this.window?.clearTimeout(this.mouseMoveTimeoutTimer || undefined)
+			this.rootElement.removeEventListener(
+				'mousemove',
+				this.endDragIfSourceWasRemovedFromDOM,
+				true,
+			)
+		}
+
+		this.mouseMoveTimeoutTimer = null
+	}
+
 	private clearCurrentDragSourceNode() {
+		this.resetMouseMoveTimer();
+
 		if (this.currentDragSourceNode) {
 			this.currentDragSourceNode = null
-
-			if (this.rootElement) {
-				this.window?.clearTimeout(this.mouseMoveTimeoutTimer || undefined)
-				this.rootElement.removeEventListener(
-					'mousemove',
-					this.endDragIfSourceWasRemovedFromDOM,
-					true,
-				)
-			}
-
-			this.mouseMoveTimeoutTimer = null
 			return true
 		}
 


### PR DESCRIPTION
## What does this do?

This PR updates the handling of the `mousemove` event listener that gets added and removed while starting a new drag. Previously, the `mousemove` listener added to `this.rootElement` would only be removed if `this.currentDragSourceNode` was still set when we called `this.clearCurrentDragSourceNode`. Now, we attempt to remove the mousemove listener regardless of whether the `this.currentDragSourceNode` is set or not.

## Why are we doing this?

My understanding of the current (pre-this-PR) flow for that listener is:
- when a new drag starts, we set a timeout for one second.
- The one second timeout is intended to allow the first mousemove events that fire for the drag preview to go through
- If that timeout ends, we attach a `mousemove` event listener to the rootElement.
  - That mousemove listener is used to catch a situation where the drag source node has been removed from the DOM, in which case 'dragend' won't be fired. When the listener fires, we manually force the drag to end.
- If the dragend is fired before the timeout expires, we clear the timeout and do not add the mousemove listener

I've been running into a bug where the mousemove event listener does not properly get cleared in Firefox. If the drag source node is removed from the DOM while the drag events are firing, you can get into a situation where Firefox will not fire the 'dragend' event appropriately, but the 'mousemove' event is still not caught by the listener. This can then result in future drag events triggering `clearCurrentDragSourceNode` without a `currentDragSourceNode` set - which will *not* remove the mousemove listener. When that happens, the mousemove listener will remain attached to the rootElement.

If the mousemove listener from a previous drag is still set when a new one is started, the initial `mousemove` events get trigger the listener, which then immediately ends the drag event, and stops further drag events being fired.

## What are the risks of this PR?
I believe this is a harmless change - calling `clearTimeout` and `removeEventListener` does not have any detrimental effect if there is no timeout or listener to clear. This change is fixing an edge case, which is likely the fault of my application's code, but it makes sense to me to be more aggressive with removing that mousemove event listener, given the indirect way that it is attached in the first place.

If I'm understanding the general flow of the HTML5 backend correctly, I do not think there are any risks with being more aggressive in removing that mousemove listener - but it's definitely possible that there are other edge cases that I'm not considering here.

I have not personally run into problems using my fork in our application, but I'm unsure of the best way to test this change for more general use cases.

#### some context on our application's specific issues
Our application has some frustrating issues with nodes rerendering due to clashing of two different JS frameworks handling render updates (YUI and React). Nodes being unexpectedly removed from the DOM and replaced with identical ones is almost certainly the fault of our own application code, but the bug looks to be caused by the indirect attaching of the event listener after a timeout, which is in itself intended to fix issues with Firefox, so I think it's fair to patch this behavior here in addition to fixing our own issues in our application.