### PR TITLE
Fixes #3179 - handle custom drag sources triggering native drops

### DIFF
--- a/.yarn/versions/e2e01ae9.yml
+++ b/.yarn/versions/e2e01ae9.yml
@@ -1,0 +1,6 @@
+releases:
+  react-dnd-documentation: patch
+  react-dnd-examples-decorators: patch
+  react-dnd-examples-hooks: patch
+  react-dnd-html5-backend: patch
+  react-dnd-test-utils: patch

--- a/packages/backend-html5/src/HTML5BackendImpl.ts
+++ b/packages/backend-html5/src/HTML5BackendImpl.ts
@@ -653,6 +653,12 @@ export class HTML5BackendImpl implements Backend {
 		if (this.isDraggingNativeItem()) {
 			e.preventDefault()
 			this.currentNativeSource?.loadDataTransfer(e.dataTransfer)
+		} else if (matchNativeItemType(e.dataTransfer)) {
+			// Dragging some elements, like <a> and <img> may still behave like a native drag event,
+			// even if the current drag event matches a user-defined type.
+			// Stop the default behavior when we're not expecting a native item to be dropped.
+
+			e.preventDefault();
 		}
 
 		this.enterLeaveCounter.reset()


### PR DESCRIPTION
This PR fixes an issue in Firefox where dragging links would still trigger native drag and drop behavior, even if the drag was caught as a custom defined drag type.

The codebase checks for native drag events firing, but mostly treats them separately from custom drag events. In Firefox, dragging an `<a>` link will still trigger native drop behavior (following the URL), because we only `preventDefault()` if a custom drag type was not recognized in the `e.dataTransfer` object.

This PR adds another check to the `handleTopDropCapture` function, which will prevent default if the drop event has a native type and the drag monitor is reporting the current drag as a custom type.