### PR TITLE
fix: don't lose drag source/preview if disconnected and immediately reconnected

### DIFF
--- a/.yarn/versions/42579e0f.yml
+++ b/.yarn/versions/42579e0f.yml
@@ -1,0 +1,9 @@
+releases:
+  react-dnd: patch
+
+declined:
+  - react-dnd-documentation
+  - react-dnd-examples
+  - test-suite-cra
+  - test-suite-vite
+  - react-dnd-test-utils

--- a/packages/react-dnd/src/internals/SourceConnector.ts
+++ b/packages/react-dnd/src/internals/SourceConnector.ts
@@ -53,6 +53,8 @@ export class SourceConnector implements Connector {
 	private dragPreviewOptionsInternal: DragPreviewOptions | null = null
 	private dragPreviewUnsubscribe: Unsubscribe | undefined
 
+	private isDragSourceConnected = false
+	private isDragPreviewConnected = false
 	private lastConnectedHandlerId: Identifier | null = null
 	private lastConnectedDragSource: any = null
 	private lastConnectedDragSourceOptions: any = null
@@ -118,7 +120,7 @@ export class SourceConnector implements Connector {
 			return didChange
 		}
 
-		if (didChange) {
+		if (didChange || !this.isDragSourceConnected) {
 			this.lastConnectedHandlerId = this.handlerId
 			this.lastConnectedDragSource = dragSource
 			this.lastConnectedDragSourceOptions = this.dragSourceOptions
@@ -127,6 +129,7 @@ export class SourceConnector implements Connector {
 				dragSource,
 				this.dragSourceOptions,
 			)
+			this.isDragSourceConnected = true
 		}
 		return didChange
 	}
@@ -152,7 +155,7 @@ export class SourceConnector implements Connector {
 			return
 		}
 
-		if (didChange) {
+		if (didChange || !this.isDragPreviewConnected) {
 			this.lastConnectedHandlerId = this.handlerId
 			this.lastConnectedDragPreview = dragPreview
 			this.lastConnectedDragPreviewOptions = this.dragPreviewOptions
@@ -161,6 +164,7 @@ export class SourceConnector implements Connector {
 				dragPreview,
 				this.dragPreviewOptions,
 			)
+			this.isDragPreviewConnected = true
 		}
 	}
 
@@ -195,15 +199,15 @@ export class SourceConnector implements Connector {
 			this.dragSourceUnsubscribe()
 			this.dragSourceUnsubscribe = undefined
 		}
+		this.isDragSourceConnected = false
 	}
 
 	public disconnectDragPreview() {
 		if (this.dragPreviewUnsubscribe) {
 			this.dragPreviewUnsubscribe()
 			this.dragPreviewUnsubscribe = undefined
-			this.dragPreviewNode = null
-			this.dragPreviewRef = null
 		}
+		this.isDragPreviewConnected = false
 	}
 
 	private get dragSource() {

--- a/packages/react-dnd/src/internals/__tests__/SourceConnector.spec.tsx
+++ b/packages/react-dnd/src/internals/__tests__/SourceConnector.spec.tsx
@@ -34,6 +34,48 @@ describe('SourceConnector', () => {
 		expect(unsubscribeDragSource).toHaveBeenCalled()
 	})
 
+	it('handles disconnect and immediate reconnect', () => {
+		const unsubscribeDragSource = jest.fn()
+		const unsubscribeDragPreview = jest.fn()
+		backend.connectDragSource.mockReturnValue(unsubscribeDragSource)
+		backend.connectDragPreview.mockReturnValue(unsubscribeDragPreview)
+
+		connector.receiveHandlerId('test')
+		connector.hooks.dragSource()({})
+		connector.hooks.dragPreview()({})
+		expect(backend.connectDragSource).toHaveBeenCalled()
+		expect(backend.connectDragPreview).toHaveBeenCalled()
+		expect(unsubscribeDragSource).not.toHaveBeenCalled()
+		expect(unsubscribeDragPreview).not.toHaveBeenCalled()
+		backend.connectDragSource.mockClear()
+		backend.connectDragPreview.mockClear()
+
+		connector.disconnectDragSource()
+		connector.disconnectDragPreview()
+		expect(backend.connectDragSource).not.toHaveBeenCalled()
+		expect(backend.connectDragPreview).not.toHaveBeenCalled()
+		expect(unsubscribeDragSource).toHaveBeenCalled()
+		expect(unsubscribeDragPreview).toHaveBeenCalled()
+		unsubscribeDragSource.mockClear()
+		unsubscribeDragPreview.mockClear()
+
+		// Source & preview should be connected after disconnect
+		connector.reconnect()
+		expect(backend.connectDragSource).toHaveBeenCalled()
+		expect(backend.connectDragPreview).toHaveBeenCalled()
+		expect(unsubscribeDragSource).not.toHaveBeenCalled()
+		expect(unsubscribeDragPreview).not.toHaveBeenCalled()
+		backend.connectDragSource.mockClear()
+		backend.connectDragPreview.mockClear()
+
+		// Source & preview should not be connected a second time
+		connector.reconnect()
+		expect(backend.connectDragSource).not.toHaveBeenCalled()
+		expect(backend.connectDragPreview).not.toHaveBeenCalled()
+		expect(unsubscribeDragSource).not.toHaveBeenCalled()
+		expect(unsubscribeDragPreview).not.toHaveBeenCalled()
+	})
+
 	it('unsubscribes drag preview when hook is called without node', () => {
 		const unsubscribeDragSource = jest.fn()
 		backend.connectDragSource.mockReturnValueOnce(unsubscribeDragSource)


### PR DESCRIPTION
This fixes a bug demonstrated in the following codesandbox. One drag source works, and the other does not.
https://codesandbox.io/s/xenodochial-christian-nu3rlw?file=/src/App.tsx

https://user-images.githubusercontent.com/14237/234934158-9208f10a-172c-4470-93aa-9cb6539b8ff2.mov



I first encountered this bug in 14.0.3, so I think it was introduced in https://github.com/react-dnd/react-dnd/pull/3290. At the time I [skipped upgrading this package](https://github.com/foxglove/studio/pull/1849) because I couldn't resolve it. Here we are 1.5 years later and it seems like the bug is still present 😅

The bug is triggered by the combination of `useDrag({ ... options: { dropEffect: "copy" } })` and `useEffect(() => setValue(1))`:
- The `setValue` call triggers the component to render again.
- A new options object `{ dropEffect: "copy" }` is allocated and passed into useDrag.
- Since `dragSourceOptions` is a dependency for this `useLayoutEffect`, `connector.disconnectDragSource()` and `connector.reconnect()` are called: https://github.com/react-dnd/react-dnd/blob/7c88c37489a53b5ac98699c46a506a8e085f1c03/packages/react-dnd/src/hooks/useDrag/useDragSourceConnector.ts#L20-L24
- Inside `reconnectDragSource()`, didChange is set to false because didDragSourceOptionsChange returns false. It returns false because the new `dragSourceOptions` are `shallowEqual` to the previous options. https://github.com/react-dnd/react-dnd/blob/7c88c37489a53b5ac98699c46a506a8e085f1c03/packages/react-dnd/src/internals/SourceConnector.ts#L101-L107 https://github.com/react-dnd/react-dnd/blob/7c88c37489a53b5ac98699c46a506a8e085f1c03/packages/react-dnd/src/internals/SourceConnector.ts#L179-L184

This patch fixes the bug by adding extra state variables, `isDragSourceConnected` & `isDragPreviewConnected`. When these are false, `backend.connectDragSource` & `backend.connectDragPreview` will be called.