### PR TITLE
Update useDrop.md, remove accept as a function

### DIFF
--- a/packages/docsite/markdown/docs/03 Using Hooks/useDrop.md
+++ b/packages/docsite/markdown/docs/03 Using Hooks/useDrop.md
@@ -35,7 +35,7 @@ function myDropTarget(props) {
 
 ### Specification Object Members
 
-- **`accept`**: Required. A string, a symbol, an array of either, or a function that returns either of those, given component's `props`. This drop target will only react to the items produced by the [drag sources](/docs/api/drag-source) of the specified type or types. Read the [overview](/docs/overview) to learn more about the items and types.
+- **`accept`**: Required. A string, a symbol, or an array of either. This drop target will only react to the items produced by the [drag sources](/docs/api/drag-source) of the specified type or types. Read the [overview](/docs/overview) to learn more about the items and types.
 
 * **`options`**: Optional. A plain object. If some of the props to your component are not scalar (that is, are not primitive values or functions), specifying a custom `arePropsEqual(props, otherProps)` function inside the `options` object can improve the performance. Unless you have performance problems, don't worry about it.
 


### PR DESCRIPTION
Looks like this doc is incorrect, `accept` does not appear to take a function. When trying to use a function for `accept`, I see this error. `Uncaught Invariant Violation: Type can only be a string or a symbol.`

`DropTargetHookSpec` says accept is `TargetType`
https://github.com/react-dnd/react-dnd/blob/e8bd6436548d96f6d6594f763752f424c2e0834b/packages/react-dnd/src/hooks/types.ts#L97 

`TargetType` is `Identifier | Identifier[] | null`
https://github.com/react-dnd/react-dnd/blob/e8bd6436548d96f6d6594f763752f424c2e0834b/packages/dnd-core/src/interfaces.ts#L3

And `Identifier` is `string | symbol`
https://github.com/react-dnd/react-dnd/blob/e8bd6436548d96f6d6594f763752f424c2e0834b/packages/dnd-core/src/interfaces.ts#L1