### PR TITLE
Fix isNodeInDocument for HTML5Backend when used in iframes

### DIFF
--- a/packages/backend-html5/src/HTML5BackendImpl.ts
+++ b/packages/backend-html5/src/HTML5BackendImpl.ts
@@ -323,7 +323,7 @@ export class HTML5BackendImpl implements Backend {
 			node &&
 				this.document &&
 				this.document.body &&
-				document.body.contains(node),
+				this.document.body.contains(node),
 		)
 	}
 


### PR DESCRIPTION
The isNodeInDocument function is used to check if a node was detached during a drag event. It checks to make sure `this.document.body` is defined, but then checks if `document.body` contains the given node.

When this library is used within an iframe, `document` in the global context may not be the same as `this.document`. This commit updates the check to use `this.document.body`, which should correctly check against the current context instead of the global document.