### PR TITLE
Updating sortable example to use useState setter as function

### DIFF
--- a/packages/examples-hooks/src/04-sortable/simple/Container.tsx
+++ b/packages/examples-hooks/src/04-sortable/simple/Container.tsx
@@ -1,4 +1,4 @@
-import { FC, useState, useCallback } from 'react'
+import { FC, useState } from 'react'
 import { Card } from './Card'
 import update from 'immutability-helper'
 
@@ -48,20 +48,17 @@ export const Container: FC = () => {
 			},
 		])
 
-		const moveCard = useCallback(
-			(dragIndex: number, hoverIndex: number) => {
-				const dragCard = cards[dragIndex]
-				setCards(
-					update(cards, {
-						$splice: [
-							[dragIndex, 1],
-							[hoverIndex, 0, dragCard],
-						],
-					}),
-				)
-			},
-			[cards],
-		)
+		const moveCard = (dragIndex: number, hoverIndex: number) => {
+			setCards((prevCards: Item[]) =>
+				update(prevCards, {
+					$splice: [
+						[dragIndex, 1],
+						[hoverIndex, 0, prevCards[dragIndex]]
+					]
+				})
+			);
+		};
+
 
 		const renderCard = (card: { id: number; text: string }, index: number) => {
 			return (


### PR DESCRIPTION
This solves #3193 

Basically when moving the cards around, the state is not able to keep up with the movement. 

By using the inner state as a function, the problem is solved. 