### PR TITLE
TouchBackend: Clear old timeout in handleTopMoveStartDelay

### DIFF
--- a/.yarn/versions/efe692e7.yml
+++ b/.yarn/versions/efe692e7.yml
@@ -1,0 +1,5 @@
+releases:
+  react-dnd-touch-backend: patch
+
+declined:
+  - react-dnd-documentation

--- a/packages/backend-touch/src/TouchBackendImpl.ts
+++ b/packages/backend-touch/src/TouchBackendImpl.ts
@@ -391,6 +391,7 @@ export class TouchBackendImpl implements Backend {
 			e.type === eventNames.touch.start
 				? this.options.delayTouchStart
 				: this.options.delayMouseStart
+		clearTimeout(this.timeout)
 		this.timeout = setTimeout(
 			this.handleTopMoveStart.bind(this, e as any),
 			delay,


### PR DESCRIPTION
## Problem

Normally, `delayTouchStart` requires that the user tap and hold the draggable element for a given delay before a drag is initiated. If there is a touchmove during this time, the drag is cancelled.

However, if the user quickly touches the screen and then initiates a tap + move within `delayTouchStart`, **the drag will incorrectly start**, ignoring the move that would have cancelled it.

A real-world case is described in https://github.com/cybersemics/em/issues/2967.

## Cause

This occurs because the `handleTopMoveStart` timer is only cleared in [`handleTopMove`](https://github.com/react-dnd/react-dnd/blob/1dd1bcdd39d9545fdbb319e34ddbeecf0fb9d89c/packages/backend-touch/src/TouchBackendImpl.ts#L416). When `handleTouchStartDelay` is triggered in quick session (by two taps), then the second call to `handleTouchStartDelay` will overwrite the existing timer before `handleTopMove` has the chance to clear it. Thus, when `handleTopMove` fires, it only clears the second timer, and the first incorrectly resolves `handleTouchStart` thinking that the user has not moved their finger.

## Solution

This is fixed by clearing the old timer before setting the new timer.