### PR TITLE
feat: allow configuring when to use the 'copy' dropEffect

### DIFF
--- a/packages/backend-html5/src/HTML5BackendImpl.ts
+++ b/packages/backend-html5/src/HTML5BackendImpl.ts
@@ -48,7 +48,7 @@ export class HTML5BackendImpl implements Backend {
 	private currentNativeSource: NativeDragSource | null = null
 	private currentNativeHandle: Identifier | null = null
 	private currentDragSourceNode: Element | null = null
-	private altKeyPressed = false
+	private isCopying = false
 	private mouseMoveTimeoutTimer: number | null = null
 	private asyncEndDragFrameId: number | null = null
 	private dragOverTargetIds: string[] | null = null
@@ -267,7 +267,7 @@ export class HTML5BackendImpl implements Backend {
 		const sourceNodeOptions = this.sourceNodeOptions.get(sourceId)
 
 		return {
-			dropEffect: this.altKeyPressed ? 'copy' : 'move',
+			dropEffect: this.isCopying ? 'copy' : 'move',
 			...(sourceNodeOptions || {}),
 		}
 	}
@@ -597,7 +597,7 @@ export class HTML5BackendImpl implements Backend {
 			return
 		}
 
-		this.altKeyPressed = e.altKey
+		this.isCopying = this.options.isCopying(e)
 
 		// If the target changes position as the result of `dragenter`, `dragover` might still
 		// get dispatched despite target being no longer there. The easy solution is to check
@@ -650,7 +650,7 @@ export class HTML5BackendImpl implements Backend {
 			return
 		}
 
-		this.altKeyPressed = e.altKey
+		this.isCopying = this.options.isCopying(e)
 		this.lastClientOffset = getEventClientOffset(e)
 
 		this.scheduleHover(dragOverTargetIds)

--- a/packages/backend-html5/src/OptionsReader.ts
+++ b/packages/backend-html5/src/OptionsReader.ts
@@ -35,4 +35,21 @@ export class OptionsReader {
 	public get rootElement(): Node | undefined {
 		return this.optionsArgs?.rootElement || this.window
 	}
+
+	public isCopying(e: DragEvent): boolean {
+		if (this.optionsArgs?.copyKey === undefined) {
+			return false
+		}
+		switch (this.optionsArgs?.copyKey) {
+			case 'shift':
+				return e.shiftKey
+			case 'ctrl':
+				return e.ctrlKey
+			case 'alt':
+				return e.altKey
+			case 'meta':
+				return e.metaKey
+		}
+		return this.optionsArgs?.copyKey(e)
+	}
 }

--- a/packages/backend-html5/src/OptionsReader.ts
+++ b/packages/backend-html5/src/OptionsReader.ts
@@ -38,7 +38,7 @@ export class OptionsReader {
 
 	public isCopying(e: DragEvent): boolean {
 		if (this.optionsArgs?.copyKey === undefined) {
-			return false
+			return e.altKey
 		}
 		switch (this.optionsArgs?.copyKey) {
 			case 'shift':

--- a/packages/backend-html5/src/types.ts
+++ b/packages/backend-html5/src/types.ts
@@ -1,4 +1,5 @@
 export type HTML5BackendContext = Window | undefined
+export type DragModifierKey = 'shift' | 'ctrl' | 'alt' | 'meta'
 
 /**
  * Configuration options for the HTML5Backend
@@ -8,4 +9,9 @@ export interface HTML5BackendOptions {
 	 * The root DOM node to use for subscribing to events. Default=Window
 	 */
 	rootElement: Node
+
+	/**
+	 * The modifier key to indicate a copy, or a custom callback predicate which should return true if copying. Default='alt'
+	 */
+	copyKey: DragModifierKey | ((ev: DragEvent) => boolean)
 }


### PR DESCRIPTION
Allows using keys other than alt to set the dropEffect to 'copy', and allows using a predicate callback in case the user wants more complex behavior.

Resolves #2979