### PR TITLE
[Doc-site] Improve navigation semantics and page title

### DIFF
--- a/packages/docsite/src/components/layout.tsx
+++ b/packages/docsite/src/components/layout.tsx
@@ -52,10 +52,16 @@ export const Layout: FC<LayoutProps> = memo(function Layout(props) {
 	const touchBackend = isTouchBackend()
 	const [dndArea, setDndArea] = useState<HTMLDivElement | null>(null)
 	const html5Options = useMemo(() => ({ rootElement: dndArea }), [dndArea])
-
+	const topicTitle: string = location?.pathname?.split('/').pop()
 	return (
 		<>
-			<Helmet title="React DnD" meta={HEADER_META} link={HEADER_LINK}>
+			<Helmet
+				title={`React DnD ${topicTitle ? '·' : ''} ${
+					topicTitle.charAt(0).toUpperCase() + topicTitle.slice(1)
+				}`}
+				meta={HEADER_META}
+				link={HEADER_LINK}
+			>
 				<html lang="en" />
 				<link
 					rel="stylesheet"

--- a/packages/docsite/src/components/navbar.tsx
+++ b/packages/docsite/src/components/navbar.tsx
@@ -14,13 +14,13 @@ export const NavBar: FC = memo(function NavBar() {
 					</LogoTitle>
 					<LogoDescription>Drag and Drop for React</LogoDescription>
 				</LogoContainer>
-				<div>
+				<nav aria-label="main">
 					<StyledGatsbyLink to={'/docs/overview'}>Docs</StyledGatsbyLink>
 					<StyledGatsbyLink to={'/examples'}>Examples</StyledGatsbyLink>
 					<StyledWebLink href={'https://github.com/react-dnd/react-dnd/'}>
 						GitHub
 					</StyledWebLink>
-				</div>
+				</nav>
 			</ContentContainer>
 		</Container>
 	)

--- a/packages/docsite/src/components/sidebar.tsx
+++ b/packages/docsite/src/components/sidebar.tsx
@@ -15,12 +15,18 @@ export const Sidebar: FC<SideBarProps> = memo(function Sidebar({
 	groups,
 	location,
 }) {
+	const navigationName = location.split('/')[1]
 	function renderGroup({ title, pages, debug }: PageGroup, index: number) {
+		const id = `${title}-${index}`
 		const isRendered = !debug || isDebugMode()
 		return isRendered ? (
 			<Group key={index}>
-				<GroupTitle>{title}</GroupTitle>
-				{Object.keys(pages).map((key) => renderLink(pages[key], key))}
+				<div role="presentation" aria-hidden="true">
+					<GroupTitle id={id}>{title}</GroupTitle>
+				</div>
+				<List aria-labelledby={id}>
+					{Object.keys(pages).map((key) => renderLink(pages[key], key))}
+				</List>
 			</Group>
 		) : null
 	}
@@ -31,17 +37,23 @@ export const Sidebar: FC<SideBarProps> = memo(function Sidebar({
 		const Link = isSelected ? SelectedSidebarItem : SidebarItem
 
 		return (
-			<Link key={key} to={pageLocation}>
-				<span>{title}</span>
-				{arrow}
-			</Link>
+			<ListItem key={key}>
+				<Link to={pageLocation}>
+					<span>{title}</span>
+					{arrow}
+				</Link>
+			</ListItem>
 		)
 	}
 
-	return <Container>{groups.map(renderGroup)}</Container>
+	return (
+		<Container aria-label={`${navigationName}`}>
+			<List>{groups.map(renderGroup)}</List>
+		</Container>
+	)
 })
 
-const Container = styled.div`
+const Container = styled.nav`
 	flex-shrink: 0;
 	flex-grow: 1;
 
@@ -56,14 +68,35 @@ const Container = styled.div`
 	}
 `
 
-const Group = styled.div`
-	margin-bottom: ${theme.dimensions.content.padding};
+const List = styled.ul`
+	list-style: none;
+	margin-block-start: 0;
+	margin-block-end: 0;
+	padding: 0;
+	margin: 0;
 `
 
-const GroupTitle = styled.h4`
+const ListItem = styled.li`
+	list-style: none;
+	margin: 0;
+	margin-block-start: 0;
+  margin-block-end: 0;
+`
+
+const Group = styled.li`
+	list-style: none;
+	margin: 0;
+	margin-block-start: 0;
+	margin-block-end: 0;
+	margin-bottom: 1.5em;
+`
+
+const GroupTitle = styled.span`
 	border-bottom: 2px solid fade(${theme.color.accent}, 10%);
-	padding-bottom: 0.5em;
-	margin: 0 0 0.5em 0;
+	padding-bottom: 1em;
+	display: block;
+	font-weight: bold;
+	font-size: 1rem;
 `
 
 const SidebarItem = styled(GatsbyLink)`


### PR DESCRIPTION
### What

This PR improves navigation semantics and page title for screen reader users. 

#### Specifics 
- Made the page title more descriptive (ex. `React DnD · Overview`, `React DnD · Faq`)
- Add `<nav>` elements on both the top nav and sidebar. Each nav element has a unique `aria-label` to help differentiate the two
- In the side bar...
  - Focused on grouping content in unordered Lists
  - Changed the GroupTitle to be an `aria-hidden` & `<span>`. 
  - Added an `id` to the GroupTitle and used the `id` to label the list of links it is describing.
