### PR TITLE
feat: support setting drop effect for drop targets.

### DIFF
--- a/packages/docsite/markdown/examples/customize/drop-effects.md
+++ b/packages/docsite/markdown/examples/customize/drop-effects.md
@@ -4,8 +4,13 @@ title: 'Drop Effects'
 ---
 
 Some browsers let you specify the “drop effects” for the draggable
-items. In the compatible browsers, you will see a “copy” icon when you
-drag the first box over the drop zone.
+items. Drop effects can be set on the drag source, the drop target
+or if the user presses the alt key. The logic for setting the drop
+effect is as follows:
+
+1. If the drag source specifies a drop effect, use that.
+2. Else if the drop target specifies a drop effect, use that.
+3. Else if the user is pressing the alt key, then use the copy effect
 
 <view-source name="05-customize/drop-effects" component="customize-drop-effects">
 </view-source>

--- a/packages/examples/src/05-customize/drop-effects/Container.tsx
+++ b/packages/examples/src/05-customize/drop-effects/Container.tsx
@@ -6,12 +6,15 @@ import { TargetBox } from './TargetBox.js'
 export const Container: FC = () => {
 	return (
 		<>
-			<div style={{ overflow: 'hidden', clear: 'both', marginTop: '1.5rem' }}>
-				<div style={{ float: 'left' }}>
-					<SourceBox showCopyIcon={true} />
+			<div style={{ overflow: 'hidden', marginTop: '1.5rem' }}>
+				<div style={{ display: 'flex', flexDirection: 'column' }}>
+					<SourceBox dropEffect="copy" />
+					<SourceBox dropEffect="move" />
 					<SourceBox />
 				</div>
-				<div style={{ float: 'left' }}>
+				<div style={{ display: 'flex', flexWrap: 'wrap' }}>
+					<TargetBox dropEffect="copy" />
+					<TargetBox dropEffect="move" />
 					<TargetBox />
 				</div>
 			</div>

--- a/packages/examples/src/05-customize/drop-effects/SourceBox.tsx
+++ b/packages/examples/src/05-customize/drop-effects/SourceBox.tsx
@@ -1,4 +1,6 @@
 import type { CSSProperties, FC } from 'react'
+import { useMemo } from 'react'
+import type { DragSourceOptions } from 'react-dnd'
 import { useDrag } from 'react-dnd'
 
 import { ItemTypes } from './ItemTypes.js'
@@ -13,26 +15,32 @@ const style: CSSProperties = {
 }
 
 export interface SourceBoxProps {
-	showCopyIcon?: boolean
+	dropEffect?: string
 }
 
-export const SourceBox: FC<SourceBoxProps> = ({ showCopyIcon }) => {
+export const SourceBox: FC<SourceBoxProps> = ({ dropEffect }) => {
+	const options = useMemo(() => {
+		const result: DragSourceOptions = {}
+		if (dropEffect) {
+			result.dropEffect = dropEffect
+		}
+		return result
+	}, [dropEffect])
+
 	const [{ opacity }, drag] = useDrag(
 		() => ({
 			type: ItemTypes.BOX,
-			options: {
-				dropEffect: showCopyIcon ? 'copy' : 'move',
-			},
+			options,
 			collect: (monitor) => ({
 				opacity: monitor.isDragging() ? 0.4 : 1,
 			}),
 		}),
-		[showCopyIcon],
+		[options],
 	)
 
 	return (
 		<div ref={drag} style={{ ...style, opacity }}>
-			When I am over a drop zone, I have {showCopyIcon ? 'copy' : 'no'} icon.
+			I have a {dropEffect || 'undefined'} dropEffect
 		</div>
 	)
 }

--- a/packages/examples/src/05-customize/drop-effects/TargetBox.tsx
+++ b/packages/examples/src/05-customize/drop-effects/TargetBox.tsx
@@ -11,9 +11,18 @@ const style: CSSProperties = {
 	textAlign: 'center',
 }
 
-export const TargetBox: FC = () => {
+interface TargetBoxProps {
+	dropEffect?: 'copy' | 'move'
+}
+
+export const TargetBox: FC<TargetBoxProps> = ({
+	dropEffect,
+}: TargetBoxProps) => {
 	const [{ isActive }, drop] = useDrop(() => ({
 		accept: ItemTypes.BOX,
+		options: {
+			dropEffect,
+		},
 		collect: (monitor) => ({
 			isActive: monitor.canDrop() && monitor.isOver(),
 		}),
@@ -21,7 +30,8 @@ export const TargetBox: FC = () => {
 
 	return (
 		<div ref={drop} style={style}>
-			{isActive ? 'Release to drop' : 'Drag item here'}
+			<p>{isActive ? 'Release to drop' : 'Drag item here'}</p>
+			<p>I have a {dropEffect || 'undefined'} dropEffect</p>
 		</div>
 	)
 }

--- a/packages/react-dnd/src/hooks/useDrop/useDrop.ts
+++ b/packages/react-dnd/src/hooks/useDrop/useDrop.ts
@@ -24,7 +24,7 @@ export function useDrop<
 ): [CollectedProps, ConnectDropTarget] {
 	const spec = useOptionalFactory(specArg, deps)
 	const monitor = useDropTargetMonitor<DragObject, DropResult>()
-	const connector = useDropTargetConnector(spec.options)
+	const connector = useDropTargetConnector(spec.options ?? {})
 	useRegisteredDropTarget(spec, monitor, connector)
 
 	return [

--- a/packages/react-dnd/src/hooks/useDrop/useDropTargetConnector.ts
+++ b/packages/react-dnd/src/hooks/useDrop/useDropTargetConnector.ts
@@ -6,7 +6,7 @@ import { useDragDropManager } from '../useDragDropManager.js'
 import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect.js'
 
 export function useDropTargetConnector(
-	options: DropTargetOptions,
+	options: DropTargetOptions | undefined,
 ): TargetConnector {
 	const manager = useDragDropManager()
 	const connector = useMemo(

--- a/packages/react-dnd/src/internals/TargetConnector.ts
+++ b/packages/react-dnd/src/internals/TargetConnector.ts
@@ -83,10 +83,10 @@ export class TargetConnector implements Connector {
 		this.reconnect()
 	}
 
-	public get dropTargetOptions(): DropTargetOptions {
+	public get dropTargetOptions(): DropTargetOptions | null {
 		return this.dropTargetOptionsInternal
 	}
-	public set dropTargetOptions(options: DropTargetOptions) {
+	public set dropTargetOptions(options: DropTargetOptions | null) {
 		this.dropTargetOptionsInternal = options
 	}
 

--- a/packages/react-dnd/src/types/options.ts
+++ b/packages/react-dnd/src/types/options.ts
@@ -45,4 +45,11 @@ export interface DragPreviewOptions {
 	offsetY?: number
 }
 
-export type DropTargetOptions = any
+export type DropTargetOptions = {
+	/**
+	 * Optional. A string. By default, 'move'. In the browsers that support this feature, specifying 'copy'
+	 * shows a special “copying” cursor, while 'move' corresponds to the “move” cursor. You might want to use
+	 * this option to provide a hint to the user about whether an action is destructive.
+	 */
+	dropEffect?: string
+}


### PR DESCRIPTION
Adds an option to the `useDrop` hook to set the drop effect based on drop target and updates the documentation to reflect the changes.

Since there can be multiple sources of truth for what the drop effect should be (drag source options, drop target options, and alt key being pressed), my PR uses the following precedence (but I'm happy to change it if the reviewer prefers something different)

1. Use dropEffect from drag source
2. Use dropEffect from the most deeply nested drop target
3. If the alt key is pressed, then use "copy"
4. Default to "move"

Resolves: #3529 