### PR TITLE
Fix single-target-in-iframe/src/Example.js (`.js` instead of `.jsx`)

### DIFF
--- a/examples_js/01-dustbin/single-target-in-iframe/src/example.js
+++ b/examples_js/01-dustbin/single-target-in-iframe/src/example.js
@@ -1,1 +1,1 @@
-export { Container as default } from './Container.js'
+export { Container as default } from './Container.jsx'


### PR DESCRIPTION
Example is pointing to `Container.js` file instead of `Container.jsx`

There are other imports/exports with incorrect extensions. If this is useful, I can fix those too.