### PR TITLE
Remove an unused argument on docsRoot.md

### DIFF
--- a/packages/docsite/markdown/docs/docsRoot.md
+++ b/packages/docsite/markdown/docs/docsRoot.md
@@ -25,7 +25,7 @@ import { ItemTypes } from './Constants'
 /**
  * Your Component
  */
-export default function Card({ isDragging, text }) {
+export default function Card({ text }) {
   const [{ opacity }, dragRef] = useDrag(
     () => ({
       type: ItemTypes.CARD,


### PR DESCRIPTION
An argument `isDragging` of `Card` component on document is not used.