### PR TITLE
fix(TouchBackendImpl.teardown): remove same top move listener as added

### DIFF
--- a/packages/backend-touch/src/TouchBackendImpl.ts
+++ b/packages/backend-touch/src/TouchBackendImpl.ts
@@ -174,7 +174,7 @@ export class TouchBackendImpl implements Backend {
 		this.removeEventListener(
 			root,
 			'start',
-			this.handleTopMoveStartCapture as any,
+			this.getTopMoveStartHandler() as any,
 			true,
 		)
 		this.removeEventListener(root, 'start', this.handleTopMoveStart as any)


### PR DESCRIPTION
teardown doesn't mirror setup...seems like a mistake