### PR TITLE
Fix Incorrect JSX Syntax in Knight Component Example

### DIFF
--- a/packages/docsite/markdown/docs/00 Quick Start/Tutorial.md
+++ b/packages/docsite/markdown/docs/00 Quick Start/Tutorial.md
@@ -499,7 +499,7 @@ function Knight() {
       }}
     >
       ♘
-    </div>,
+    </div>
   )
 }
 
@@ -625,7 +625,7 @@ function BoardSquare({ x, y, children }) {
           }}
         />
       )}
-    </div>,
+    </div>
   )
 }
 


### PR DESCRIPTION
### Fix Incorrect JSX Syntax in Knight Component Example

This PR fixes an issue with the JSX syntax in the Knight component example provided in the documentation. The problem was caused by a misplaced closing parenthesis in the return block, which was breaking the component's functionality.

#### Changes:
- Removed the extra comma in the JSX to fix the closing parenthesis issue.
- Updated the example to reflect the correct syntax.

#### Issue:
Closes #3646

