### PR TITLE
Remove the confusing code from the example

### DIFF
--- a/.yarn/versions/bc7330ba.yml
+++ b/.yarn/versions/bc7330ba.yml
@@ -1,0 +1,3 @@
+declined:
+  - react-dnd-examples-decorators
+  - react-dnd-examples-hooks

--- a/packages/examples-decorators/src/04-sortable/cancel-on-drop-outside/Card.tsx
+++ b/packages/examples-decorators/src/04-sortable/cancel-on-drop-outside/Card.tsx
@@ -49,7 +49,6 @@ const Card: FC<CardProps> = ({
 export default DropTarget(
 	ItemTypes.CARD,
 	{
-		canDrop: () => false,
 		hover(props: CardProps, monitor: DropTargetMonitor) {
 			const { id: draggedId } = monitor.getItem<CardDragObject>()
 			const { id: overId } = props

--- a/packages/examples-hooks/src/04-sortable/cancel-on-drop-outside/Card.tsx
+++ b/packages/examples-hooks/src/04-sortable/cancel-on-drop-outside/Card.tsx
@@ -50,7 +50,6 @@ export const Card: FC<CardProps> = memo(function Card({
 	const [, drop] = useDrop(
 		() => ({
 			accept: ItemTypes.CARD,
-			canDrop: () => false,
 			hover({ id: draggedId }: Item) {
 				if (draggedId !== id) {
 					const { index: overIndex } = findCard(id)


### PR DESCRIPTION
## Motivation

Mentioned in the document:
  > Unlike `drop()`, this method will be called even if `canDrop()` is defined and returns `false`. You can check `monitor.canDrop()` to test whether this is the case.

In that case, keeping the `canDrop: () => false,` will only confuse the novice. Or can you add comments to explain the meaning of this line of code? Actually, I don't quite understand its role here.