### PR TITLE
Update package.json to include the repository

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -7,6 +7,11 @@
     "clean": "rimraf lib",
     "build": "tsc -b"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/react-dnd/react-dnd.git",
+    "directory": "packages/build"
+  },
   "dependencies": {
     "@babel/core": "^7.15.0",
     "@babel/plugin-proposal-class-properties": "^7.14.5",

--- a/packages/docsite/package.json
+++ b/packages/docsite/package.json
@@ -42,6 +42,11 @@
     "typography": "^0.16.19",
     "typography-theme-github": "^0.16.19"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/react-dnd/react-dnd.git",
+    "directory": "packages/docsite"
+  },
   "browserslist": [
     ">0.2%",
     "not dead",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -8,6 +8,11 @@
     "module": "dist/esm/index.js",
     "types": "dist/types/index.d.ts"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/react-dnd/react-dnd.git",
+    "directory": "packages/test-utils"
+  },
   "sideEffects": false,
   "scripts": {
     "clean": "gulp clean",


### PR DESCRIPTION
NOTE: This is not a bot. This change was made by and comments will be reviewed by humans. We are using this service account to be able to track the overall progress.

With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.

We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your package.json REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.

If you do not want us to create such PRs against your GitHub repositories, or wish to provide any other feedback, please comment on this PR.

Published NPM packages with repository information:
• build
• docsite
• test-utils