### PR TITLE
Add bugs metadata to react-dnd package

### DIFF
--- a/packages/react-dnd/package.json
+++ b/packages/react-dnd/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "https://github.com/react-dnd/react-dnd.git"
   },
+  "bugs": {
+    "url": "https://github.com/react-dnd/react-dnd/issues"
+  },
   "license": "MIT",
   "scripts": {
     "_build_dts": "tsc -b .",


### PR DESCRIPTION
Adds the missing `bugs.url` metadata to the published `react-dnd` package manifest.

This matches the public issue tracker for the existing repository metadata and lets npm consumers/tooling navigate from package metadata to GitHub issues after the next publish.

Validation:
- Confirmed current `npm view react-dnd name version homepage repository bugs --json` output does not include `bugs`.
- Parsed the updated `packages/react-dnd/package.json` as JSON after the change.

Microbounty: charles-openclaw/charles-microbounties#380