### PR TITLE
fix NODE_ENV interpolation in vite production build

### DIFF
--- a/packages/util-invariant/src/index.ts
+++ b/packages/util-invariant/src/index.ts
@@ -10,7 +10,7 @@
  */
 
 export function invariant(condition: any, format: string, ...args: any[]) {
-	if (isProduction()) {
+	if (process.env.NODE_ENV === 'production') {
 		if (format === undefined) {
 			throw new Error('invariant requires an error message argument')
 		}
@@ -35,10 +35,4 @@ export function invariant(condition: any, format: string, ...args: any[]) {
 		(error as any).framesToPop = 1 // we don't care about invariant's own frame
 		throw error
 	}
-}
-
-function isProduction() {
-	return (
-		typeof process !== 'undefined' && process.env['NODE_ENV'] === 'production'
-	)
 }


### PR DESCRIPTION
I received an error in my project:

<img width="727" alt="Screenshot 2023-02-16 at 13 44 40" src="https://user-images.githubusercontent.com/950216/219373734-4533469d-62c2-4869-88a1-5beb73d44087.png">

I'm using [vitejs](https://vitejs.dev/) toolchain and seems like it replaces `process.env.NODE_ENV` string with `true/false` value during the build, but it doesn't replace `process.env['NODE_ENV']` ([see source](https://github.com/vitejs/vite/blob/00919bb95e51c9ecb3fbce5af21524e838d8da12/packages/vite/src/node/plugins/clientInjections.ts#L69)).

I got the problem because in my particular case one of the modules are declares `process` variable (so it's not an undefined) but `vitejs` doesn't specify `process.env`.

I'm suggesting to replace current check with `process.env.NODE_ENV === 'production'`. In this case `vitejs` can easily replace this string with particular value during the build.

This is should be safe update because there are plenty of popular packages that do the same check:
- [react](https://github.com/facebook/react/blob/cae635054e17a6f107a39d328649137b83f25972/packages/react/npm/index.js#L3)
- [redux](https://github.com/reduxjs/redux/blob/db0d9681cedea543da3f647e4b379945b9438476/src/combineReducers.ts#L131)
- [react-query](https://github.com/TanStack/query/blob/53204fead507bf685a53436dadd107f1d3196268/packages/react-query/src/QueryClientProvider.tsx#L84)
- [emotion](https://github.com/emotion-js/emotion/blob/89b6dbb3c13d49ef1fa3d88888672d810853f05a/packages/react/src/emotion-element.js#L21)

If you will search for `process.env.NODE_ENV` in node_modules you will see plenty of search results:

<img width="321" alt="Screenshot 2023-02-16 at 14 23 05" src="https://user-images.githubusercontent.com/950216/219376496-6cf0e20d-e9f7-4213-bddc-676108d57f63.png">

But `process.env['NODE_ENV']` only appears in react-dnd:

<img width="729" alt="Screenshot 2023-02-16 at 14 23 47" src="https://user-images.githubusercontent.com/950216/219376696-8ea3ff3d-8ad2-4d90-a6d2-3c46ecf18906.png">

